### PR TITLE
ci: not specifying container name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -593,7 +593,7 @@ release:mender-docs-changelog:
         fi
         THIS_KEY=".${CONTAINER_KEY}.image.tag" THIS_VALUE="${THIS_TAG}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
         THIS_KEY=".${CONTAINER}.image.registry" THIS_VALUE="${MENDER_PUBLISH_REGISTRY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-        THIS_KEY=".${CONTAINER}.image.repository" THIS_VALUE="${MENDER_PUBLISH_REPOSITORY}/${CONTAINER}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
+        THIS_KEY=".${CONTAINER}.image.repository" THIS_VALUE="${MENDER_PUBLISH_REPOSITORY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
       done
     - git add ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
     - echo "DEBUG - display values file content"


### PR DESCRIPTION
The container name is filled at the Helm level, there's no need to specify it also in the repository name

Ticket: QA-818