### PR TITLE
ci: clone every changelog job to get the full history

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,6 +398,7 @@ changelog:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
   stage: changelog
   variables:
+    GIT_STRATEGY: clone  # Always get the full history
     GIT_CLIFF__BUMP__INITIAL_TAG: "4.0.0"  # TODO: after the new tag is created,
                                            # remove this variable
   tags:


### PR DESCRIPTION
Git cliff relies on the Git History to create the Changelog, but the default git strategy in Gitlab CICD is the Fetch one to save time. Moving to clone, we should get the full git history, and more reliable changelog files.

Changelog: None
Ticket: None