### PR TITLE
fix: fixed an issue that prevented onboarding tips from showing

### DIFF
--- a/frontend/src/js/store/onboardingSlice/index.ts
+++ b/frontend/src/js/store/onboardingSlice/index.ts
@@ -30,7 +30,7 @@ export const onboardingSlice = createSlice({
   initialState,
   reducers: {
     setOnboardingState: (state, action) => {
-      state = { ...state, ...action.payload };
+      return { ...state, ...action.payload };
     },
     setDemoArtifactPort: (state, action) => {
       state.demoArtifactPort = action.payload;

--- a/frontend/src/js/store/onboardingSlice/reducer.test.ts
+++ b/frontend/src/js/store/onboardingSlice/reducer.test.ts
@@ -18,6 +18,10 @@ describe('organization reducer', () => {
   it('should return the initial state', async () => {
     expect(reducer(undefined, {})).toEqual(initialState);
   });
+  it('should handle setOnboardingState', async () => {
+    expect(reducer(undefined, { type: actions.setOnboardingState, payload: { foo: 'bar', showTips: true } }).showTips).toEqual(true);
+    expect(reducer(initialState, { type: actions.setOnboardingState, payload: { foo: false } }).showTips).toEqual(null);
+  });
   it('should handle SET_SHOW_ONBOARDING_HELP', async () => {
     expect(reducer(undefined, { type: actions.setShowOnboardingHelp, payload: true }).showTips).toEqual(true);
     expect(reducer(initialState, { type: actions.setShowOnboardingHelp, payload: false }).showTips).toEqual(false);


### PR DESCRIPTION
With the RTK approach destructuring the entire slice state will not produce a proper object and break the change tracking of the js proxy and instead the change will just fall back to the previous value... but if instead of relying on the proxy tracking the entire state is returned as a new object, this will be picked up as a new state altogether, so all the selectors get updated as well 👌.
