### PR TITLE
chore(docker): add default ca certificate chain

### DIFF
--- a/backend/services/deviceauth/Dockerfile
+++ b/backend/services/deviceauth/Dockerfile
@@ -25,4 +25,5 @@ ARG BIN_FILE=./dist/${TARGETOS}/${TARGETARCH}/deviceauth
 USER $USER
 COPY --chown=$USER  backend/services/deviceauth/config.yaml /etc/deviceauth/config.yaml
 COPY --from=builder --chown=$USER /build/deviceauth /usr/bin/deviceauth
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/usr/bin/deviceauth", "--config", "/etc/deviceauth/config.yaml"]

--- a/backend/services/deviceconfig/Dockerfile
+++ b/backend/services/deviceconfig/Dockerfile
@@ -24,4 +24,5 @@ ARG USER=65534
 USER $USER
 COPY --chown=$USER  backend/services/deviceconfig/config.yaml /etc/deviceconfig/config.yaml
 COPY --from=builder --chown=$USER /build/deviceconfig /usr/bin/deviceconfig
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/usr/bin/deviceconfig", "--config", "/etc/deviceconfig/config.yaml"]

--- a/backend/services/deviceconnect/Dockerfile
+++ b/backend/services/deviceconnect/Dockerfile
@@ -24,4 +24,5 @@ ARG USER=65534
 USER $USER
 COPY --chown=$USER  backend/services/deviceconnect/config.yaml /etc/deviceconnect/config.yaml
 COPY --from=builder --chown=$USER /build/deviceconnect /usr/bin/deviceconnect
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/usr/bin/deviceconnect", "--config", "/etc/deviceconnect/config.yaml"]

--- a/backend/services/inventory/Dockerfile
+++ b/backend/services/inventory/Dockerfile
@@ -27,4 +27,5 @@ ARG BIN_FILE=./dist/${TARGETOS}/${TARGETARCH}/inventory
 USER $USER
 COPY --chown=$USER  backend/services/inventory/config.yaml /etc/inventory/config.yaml
 COPY --from=builder --chown=$USER /build/inventory /usr/bin/inventory
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/usr/bin/inventory", "--config", "/etc/inventory/config.yaml"]


### PR DESCRIPTION
Might be handy when trying to connect to MongoDB using TLS.
