### PR TITLE
chore: Enable replication oplog for mongodb in dev setup

### DIFF
--- a/dev/config/mongo.init.js
+++ b/dev/config/mongo.init.js
@@ -1,0 +1,13 @@
+try {
+	rs.status()
+} catch (exception) {
+	if (exception.codeName === "NotYetInitialized") {
+		rs.initiate({
+			_id: "rs0",
+			members: [{
+				_id: 0,
+				host: "127.0.0.1",
+			}],
+		});
+	}
+}

--- a/dev/docker-compose.enterprise.yml
+++ b/dev/docker-compose.enterprise.yml
@@ -483,8 +483,10 @@ services:
 
   mongo:
     image: mongo:6.0
+    command: [--replSet, rs0]
     volumes :
       - mongo:/data
+      - ./config/mongo.init.js:/docker-entrypoint-initdb.d/mongo.init.js
     networks:
       default:
         aliases: [mender-mongo]

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -359,8 +359,10 @@ services:
 
   mongo:
     image: mongo:6.0
+    command: [--replSet, rs0]
     volumes :
       - mongo:/data
+      - ./config/mongo.init.js:/docker-entrypoint-initdb.d/mongo.init.js
     networks:
       default:
         aliases: [mender-mongo]


### PR DESCRIPTION
Useful for debugging database writes and enables transactions and change streams :sparkles: