### PR TITLE
MEN-7788: Use Virtual Device for OS updates in docker composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ To initialize the admin user, use the following snippet in step 3:
 MENDER_NAME=Admin
 MENDER_USERNAME=admin@docker.mender.io
 MENDER_PASSWORD=password123
-docker compose exec tenantadm tenantadm create-org --username "$MENDER_USERNAME" --password "$MENDER_PASSWORD" --name "$MENDER_NAME"
+TENANT_ID=$(docker compose exec tenantadm tenantadm create-org --username "$MENDER_USERNAME" --password "$MENDER_PASSWORD" --name "$MENDER_NAME)"
+```
+
+To add a virtual client with the composition, use the following snippet in step 5:
+
+```bash
+TENANT_TOKEN=$(docker compose exec tenantadm tenantadm get-tenant --id "$TENANT_ID" | jq -r .tenant_token)
+export TENANT_TOKEN
+docker compose run -d client
 ```
 
 Visit [https://localhost](https://localhost) and sign in using the credentials from the snippet above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,25 +359,12 @@ services:
         aliases: [mender-nats]
 
   client:
-    image: mendersoftware/mender-client-docker-addons:mender-master
+    image: mendersoftware/mender-client-qemu:mender-master
     scale: 0
-    configs:
-      - source: client_json
-        target: /etc/mender/mender.conf
-    volumes:
-      - ./compose/certs/mender.crt:/var/lib/mender/mender.crt
-
-configs:
-  client_json:
-    content: |
-      {
-        "InventoryPollIntervalSeconds": 5,
-        "RetryPollIntervalSeconds": 5,
-        "ServerURL": "${SERVER_URL:-https://docker.mender.io}",
-        "ServerCertificate": "/var/lib/mender/mender.crt",
-        "UpdatePollIntervalSeconds": 5,
-        "TenantToken": "${TENANT_TOKEN:-}"
-      }
+    privileged: true
+    environment:
+      SERVER_URL: "${SERVER_URL:-https://docker.mender.io}"
+      TENANT_TOKEN: "${TENANT_TOKEN:-}"
 
 volumes:
   mongo: {}

--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -55,6 +55,7 @@ services:
 
   client:
     scale: 1
+    image: mendersoftware/mender-client-docker-addons:mender-master
     configs:
       - source: client_json
         target: /etc/mender/mender.conf


### PR DESCRIPTION
For the upcoming release, we will use the same Virtual Device that we had in the Mender 3.x series. After the release, we will work on migrating to the Virtual Device for app updates consistently across docker composition, ui and docs. See more context in the parent JIRA epic related to this task.

 For the e2e tests, use an override image for the `client` service so that we use the new Virtual Device.