### PR TITLE
ci: Align `needs` conditions for build and test of frontend

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -125,7 +125,7 @@ build:frontend:docker:
   extends: .template:build:docker
   rules:
     - changes:
-        paths: ['frontend/**/*']
+        paths: ['frontend/**/*', 'compose/**/*', 'docker-compose.yml']
         compare_to: '${RULES_CHANGES_COMPARE_TO_REF}'
       when: always
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'


### PR DESCRIPTION
Otherwise a PR modifying a `docker-compose.yml` or any of the `compose/` dependencies would not start due to conflicting requirements for these jobs