### PR TITLE
fix(gui): enable device configuration for non enterprise users

### DIFF
--- a/frontend/src/js/store/commonSelectors.ts
+++ b/frontend/src/js/store/commonSelectors.ts
@@ -107,7 +107,7 @@ export const getTenantCapabilities = createSelector(
   ) => {
     const canDelta = isEnterprise || plan === PLANS.professional.id;
     const hasAuditlogs = isAuditlogEnabled && isEnterprise;
-    const hasDeviceConfig = isDeviceConfigEnabled && addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled));
+    const hasDeviceConfig = isDeviceConfigEnabled && (!isEnterprise || addons.some(addon => addon.name === 'configure' && Boolean(addon.enabled)));
     const hasDeviceConnect = isDeviceConnectEnabled && (!isEnterprise || addons.some(addon => addon.name === 'troubleshoot' && Boolean(addon.enabled)));
     const hasMonitor = isMonitorEnabled && addons.some(addon => addon.name === 'monitor' && Boolean(addon.enabled));
     return {


### PR DESCRIPTION
Currently it's not possible to see device configuration if you host
Mender self and have environment variable `HAVE_DEVICECONFIG=true`.

Changes the predicate to be the same as for `hasDeviceConnect`.

If I interpret the [add-ons/configure](https://mender.io/pricing/add-ons/configure) page correctly, it should be available in open-source version as well?