### PR TITLE
chore: Upgraded mender-artifact in create-artifact-worker from jammy to noble

### DIFF
--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -3,7 +3,7 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG MENDER_ARTIFACT_VERSION=3.11.2
 RUN apk add dpkg zstd && \
-    wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bubuntu%2bjammy_${TARGETARCH}.deb" -O mender-artifact.deb && \
+    wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_${MENDER_ARTIFACT_VERSION}-1%2bubuntu%2bnoble_${TARGETARCH}.deb" -O mender-artifact.deb && \
     dpkg -x mender-artifact.deb . && \
     mkdir /var/cache/create-artifact-worker
 


### PR DESCRIPTION
This implicitly bumps the version of golang it was compiled with.