### PR TITLE
ci: revert to docker buildkit v0.17

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,9 @@ variables:
   DOCKER_VERSION:
     value: "27"
     description: "Version of docker to use in pipelines"
+  DOCKER_BUILDKITARGS:
+    value: '--driver-opt "image=moby/buildkit:v0.17.3"' # QA-823
+    description: "Optional buildkit args for docker build"
   SKOPEO_VERSION:
     value: "v1.16.1"
     description: "Version of skopeo to use for publishing images"
@@ -111,7 +114,7 @@ default:
     - test "$CI_COMMIT_REF_PROTECTED" != "true" && unset DOCKER_PLATFORM
     - if test -n "${DOCKER_PLATFORM}"; then
       docker context create ci;
-      docker builder create --name ci-builder ci;
+      docker builder create ${DOCKER_BUILDKITARGS} --name ci-builder ci;
       export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --builder=ci-builder";
       unset DOCKER_HOST;
       fi

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -135,7 +135,7 @@ build:frontend:docker:
     - if test -z "${DOCKER_PLATFORM}"; then
     - docker context create ci;
     - fi
-    - docker buildx create --name gui-builder --driver=docker-container ci
+    - docker buildx create ${DOCKER_BUILDKITARGS} --name gui-builder --driver=docker-container ci
     # build production target
     - docker build
       --tag ${MENDER_IMAGE_GUI}


### PR DESCRIPTION
To walk through the error:
runc run failed: unable to start container process: error during container init: error mounting "proc" to rootfs at "/proc": mount src=proc, dst=/proc, dstFd=/proc/thread-self/fd/8, flags=0xe: no such file or directory

Ticket: None
Changelog: None