### PR TITLE
chore(compose): remove configs top-level element from evaluation composition

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,3 @@
 MENDER_IMAGE_TAG=main
 # MENDER_IMAGE_REGISTRY=docker.io|registry.mender.io
 # MENDER_IMAGE_REPOSITORY=mendersoftware|mender-server-enterprise
-
-# Environment for configuring s3 secret.
-MENDER_ACCESS_KEY_ID=mender
-MENDER_SECRET_ACCESS_KEY=thisisnotsecure

--- a/compose/config/mender.conf
+++ b/compose/config/mender.conf
@@ -1,0 +1,8 @@
+{
+  "InventoryPollIntervalSeconds": 5,
+  "RetryPollIntervalSeconds": 30,
+  "ServerURL": "https://docker.mender.io/",
+  "TenantToken": "",
+  "UpdatePollIntervalSeconds": 5,
+  "ServerCertificate": "/usr/share/doc/mender/server.crt"
+}

--- a/compose/config/seaweedfs-s3.conf
+++ b/compose/config/seaweedfs-s3.conf
@@ -1,0 +1,20 @@
+{
+  "identities": [
+    {
+      "name": "mender",
+      "credentials": [
+        {
+          "accessKey": "mender",
+          "secretKey": "thisisnotsecure"
+        }
+      ],
+      "actions": [
+        "Admin:mender",
+        "Read:mender",
+        "Write:mender",
+        "List:mender",
+        "Tagging:mender"
+      ]
+    }
+  ]
+}

--- a/compose/docker-compose.seaweedfs.yml
+++ b/compose/docker-compose.seaweedfs.yml
@@ -1,27 +1,3 @@
-configs:
-  s3-conf:
-    content: |
-      {
-        "identities": [
-          {
-            "name": "mender",
-            "credentials": [
-              {
-                "accessKey": "${MENDER_ACCESS_KEY_ID:-mender}",
-                "secretKey": "${MENDER_SECRET_ACCESS_KEY:-thisisnotsecure}"
-              }
-            ],
-            "actions": [
-              "Admin:mender",
-              "Read:mender",
-              "Write:mender",
-              "List:mender",
-              "Tagging:mender"
-            ]
-          }
-        ]
-      }
-
 services:
   s3-master:
     image: chrislusf/seaweedfs
@@ -74,9 +50,6 @@ services:
       - s3-master
       - s3-volume
       - s3-filer
-    configs:
-      - source: s3-conf
-        target: /etc/seaweedfs/s3.conf
     labels:
       traefik.enable: "true"
       traefik.http.routers.s3.priority: "99999"
@@ -92,6 +65,7 @@ services:
       interval: 5s
       retries: 10
     volumes:
+      - /etc/seaweedfs/s3.conf:./config/seaweedfs-s3.conf:ro
       - s3:/data
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -364,20 +364,11 @@ services:
     configs:
       - source: client_json
         target: /etc/mender/mender.conf
+    environment:
+      SERVER_URL: ${SERVER_URL:-https://docker.mender.io}
+      TENANT_TOKEN: ${TENANT_TOKEN:-}
     volumes:
-      - ./compose/certs/mender.crt:/var/lib/mender/mender.crt
-
-configs:
-  client_json:
-    content: |
-      {
-        "InventoryPollIntervalSeconds": 5,
-        "RetryPollIntervalSeconds": 5,
-        "ServerURL": "${SERVER_URL:-https://docker.mender.io}",
-        "ServerCertificate": "/var/lib/mender/mender.crt",
-        "UpdatePollIntervalSeconds": 5,
-        "TenantToken": "${TENANT_TOKEN:-}"
-      }
-
+      - ./compose/config/mender.conf:/etc/mender/mender.conf
+      - ./compose/certs/mender.crt:/usr/share/doc/mender/server.crt
 volumes:
   mongo: {}


### PR DESCRIPTION
The `configs` attribute requires a newer version of Docker Compose. Removing it to lower the entry barrier.
NOTE: S3 credentials cannot be changed using the project environment
      (`.env`).