### PR TITLE
ci: force version 4.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -397,6 +397,9 @@ lint:commit:
 changelog:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
   stage: changelog
+  variables:
+    GIT_CLIFF__BUMP__INITIAL_TAG: "4.0.0"  # TODO: after the new tag is created,
+                                           # remove this variable
   tags:
     - hetzner-amd-beefy
   rules:


### PR DESCRIPTION
Git cliff can't find an old tag, so it's starting from 0.1.0. With this temporary workaround, it will start from the version 4.0.0