### PR TITLE
Fix/improve SeaweedFS docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -367,7 +367,10 @@ services:
       traefik.http.routers.s3fs.priority: "99999"
       traefik.http.routers.s3fs.rule: PathPrefix(`/mender`)
       traefik.http.services.s3fs.loadBalancer.server.port: "8333"
-    command: [server -s3 -s3.config /etc/seaweedfs/s3.conf]
+    command:
+      - server
+      - -s3
+      - -s3.config=/etc/seaweedfs/s3.conf
     healthcheck:
       test:
         - CMD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,6 +369,10 @@ services:
       traefik.http.services.s3fs.loadBalancer.server.port: "8333"
     command:
       - server
+      - -dir=/data
+      - -master.electionTimeout=1s
+      - -master.heartbeatInterval=250ms
+      - -master.raftHashicorp=true
       - -s3
       - -s3.config=/etc/seaweedfs/s3.conf
     healthcheck:
@@ -378,6 +382,8 @@ services:
         - "-z"
         - "127.0.0.1"
         - "8333"
+      start_period: 1m
+      start_interval: 1s
       retries: 10
 
   client:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,7 +365,7 @@ services:
     labels:
       traefik.enable: "true"
       traefik.http.routers.s3fs.priority: "99999"
-      traefik.http.routers.s3fs.rule: HostRegexp(`s3\..*`)
+      traefik.http.routers.s3fs.rule: PathPrefix(`/mender`)
       traefik.http.services.s3fs.loadBalancer.server.port: "8333"
     command: [server -s3 -s3.config /etc/seaweedfs/s3.conf]
     healthcheck:


### PR DESCRIPTION
The command passed to the `s3fs` service messed up the entrypoint as all the argument was passed as a single string. The entrypoint adds default argument using a weak test on the first argument passed, since it didn't match the expectation the persistence configuration was messed up and would break on restarts (only the file index would be persisted without the actual data).
Since we are using path-style URLs for accessing the artifacts bucket, we can make the rule independent of the hostname.