### PR TITLE
feat: Add `version` command to all Go binaries

### DIFF
--- a/backend/pkg/version/version.go
+++ b/backend/pkg/version/version.go
@@ -1,0 +1,60 @@
+package version
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"text/tabwriter"
+)
+
+var (
+	version string = "v0.0.0-dev"
+)
+
+type Version struct {
+	Version      string
+	GoVersion    string
+	GitCommit    string `json:",omitempty"`
+	RevisionTime string `json:",omitempty"`
+	OS           string
+	Arch         string
+}
+
+func Get() Version {
+	v := Version{
+		Version:   version,
+		GoVersion: runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+	if bldInfo, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range bldInfo.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				v.GitCommit = setting.Value
+			case "vcs.time":
+				v.RevisionTime = setting.Value
+			}
+		}
+	}
+	return v
+}
+
+func (v Version) String() string {
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 8, 0, '\t', 0)
+	fmt.Fprintf(w, "Version:\t%s\n", version)
+	fmt.Fprintf(w, "Go version:\t%s\n", v.GoVersion)
+	fmt.Fprintf(w, "Git commit:\t%s\n", v.GitCommit)
+	fmt.Fprintf(w, "Revision time:\t%s\n", v.RevisionTime)
+	fmt.Fprintf(w, "Os/Arch:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+	w.Flush()
+	return buf.String()
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	type version Version
+	return json.Marshal((version)(v))
+}

--- a/backend/services/Makefile.common
+++ b/backend/services/Makefile.common
@@ -79,12 +79,12 @@ docker-publish:
 endif
 
 $(binfile): $(GOFILES)
-	# TODO: Add -ldflags "-X ...$(Version)"
 	env CGO_ENABLED=$(CGO_ENABLED) \
 		GOOS=$(GOOS) \
 		GOARCH=$(GOARCH) \
 		go build -o $(binfile) \
 			-ldflags '$(LDFLAGS)' \
+			-ldflags '-X github.com/mendersoftware/mender-server/pkg/version.version=$(VERSION)' \
 			$(BUILDFLAGS)
 
 .PHONY: build

--- a/backend/services/deployments/main.go
+++ b/backend/services/deployments/main.go
@@ -16,8 +16,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,6 +29,7 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
 	mstore "github.com/mendersoftware/mender-server/pkg/store"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	"github.com/mendersoftware/mender-server/services/deployments/app"
 	"github.com/mendersoftware/mender-server/services/deployments/client/workflows"
@@ -41,6 +44,8 @@ const (
 	cliDefaultRateLimit = 50
 )
 
+var appVersion = version.Get()
+
 func main() {
 	doMain(os.Args)
 }
@@ -51,6 +56,7 @@ func doMain(args []string) {
 
 	app := cli.NewApp()
 	app.Usage = "Deployments Service"
+	app.Version = appVersion.Version
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -128,6 +134,28 @@ func doMain(args []string) {
 				},
 			},
 			Action: cmdStorageDaemon,
+		},
+		{
+			Name:  "version",
+			Usage: "Show version information",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "output",
+					Usage: "Output format <json|text>",
+					Value: "text",
+				},
+			},
+			Action: func(args *cli.Context) error {
+				switch strings.ToLower(args.String("output")) {
+				case "text":
+					fmt.Print(appVersion)
+				case "json":
+					_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+				default:
+					return fmt.Errorf("Unknown output format %q", args.String("output"))
+				}
+				return nil
+			},
 		},
 	}
 

