### PR TITLE
ci: explicitly set image repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,14 @@ variables:
     description: "The changelog file in the remote changelog repo"
     value: "10.Mender-Server/docs.md"
 
+  # Helm version bump
+  MENDER_PUBLISH_REGISTRY:
+    description: "The registry where to push images"
+    value: "docker.io"
+  MENDER_PUBLISH_REPOSITORY:
+    description: "The repositorywhere to push images"
+    value: "mendersoftware"
+
 include:
   - project: "Northern.tech/Mender/mendertesting"
     file:
@@ -584,6 +592,8 @@ release:mender-docs-changelog:
           esac
         fi
         THIS_KEY=".${CONTAINER_KEY}.image.tag" THIS_VALUE="${THIS_TAG}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
+        THIS_KEY=".${CONTAINER}.image.registry" THIS_VALUE="${MENDER_PUBLISH_REGISTRY }" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
+        THIS_KEY=".${CONTAINER}.image.repository" THIS_VALUE="${MENDER_PUBLISH_REPOSITOIRY}/${CONTAINER}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
       done
     - git add ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
     - echo "DEBUG - display values file content"


### PR DESCRIPTION
Added the ability to explicitly set the image repositories, because from now, the gui service could be pushed directly from the mender-server oss repository, so we have to define from which repo the images are.

Ticket: QA-818