### PR TITLE
ci: Frontend acceptance job use local artifacts for protected refs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -327,7 +327,7 @@ publish:backend:docker:
     - skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io
     - dnf install -y make git-core
-    - export MENDER_PUBLISH_TAG="${CI_COMMIT_REF_SLUG}"
+    - export MENDER_PUBLISH_TAG="${CI_COMMIT_REF_NAME}"
   script:
     - make -C backend -j 4 docker-publish NOASK=y
     - |

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -191,9 +191,13 @@ build:frontend:docker:
     - !reference [.dind-login]
     - apk add --no-cache bash git jq wget
     - docker pull ${MENDER_IMAGE_GUI}
-    # Update the docker references to pull from upstream
-    - unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
-    - export MENDER_IMAGE_TAG=${CI_COMMIT_TAG:-main}
+    # If branch is not protected, use upstream main
+    # Otherwise use the local pipeline reference.
+    - |
+      if test "$CI_COMMIT_REF_PROTECTED" != "true"; then
+        unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
+        export MENDER_IMAGE_TAG=main
+      fi
   artifacts:
     expire_in: 2w
     paths:


### PR DESCRIPTION
The Frontend acceptance tests fails for commit tags because the reference is published after the test pass. Also, we want to test the build artifacts for protected branches. Therefore it will only use upstream main for PRs.