--- a/backend/services/deviceauth/main.go
+++ b/backend/services/deviceauth/main.go
@@ -15,8 +15,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,6 +26,7 @@ import (
 
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	cinv "github.com/mendersoftware/mender-server/services/deviceauth/client/inventory"
 	"github.com/mendersoftware/mender-server/services/deviceauth/client/orchestrator"
@@ -36,6 +39,8 @@ import (
 const (
 	cliDefaultRateLimit = 50
 )
+
+var appVersion = version.Get()
 
 func main() {
 	doMain(os.Args)
@@ -190,8 +195,31 @@ func doMain(args []string) {
 			},
 			Action: cmdCheckDeviceLimits,
 		},
+		{
+			Name:  "version",
+			Usage: "Show version information",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "output",
+					Usage: "Output format <json|text>",
+					Value: "text",
+				},
+			},
+			Action: func(args *cli.Context) error {
+				switch strings.ToLower(args.String("output")) {
+				case "text":
+					fmt.Print(appVersion)
+				case "json":
+					_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+				default:
+					return fmt.Errorf("Unknown output format %q", args.String("output"))
+				}
+				return nil
+			},
+		},
 	}
 
+	app.Version = appVersion.Version
 	app.Action = cmdServer
 	app.Before = func(args *cli.Context) error {
 		log.Setup(debug)

--- a/backend/services/deviceconfig/main.go
+++ b/backend/services/deviceconfig/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -27,12 +28,15 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	. "github.com/mendersoftware/mender-server/services/deviceconfig/config"
 	"github.com/mendersoftware/mender-server/services/deviceconfig/server"
 	"github.com/mendersoftware/mender-server/services/deviceconfig/store"
 	"github.com/mendersoftware/mender-server/services/deviceconfig/store/mongo"
 )
+
+var appVersion = version.Get()
 
 func main() {
 	doMain(os.Args)
@@ -80,10 +84,32 @@ func doMain(args []string) {
 					},
 				},
 			},
+			{
+				Name:  "version",
+				Usage: "Show version information",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "output",
+						Usage: "Output format <json|text>",
+						Value: "text",
+					},
+				},
+				Action: func(args *cli.Context) error {
+					switch strings.ToLower(args.String("output")) {
+					case "text":
+						fmt.Print(appVersion)
+					case "json":
+						_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+					default:
+						return fmt.Errorf("Unknown output format %q", args.String("output"))
+					}
+					return nil
+				},
+			},
 		},
+		Version: appVersion.Version,
 	}
 	app.Usage = "Device Configure"
-	app.Version = "1.0.0"
 	app.Action = cmdServer
 
 	app.Before = func(args *cli.Context) error {

--- a/backend/services/iot-manager/main.go
+++ b/backend/services/iot-manager/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -38,7 +39,10 @@ import (
 
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/version"
 )
+
+var appVersion = version.Get()
 
 func main() {
 	doMain(os.Args)
@@ -101,7 +105,30 @@ func doMain(args []string) {
 					},
 				},
 			},
+			{
+				Name:  "version",
+				Usage: "Show version information",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "output",
+						Usage: "Output format <json|text>",
+						Value: "text",
+					},
+				},
+				Action: func(args *cli.Context) error {
+					switch strings.ToLower(args.String("output")) {
+					case "text":
+						fmt.Print(appVersion)
+					case "json":
+						_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+					default:
+						return fmt.Errorf("Unknown output format %q", args.String("output"))
+					}
+					return nil
+				},
+			},
 		},
+		Version: appVersion.Version,
 	}
 	app.Usage = "IoT Manager"
 	app.Action = cmdServer

--- a/backend/services/reporting/main.go
+++ b/backend/services/reporting/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -28,6 +29,7 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/log"
 	mlog "github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	"github.com/mendersoftware/mender-server/services/reporting/app/indexer"
 	"github.com/mendersoftware/mender-server/services/reporting/app/server"
@@ -42,6 +44,8 @@ const (
 	opensearchMaxWaitingTime      = 300
 	opensearchRetryDelayInSeconds = 1
 )
