### PR TITLE
ci: don't let override variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,10 +55,10 @@ variables:
     value: "10.Mender-Server/docs.md"
 
   # Helm version bump
-  MENDER_PUBLISH_REGISTRY:
+  HELM_MENDER_PUBLISH_REGISTRY:
     description: "The registry where to push images"
     value: "docker.io"
-  MENDER_PUBLISH_REPOSITORY:
+  HELM_MENDER_PUBLISH_REPOSITORY:
     description: "The repositorywhere to push images"
     value: "mendersoftware"
 
@@ -592,8 +592,8 @@ release:mender-docs-changelog:
           esac
         fi
         THIS_KEY=".${CONTAINER_KEY}.image.tag" THIS_VALUE="${THIS_TAG}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-        THIS_KEY=".${CONTAINER}.image.registry" THIS_VALUE="${MENDER_PUBLISH_REGISTRY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-        THIS_KEY=".${CONTAINER}.image.repository" THIS_VALUE="${MENDER_PUBLISH_REPOSITORY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
+        THIS_KEY=".${CONTAINER_KEY}.image.registry" THIS_VALUE="${HELM_MENDER_PUBLISH_REGISTRY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
+        THIS_KEY=".${CONTAINER_KEY}.image.repository" THIS_VALUE="${HELM_MENDER_PUBLISH_REPOSITORY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
       done
     - git add ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
     - echo "DEBUG - display values file content"


### PR DESCRIPTION
The variables get overridden as internal ECR registry; this fix enforce the external registries every stage

Ticket: QA-818