### PR TITLE
update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,6 @@ updates:
   - commit-message:
       prefix: chore
     directories:
-      - /backend
       - /backend/services/create-artifact-worker
       - /backend/services/iot-manager
     package-ecosystem: docker


### PR DESCRIPTION
By mistake I added directory without Dockerfiles to dependabot configuration.
This PR removes it.