### PR TITLE
ci: fix missing container digest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -354,7 +354,8 @@ publish:backend:docker:
     - dnf install -y make git-core
     - export MENDER_PUBLISH_TAG="${CI_COMMIT_REF_NAME}"
   script:
-    - make -C backend -j 4 docker-publish NOASK=y
+    - make -C backend -j 4 docker-publish NOASK=y \
+          SKOPEO_ARGS='--digestfile '''${CI_PROJECT_DIR}'''/.digests/$(COMPONENT)'
     - |
       if echo -n "${MENDER_PUBLISH_TAG}" | grep -E '^v[0-9]+\.v[0-9]+\.[0-9]+$'; then
          make -C backend -j 4 docker-publish NOASK=y \
@@ -364,6 +365,11 @@ publish:backend:docker:
          make -C backend -j 4 docker-publish NOASK=y \
             MENDER_PUBLISH_TAG=latest
       fi
+  artifacts:
+    when: on_success
+    expire_in: 1w
+    paths:
+      - .digests
 
 publish:backend:licenses:
   stage: publish

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -275,6 +275,7 @@ publish:frontend:docker:
     - echo "About to publish ${DOCKER_TAG} to ${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG}"
     - |
       skopeo copy --multi-arch all \
+        --digestfile .digests/gui \
         docker://${MENDER_IMAGE_GUI} \
         docker://${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG} # covers vX.Y.Z + -fragment/ -build tags
     - |
@@ -283,3 +284,8 @@ publish:frontend:docker:
         skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-1)
         skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:latest
       fi
+  artifacts:
+    when: on_success
+    expire_in: 1w
+    paths:
+      - .digests


### PR DESCRIPTION
The container digests have to be included to pull an image from helm

Sorry, I forgot this part

Ticket: QA-818
Changelog: None