### PR TITLE
ci: switch to stable releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,8 +9,8 @@
     }
   },
   "release-type": "simple",
-  "versioning": "prerelease",
-  "prerelease": true,
+  "versioning": "default",
+  "prerelease": false,
   "prerelease-type": "rc",
   "include-component-in-tag": false,
   "include-v-in-tag": true,


### PR DESCRIPTION
We are approaching the next hM release, we have to switch the versioning strategy back to stable from the release candidate

Ticket: None
Changelog: None