### PR TITLE
chore: revert seaweedfs health check to use netcat

### DIFF
--- a/compose/docker-compose.seaweedfs.yml
+++ b/compose/docker-compose.seaweedfs.yml
@@ -85,14 +85,11 @@ services:
     healthcheck:
       test:
         - CMD
-        - /usr/bin/wget
-        - -q
-        - -O
-        - /dev/null
-        - http://127.0.0.1:8080/healthz
-      start_period: 1m
-      start_interval: 500ms
-      interval: 1m
+        - /usr/bin/nc
+        - -z
+        - 127.0.0.1
+        - "8080"
+      interval: 5s
       retries: 10
     volumes:
       - s3:/data


### PR DESCRIPTION
It seems like the `/healthz` route is not always added for the SeaweedFS s3 gateway. Adjusting the healthcheck to check for open port instead.