+
+var appVersion = version.Get()
 
 func main() {
 	os.Exit(doMain(os.Args))
@@ -88,7 +92,30 @@ func doMain(args []string) int {
 				Usage:  "Run the migrations",
 				Action: cmdMigrate,
 			},
+			{
+				Name:  "version",
+				Usage: "Show version information",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "output",
+						Usage: "Output format <json|text>",
+						Value: "text",
+					},
+				},
+				Action: func(args *cli.Context) error {
+					switch strings.ToLower(args.String("output")) {
+					case "text":
+						fmt.Print(appVersion)
+					case "json":
+						_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+					default:
+						return fmt.Errorf("Unknown output format %q", args.String("output"))
+					}
+					return nil
+				},
+			},
 		},
+		Version: appVersion.Version,
 	}
 	app.Usage = "Reporting"
 	app.Action = cmdServer

--- a/backend/services/useradm/main.go
+++ b/backend/services/useradm/main.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -23,11 +24,14 @@ import (
 
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	. "github.com/mendersoftware/mender-server/services/useradm/config"
 	"github.com/mendersoftware/mender-server/services/useradm/model"
 	"github.com/mendersoftware/mender-server/services/useradm/store/mongo"
 )
+
+var appVersion = version.Get()
 
 func main() {
 	if err := doMain(os.Args); err != nil {
@@ -121,8 +125,31 @@ func doMain(args []string) error {
 
 			Action: runMigrate,
 		},
+		{
+			Name:  "version",
+			Usage: "Show version information",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "output",
+					Usage: "Output format <json|text>",
+					Value: "text",
+				},
+			},
+			Action: func(args *cli.Context) error {
+				switch strings.ToLower(args.String("output")) {
+				case "text":
+					fmt.Print(appVersion)
+				case "json":
+					_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+				default:
+					return fmt.Errorf("Unknown output format %q", args.String("output"))
+				}
+				return nil
+			},
+		},
 	}
 
+	app.Version = appVersion.Version
 	app.Action = runServer
 	app.Before = func(args *cli.Context) error {
 		log.Setup(debug)

--- a/backend/services/workflows/main.go
+++ b/backend/services/workflows/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -25,6 +26,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/mendersoftware/mender-server/pkg/config"
+	"github.com/mendersoftware/mender-server/pkg/version"
 
 	"github.com/mendersoftware/mender-server/services/workflows/app/server"
 	"github.com/mendersoftware/mender-server/services/workflows/app/worker"
@@ -33,6 +35,8 @@ import (
 	"github.com/mendersoftware/mender-server/services/workflows/model"
 	store "github.com/mendersoftware/mender-server/services/workflows/store/mongo"
 )
+
+var appVersion = version.Get()
 
 func main() {
 	doMain(os.Args)
@@ -113,7 +117,30 @@ func doMain(args []string) {
 					},
 				},
 			},
+			{
+				Name:  "version",
+				Usage: "Show version information",
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "output",
+						Usage: "Output format <json|text>",
+						Value: "text",
+					},
+				},
+				Action: func(args *cli.Context) error {
+					switch strings.ToLower(args.String("output")) {
+					case "text":
+						fmt.Print(appVersion)
+					case "json":
+						_ = json.NewEncoder(os.Stdout).Encode(appVersion)
+					default:
+						return fmt.Errorf("Unknown output format %q", args.String("output"))
+					}
+					return nil
+				},
+			},
 		},
+		Version: appVersion.Version,
 	}
 	app.Usage = "Workflows"
 	app.Action = cmdServer


### PR DESCRIPTION
The `version` command will display the app version (linked at build time) as well as runtime version and commit SHA1.

Changelog: Title
Ticket: None

Sample output (created a local v4.0.0-alpha0 tag for demo purposes).
```bash
deviceauth version
```
> ```
> Version:	v4.0.0-alpha0
> Go version:	go1.23.1
> Git commit:	0701064f0ee1784feea9178fc11d08c033805cca
> Revision time:	2024-10-02T10:58:16Z
> Os/Arch:	linux/amd64
> ```

```bash
deviceauth --version
```
> ```
> deviceauth version v4.0.0-alpha0
> ```