### PR TITLE
Change S3 routing and optimize SeaweedFS deployment

### DIFF
--- a/compose/docker-compose.seaweedfs.yml
+++ b/compose/docker-compose.seaweedfs.yml
@@ -1,0 +1,99 @@
+configs:
+  s3-conf:
+    content: |
+      {
+        "identities": [
+          {
+            "name": "mender",
+            "credentials": [
+              {
+                "accessKey": "${MENDER_ACCESS_KEY_ID:-mender}",
+                "secretKey": "${MENDER_SECRET_ACCESS_KEY:-thisisnotsecure}"
+              }
+            ],
+            "actions": [
+              "Admin:mender",
+              "Read:mender",
+              "Write:mender",
+              "List:mender",
+              "Tagging:mender"
+            ]
+          }
+        ]
+      }
+
+services:
+  s3-master:
+    image: chrislusf/seaweedfs
+    command:
+      - master
+      - -mdir=/data
+      - -ip=s3-master
+      - -ip.bind=0.0.0.0
+      - -electionTimeout=1s
+      - -heartbeatInterval=200ms
+      - -raftHashicorp=true
+    volumes:
+      - s3:/data
+
+  s3-volume:
+    image: chrislusf/seaweedfs
+    command:
+      - volume
+      - -mserver=s3-master:9333
+      - -ip.bind=0.0.0.0
+      - -port=8080
+      - -dir=/data
+      - -preStopSeconds=0
+    depends_on:
+      - s3-master
+    volumes:
+      - s3:/data
+
+  s3-filer:
+    image: chrislusf/seaweedfs
+    command:
+      - filer
+      - -master=s3-master:9333
+      - -ip.bind=0.0.0.0
+    depends_on:
+      - s3-master
+      - s3-volume
+    volumes:
+      - s3:/data
+
+  s3:
+    image: chrislusf/seaweedfs
+    command:
+      - s3
+      - -filer=s3-filer:8888
+      - -ip.bind=0.0.0.0
+      - -config=/etc/seaweedfs/s3.conf
+    depends_on:
+      - s3-master
+      - s3-volume
+      - s3-filer
+    configs:
+      - source: s3-conf
+        target: /etc/seaweedfs/s3.conf
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.s3fs.priority: "99999"
+      traefik.http.routers.s3fs.rule: PathPrefix(`/mender`)
+      traefik.http.services.s3fs.loadBalancer.server.port: "8333"
+    healthcheck:
+      test:
+        - CMD
+        - "/usr/bin/nc"
+        - "-z"
+        - "127.0.0.1"
+        - "8333"
+      start_period: 1m
+      start_interval: 500ms
+      interval: 1m
+      retries: 10
+    volumes:
+      - s3:/data
+
+volumes:
+  s3: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 name: mender
+include:
+  - path: compose/docker-compose.seaweedfs.yml
+
 services:
   create-artifact-worker:
     build:
@@ -23,7 +26,7 @@ services:
     depends_on:
       mongo:
         condition: service_started
-      s3fs:
+      s3:
         condition: service_healthy
     environment:
       DEPLOYMENTS_PRESIGN_URL_HOSTNAME: "docker.mender.io"
@@ -32,7 +35,7 @@ services:
       DEPLOYMENTS_MENDER_WORKFLOWS: http://workflows:8080
       DEPLOYMENTS_MONGO_URL: "mongodb://mongo"
       DEPLOYMENTS_STORAGE_BUCKET: "mender"
-      DEPLOYMENTS_AWS_URI: "http://s3fs:8333"
+      DEPLOYMENTS_AWS_URI: "http://s3:8333"
       DEPLOYMENTS_AWS_EXTERNAL_URI: "https://s3.docker.mender.io"
       DEPLOYMENTS_AWS_AUTH_KEY: "${MENDER_ACCESS_KEY_ID:-mender}"
       DEPLOYMENTS_AWS_AUTH_SECRET: "${MENDER_SECRET_ACCESS_KEY:-thisisnotsecure}"
@@ -355,28 +358,6 @@ services:
       default:
         aliases: [mender-nats]
 
-  s3fs:
-    image: chrislusf/seaweedfs
-    configs:
-      - source: s3_conf
-        target: /etc/seaweedfs/s3.conf
-    volumes:
-      - s3:/data
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.s3fs.priority: "99999"
-      traefik.http.routers.s3fs.rule: PathPrefix(`/mender`)
-      traefik.http.services.s3fs.loadBalancer.server.port: "8333"
-    command: [server -s3 -s3.config /etc/seaweedfs/s3.conf]
-    healthcheck:
-      test:
-        - CMD
-        - "/usr/bin/nc"
-        - "-z"
-        - "127.0.0.1"
-        - "8333"
-      retries: 10
-
   client:
     image: mendersoftware/mender-client-docker-addons:mender-master
     scale: 0
@@ -397,29 +378,6 @@ configs:
         "UpdatePollIntervalSeconds": 5,
         "TenantToken": "${TENANT_TOKEN:-}"
       }
-  s3_conf:
-    content: |
-      {
-        "identities": [
-          {
-            "name": "mender",
-            "credentials": [
-              {
-                "accessKey": "${MENDER_ACCESS_KEY_ID:-mender}",
-                "secretKey": "${MENDER_SECRET_ACCESS_KEY:-thisisnotsecure}"
-              }
-            ],
-            "actions": [
-              "Admin:mender",
-              "Read:mender",
-              "Write:mender",
-              "List:mender",
-              "Tagging:mender"
-            ]
-          }
-        ]
-      }
 
 volumes:
-  s3: {}
   mongo: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,7 +365,7 @@ services:
     labels:
       traefik.enable: "true"
       traefik.http.routers.s3fs.priority: "99999"
-      traefik.http.routers.s3fs.rule: HostRegexp(`s3\..*`)
+      traefik.http.routers.s3fs.rule: PathPrefix(`/mender`)
       traefik.http.services.s3fs.loadBalancer.server.port: "8333"
     command: [server -s3 -s3.config /etc/seaweedfs/s3.conf]
     healthcheck:


### PR DESCRIPTION
Refactored the SeaweedFS topology to run each service in a separate container. It seems like there are some underlying issues with the monolith `server` command. Changing the topology allowed to significantly lower the startup and shutdown time as the RAFT initialization is now performed in one second instead of 30s.

The Traefik routing rule is now based on the `/mender` (bucket) path prefix to make it hostname independent.