### PR TITLE
test(integration): Add coverage instrumentation to Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,7 +175,7 @@ test:backend:integration:
   before_script:
     - apk add make bash git curl
     - *dind-login
-    - make -C backend -j 4 docker-pull
+    - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
   script:
     - make -C backend test-integration
   artifacts:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -66,6 +66,7 @@ $(TEST_ACCEPTANCE_TARGETS):
 	@$(MAKE) -C services/$(subst -test-acceptance,,$@) test-acceptance-run
 
 .PHONY: test-integration
+test-integration: MENDER_IMAGE_TAG=$(MENDER_IMAGE_TAG_TEST)
 test-integration:
 	./tests/integration/run $(args)
 


### PR DESCRIPTION
Uses the test images for running `test-integration`