### PR TITLE
ci: drop prepend flag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -437,7 +437,7 @@ changelog:
     - test -z "$RELEASE_PLEASE_PR" && echo "No release-please PR found" && exit 0
     - gh pr checkout --force $RELEASE_PLEASE_PR
     - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
-    - git cliff --unreleased --bump --prepend CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
+    - git cliff --bump --output CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
     - git add CHANGELOG.md
     - git commit --amend -s --no-edit
     - git push github-${CI_JOB_ID} --force


### PR DESCRIPTION
Git cliff usually work on an existing PR, with a temporary CHANGELOG with the 4.0.0 version. When another commit for the same version triggers another git cliff, it runs on the previous pre-populated CHANGELOG, messing it up. For this reason we're dropping the --prepend option and always rely on the full git history, which should not change, to rewrite the full CHANGELOG