### PR TITLE
ci(gui): always keep video recordings of e2e runs on release related branches

### DIFF
--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -22,8 +22,9 @@ services:
     deploy:
       replicas: 0
     environment:
-      - TEST_ENVIRONMENT
+      - CI_COMMIT_REF_PROTECTED
       - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - TEST_ENVIRONMENT
     networks:
       - default
     depends_on:

--- a/frontend/tests/e2e_tests/playwright.config.ts
+++ b/frontend/tests/e2e_tests/playwright.config.ts
@@ -69,7 +69,7 @@ const options: PlaywrightTestConfig = {
     ...contextArgs,
     contextOptions: contextArgs,
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.CI_COMMIT_REF_PROTECTED ? 'on' : 'retain-on-failure',
     // headless: false,
     launchOptions
   }

--- a/frontend/tests/e2e_tests/playwright.config.ts
+++ b/frontend/tests/e2e_tests/playwright.config.ts
@@ -68,10 +68,10 @@ const options: PlaywrightTestConfig = {
   use: {
     ...contextArgs,
     contextOptions: contextArgs,
-    screenshot: 'only-on-failure',
-    video: process.env.CI_COMMIT_REF_PROTECTED ? 'on' : 'retain-on-failure',
     // headless: false,
-    launchOptions
+    launchOptions,
+    screenshot: 'only-on-failure',
+    video: process.env.CI_COMMIT_REF_PROTECTED ? 'on' : 'retain-on-failure'
   }
 };
 


### PR DESCRIPTION
- to ease checking OS setup functionality
example video for accepting a device

[accepting a device](https://github.com/user-attachments/assets/e7d41ead-a8f8-4925-a680-6d1fa8330ba5)

more here:
https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/8808529329/artifacts/browse/frontend/screenshots/

and enterprise:
https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/8808529331/artifacts/browse/frontend/screenshots/

[tenantcreation.webm](https://github.com/user-attachments/assets/fd0784d0-79bc-4222-af2b-24d7fa34f774)
