### PR TITLE
fix(deviceconfig): enable multiplatform build

### DIFF
--- a/backend/services/deviceconfig/Dockerfile
+++ b/backend/services/deviceconfig/Dockerfile
@@ -1,4 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 ARG LDFLAGS="-s -w"
 ARG BUILDFLAGS="-trimpath"
 WORKDIR /build


### PR DESCRIPTION
The required TARGETOS and TARGETARCH variables were missing from the Dockerfile.

Ticket: QA-673