### PR TITLE
ci: unset git depth to get full history

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,6 +398,7 @@ changelog:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
   stage: changelog
   variables:
+    GIT_DEPTH: 0  # Always get the full history
     GIT_STRATEGY: clone  # Always get the full history
     GIT_CLIFF__BUMP__INITIAL_TAG: "4.0.0"  # TODO: after the new tag is created,
                                            # remove this variable


### PR DESCRIPTION
The git history is needed for the changelog job

Ticket: None
Changelog: None