### PR TITLE
ci: prerelease support to release-please

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,7 +430,7 @@ changelog:
     - release-please release-pr
         --token=${GITHUB_BOT_TOKEN_REPO_FULL}
         --repo-url=${GITHUB_REPO_URL}
-        --target-branch=${CI_COMMIT_REF_NAME}
+        --target-branch=${CI_COMMIT_REF_NAME} || echo "INFO - release already exists" # workaround because we shifted to prerelease versioning strategy and there's already a PR open
     # git cliff: override the changelog
     - test $GIT_CLIFF == "false" && echo "INFO - Skipping git-cliff" && exit 0
     - git remote add github-${CI_JOB_ID} https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL} || true  # Ignore already existing remote

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,9 @@
     }
   },
   "release-type": "simple",
+  "versioning": "prerelease",
+  "prerelease": true,
+  "prerelease-type": "rc",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "signoff": "mender-test-bot <mender@northern.tech>",


### PR DESCRIPTION
Enable prerelease tags; this is the default for every master commit. If you want to create a stable release, you have to create a Release-As<colon> <your release version>

Ticket: QA-795
Changelog: None

TODO:
* [ ] edit the [currently open PR](https://github.com/mendersoftware/mender-server/pull/126) by adding `-rc` suffixes
* [ ] after the [currently open PR](https://github.com/mendersoftware/mender-server/pull/126) is merged, revert this [commit](d14a46c9e7086a0dccf93bc72e1ceefa67a2e48e).