### PR TITLE
docs: Bump docker compose requirement to 2.23.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mender Server monorepo
 ## Getting started
 
 Before you start the Mender server, make sure you have [Docker Compose](https://docs.docker.com/compose/install/) installed.
-Mender server requires Docker Compose version `v2.21.0` or newer.
+Mender server requires Docker Compose version `v2.23.1` or newer.
 ```
 docker compose version
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ echo '127.0.0.1   docker.mender.io s3.docker.mender.io' | sudo tee -a /etc/hosts
 > This docker composition is only meant for evaluation purposes.
 > Please use [the helm chart](https://github.com/mendersoftware/mender-helm) in production environments.
 
+Start by cloning and entering this repository:
+
+```bash
+git clone https://github.com/mendersoftware/mender-server && cd mender-server
+```
+
 To start evaluating Mender, you can bring up your Mender server by running:
 ```
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # mender-server
+
 Mender Server monorepo
 
 ## Getting started
 
 Before you start the Mender server, make sure you have [Docker Compose](https://docs.docker.com/compose/install/) installed.
 Mender server requires Docker Compose version `v2.23.1` or newer.
-```
+
+```bash
 docker compose version
 ```
 
 You will also need to update your local DNS or host rewrites, for example by appending to `/etc/hosts`:
+
 ```bash
 echo '127.0.0.1   docker.mender.io s3.docker.mender.io' | sudo tee -a /etc/hosts
 ```
@@ -25,12 +28,14 @@ git clone https://github.com/mendersoftware/mender-server && cd mender-server
 ```
 
 To start evaluating Mender, you can bring up your Mender server by running:
-```
+
+```bash
 docker compose up -d
 ```
 
 Once all containers are running, you can create your initial user using the following command:
-```
+
+```bash
 MENDER_USERNAME=admin@docker.mender.io
 MENDER_PASSWORD=password123
 docker compose exec useradm useradm create-user --username "$MENDER_USERNAME" --password "$MENDER_PASSWORD"
@@ -41,6 +46,7 @@ Visit [https://localhost](https://localhost) and sign in using the credentials f
 ### Adding a virtual client
 
 To add a virtual client with the composition, run the following command:
+
 ```bash
 docker compose run -d client
 ```
@@ -53,7 +59,8 @@ docker compose run -d client
 
 For paying customers with access to private enterprise components, you can evaluate the Mender Server enterprise by replacing the above snippets from the following section.
 To start the server run:
-```
+
+```bash
 export COMPOSE_FILE="docker-compose.yml:compose/docker-compose.enterprise.yml"
 docker compose up -d
 ```
@@ -62,7 +69,8 @@ docker compose up -d
 > This composition will not work without a paid license with access to registry.mender.io.
 
 To initialize the admin user, use the following snippet:
-```
+
+```bash
 MENDER_NAME=Admin
 MENDER_USERNAME=admin@docker.mender.io
 MENDER_PASSWORD=password123
@@ -71,12 +79,12 @@ docker compose exec tenantadm tenantadm create-org --username "$MENDER_USERNAME"
 
 Visit [https://localhost](https://localhost) and sign in using the credentials from the snippet above.
 
-
 ### Testing Gitlab build artifacts
 
 To test/debug artifacts from GitLab CI, you can pull the image straight from the internal registry (after generating credentials).
 For testing, you need to setup the following environment variables:
-```
+
+```bash
 CI_PIPELINE_IID="1234" # The number of the pipeline
 export MENDER_IMAGE_REGISTRY=registry.gitlab.com
 export MENDER_IMAGE_REPOSITORY=northern.tech/mender/mender-server


### PR DESCRIPTION
* Bumped compose requirement to v2.23.1 
  * Required by configs.content element.
* Added snippet to clone and enter repository before executing compose commands
  * Completes the copy :spaghetti: experience
*  Added bash syntax heading to all code blocks and injected whitespace around code blocks and headings