### PR TITLE
revert: Change docker entrypoint to launch workflows worker

### DIFF
--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -55,5 +55,5 @@ COPY --chown=$USER  backend/services/create-artifact-worker/config.yaml /etc/wor
 COPY --chown=$USER  backend/services/create-artifact-worker/workflows /etc/workflows/definitions
 COPY --from=builder --chown=$USER /build/workflows /usr/bin/workflows
 COPY --from=builder --chown=$USER /build/create-artifact-worker /usr/bin/create-artifact
-ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml"]
+ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "worker"]
 CMD ["worker"]

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: ./backend/services/create-artifact-worker/Dockerfile
     image: ${MENDER_IMAGE_PREFIX:-localhost:5000/mender-server}/create-artifact-worker:${MENDER_IMAGE_TAG:-latest}
     restart: on-failure:3
-    command: [worker]
     depends_on:
       - workflows
     environment:


### PR DESCRIPTION
This was done by mistake when updating the Dockerfile for the monorepo.