### PR TITLE
ci: ignore own license

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -472,7 +472,7 @@ publish:backend:licenses:
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: golang:${GOLANG_VERSION}
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:${GOLANG_VERSION}
   before_script:
     - go install github.com/google/go-licenses@v1.6.0
   script:
@@ -482,6 +482,7 @@ publish:backend:licenses:
     - |
       GOFLAGS='-tags=nopkcs11' go-licenses report \
         --template=./tests/go-licenses.gotpl \
+        -ignore github.com/mendersoftware/mender-server \
         $(go list -f '{{ if eq .Name "main" }}{{println .Dir }}{{end}}' ./services/...) > licenses.md
     - |
       if grep -o '^LICENSE TEXT MISSING FOR.*$' licenses.md; then


### PR DESCRIPTION
To allow the enterprise repository to successfully run the external license generator. Own licenses are in the LICENSE file after all.

Ticket: QA-831
Changelog: None