### PR TITLE
chore(compose): Consistently use `deploy.replicas` instead of `scale`

### DIFF
--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -3,7 +3,8 @@ include:
 
 services:
   acceptance-tester:
-    scale: 0
+    deploy:
+      replicas: 0
     image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_ACCEPTANCE_IMAGE_TAG:-acceptance}"
     build:
       dockerfile: Dockerfile.acceptance
@@ -21,7 +22,8 @@ services:
       - workflows-worker
 
   integration-tester:
-    scale: 0
+    deploy:
+      replicas: 0
     image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_INTEGRATION_IMAGE_TAG:-integration}"
     build:
       dockerfile: Dockerfile.integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -379,7 +379,8 @@ services:
 
   client:
     image: mendersoftware/mender-client-docker-addons:mender-master
-    scale: 0
+    deploy:
+      replicas: 0
     configs:
       - source: client_json
         target: /etc/mender/mender.conf

--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -54,7 +54,8 @@ services:
       - ${GUI_REPOSITORY}/videos:/e2e/videos
 
   client:
-    scale: 1
+    deploy:
+      replicas: 0
     configs:
       - source: client_json
         target: /etc/mender/mender.conf


### PR DESCRIPTION
Resolves conflict with enterprise end-to-end tests.