### PR TITLE
fix: Use internal URLs for storage backend when generating artifacts

### DIFF
--- a/backend/services/deployments/app/app.go
+++ b/backend/services/deployments/app/app.go
@@ -627,13 +627,19 @@ func (d *Deployments) handleRawFile(ctx context.Context,
 		filePath,
 		path.Base(filePath),
 		DefaultImageGenerationLinkExpire,
+		false,
 	)
 	if err != nil {
 		return "", err
 	}
 	multipartMsg.GetArtifactURI = link.Uri
 
-	link, err = d.objectStorage.DeleteRequest(ctx, filePath, DefaultImageGenerationLinkExpire)
+	link, err = d.objectStorage.DeleteRequest(
+		ctx,
+		filePath,
+		DefaultImageGenerationLinkExpire,
+		false,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -797,6 +803,7 @@ func (d *Deployments) DownloadLink(ctx context.Context, imageID string,
 		imagePath,
 		image.Name+model.ArtifactFileSuffix,
 		expire,
+		true,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "Generating download link")
@@ -820,7 +827,7 @@ func (d *Deployments) UploadLink(
 	if skipVerify {
 		path = model.ImagePathFromContext(ctx, artifactID)
 	}
-	link, err := d.objectStorage.PutRequest(ctx, path, expire)
+	link, err := d.objectStorage.PutRequest(ctx, path, expire, true)
 	if err != nil {
 		return nil, errors.WithMessage(err, "app: failed to generate signed URL")
 	}
@@ -1576,6 +1583,7 @@ func (d *Deployments) getDeploymentInstructions(
 		imagePath,
 		deviceDeployment.Image.Name+model.ArtifactFileSuffix,
 		DefaultUpdateDownloadLinkExpire,
+		true,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "Generating download link for the device")

--- a/backend/services/deployments/app/app_test.go
+++ b/backend/services/deployments/app/app_test.go
@@ -461,6 +461,7 @@ func TestUploadLink(t *testing.T) {
 			regexMatcher(`^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\`+
 				fileSuffixTmp),
 			time.Minute,
+			true,
 		).Return(link, nil)
 
 		ds.On("GetStorageSettings", ctx).
@@ -489,6 +490,7 @@ func TestUploadLink(t *testing.T) {
 				`[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\`+
 				fileSuffixTmp),
 			time.Minute,
+			true,
 		).Return(link, nil)
 
 		ds.On("GetStorageSettings", h.ContextMatcher()).
@@ -521,6 +523,7 @@ func TestUploadLink(t *testing.T) {
 				`[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\`+
 				fileSuffixTmp),
 			time.Minute,
+			true,
 		).Return(nil, errInternal)
 
 		upLink, err := deploy.UploadLink(ctx, time.Minute, false)
@@ -544,6 +547,7 @@ func TestUploadLink(t *testing.T) {
 				`[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\`+
 				fileSuffixTmp),
 			time.Minute,
+			true,
 		).Return(link, nil)
 
 		ds.On("GetStorageSettings", ctx).

--- a/backend/services/deployments/app/images_test.go
+++ b/backend/services/deployments/app/images_test.go
@@ -199,6 +199,7 @@ func TestGenerateImageErrorS3GetRequest(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(nil, errors.New("error get request")).
 		On("DeleteObject",
 			h.ContextMatcher(),
@@ -251,6 +252,7 @@ func TestGenerateImageErrorS3DeleteRequest(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(&model.Link{
 		Uri: "GET",
 	}, nil)
@@ -259,6 +261,7 @@ func TestGenerateImageErrorS3DeleteRequest(t *testing.T) {
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(nil, errors.New("error delete request")).
 		On("DeleteObject",
 			h.ContextMatcher(),
@@ -296,6 +299,7 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(&model.Link{
 		Uri: "GET",
 	}, nil)
@@ -304,7 +308,7 @@ func TestGenerateImageErrorWhileStartingWorkflow(t *testing.T) {
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
-		mock.AnythingOfType("string"),
+		false,
 	).Return(&model.Link{
 		Uri: "DELETE",
 	}, nil)
@@ -376,6 +380,7 @@ func TestGenerateImageErrorWhileStartingWorkflowAndFailsWhenCleaningUp(t *testin
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(&model.Link{
 		Uri: "GET",
 	}, nil)
@@ -384,7 +389,7 @@ func TestGenerateImageErrorWhileStartingWorkflowAndFailsWhenCleaningUp(t *testin
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
-		mock.AnythingOfType("string"),
+		false,
 	).Return(&model.Link{
 		Uri: "DELETE",
 	}, nil)
@@ -458,6 +463,7 @@ func TestGenerateImageSuccessful(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(&model.Link{
 		Uri: "GET",
 	}, nil)
@@ -466,7 +472,7 @@ func TestGenerateImageSuccessful(t *testing.T) {
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
-		mock.AnythingOfType("string"),
+		false,
 	).Return(&model.Link{
 		Uri: "DELETE",
 	}, nil)
@@ -523,6 +529,7 @@ func TestGenerateImageSuccessfulWithTenant(t *testing.T) {
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
+		false,
 	).Return(&model.Link{
 		Uri: "GET",
 	}, nil)
@@ -531,7 +538,7 @@ func TestGenerateImageSuccessfulWithTenant(t *testing.T) {
 		h.ContextMatcher(),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("time.Duration"),
-		mock.AnythingOfType("string"),
+		false,
 	).Return(&model.Link{
 		Uri: "DELETE",
 	}, nil)

--- a/backend/services/deployments/storage/azblob/azblob.go
+++ b/backend/services/deployments/storage/azblob/azblob.go
@@ -326,6 +326,7 @@ func (c *client) buildSignedURL(
 	blobURL string,
 	expire time.Duration,
 	filename string,
+	public bool,
 ) (*model.Link, error) {
 	var permissions sas.BlobPermissions
 	switch method {
@@ -382,9 +383,11 @@ func (c *client) buildSignedURL(
 		}
 	}
 	baseURL.RawQuery = q.Encode()
-	baseURL, err = utils.RewriteProxyURL(baseURL, proxyURL)
-	if err != nil {
-		return nil, err
+	if public {
+		baseURL, err = utils.RewriteProxyURL(baseURL, proxyURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &model.Link{
 		Expire: exp,
@@ -398,6 +401,7 @@ func (c *client) GetRequest(
 	objectPath string,
 	filename string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	azClient, err := c.clientFromContext(ctx)
 	if err != nil {
@@ -436,6 +440,7 @@ func (c *client) GetRequest(
 		bc.URL(),
 		duration,
 		filename,
+		public,
 	)
 	if err != nil {
 		return nil, OpError{
@@ -451,6 +456,7 @@ func (c *client) DeleteRequest(
 	ctx context.Context,
 	path string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	azClient, err := c.clientFromContext(ctx)
 	if err != nil {
@@ -467,7 +473,7 @@ func (c *client) DeleteRequest(
 			Reason:  err,
 		}
 	}
-	link, err := c.buildSignedURL(ctx, http.MethodDelete, bc.URL(), duration, "")
+	link, err := c.buildSignedURL(ctx, http.MethodDelete, bc.URL(), duration, "", public)
 	if err != nil {
 		return nil, OpError{
 			Op:      OpDeleteRequest,
@@ -483,6 +489,7 @@ func (c *client) PutRequest(
 	ctx context.Context,
 	objectPath string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	azClient, err := c.clientFromContext(ctx)
 	if err != nil {
@@ -499,7 +506,7 @@ func (c *client) PutRequest(
 			Reason:  err,
 		}
 	}
-	link, err := c.buildSignedURL(ctx, http.MethodPut, bc.URL(), duration, "")
+	link, err := c.buildSignedURL(ctx, http.MethodPut, bc.URL(), duration, "", public)
 	if err != nil {
 		return nil, OpError{
 			Op:      OpPutRequest,

--- a/backend/services/deployments/storage/azblob/azblob_test.go
+++ b/backend/services/deployments/storage/azblob/azblob_test.go
@@ -205,10 +205,10 @@ func TestObjectStorage(t *testing.T) {
 			// Test signed requests
 
 			// Generate signed URL for object that does not exist
-			_, err = c.GetRequest(ctx, subPrefix+"not_found", "foo.mender", time.Minute)
+			_, err = c.GetRequest(ctx, subPrefix+"not_found", "foo.mender", time.Minute, true)
 			assert.ErrorIs(t, err, storage.ErrObjectNotFound)
 
-			link, err := c.GetRequest(ctx, subPrefix+"foo", "bar.mender", time.Minute)
+			link, err := c.GetRequest(ctx, subPrefix+"foo", "bar.mender", time.Minute, true)
 			if assert.NoError(t, err) {
 				req, err := http.NewRequest(link.Method, link.Uri, nil)
 				if assert.NoError(t, err) {
@@ -222,7 +222,7 @@ func TestObjectStorage(t *testing.T) {
 				}
 			}
 
-			link, err = c.DeleteRequest(ctx, subPrefix+"foo", time.Minute)
+			link, err = c.DeleteRequest(ctx, subPrefix+"foo", time.Minute, false)
 			if assert.NoError(t, err) {
 				req, err := http.NewRequest(link.Method, link.Uri, nil)
 				if assert.NoError(t, err) {
@@ -235,7 +235,7 @@ func TestObjectStorage(t *testing.T) {
 				}
 			}
 
-			link, err = c.PutRequest(ctx, subPrefix+"bar", time.Minute*5)
+			link, err = c.PutRequest(ctx, subPrefix+"bar", time.Minute*5, true)
 			if assert.NoError(t, err) {
 				req, err := http.NewRequest(link.Method, link.Uri, strings.NewReader(blobContent))
 				if assert.NoError(t, err) {

--- a/backend/services/deployments/storage/manager/client.go
+++ b/backend/services/deployments/storage/manager/client.go
@@ -119,34 +119,37 @@ func (c *client) GetRequest(
 	path string,
 	filename string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	objStore, err := c.clientFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return objStore.GetRequest(ctx, path, filename, duration)
+	return objStore.GetRequest(ctx, path, filename, duration, public)
 }
 
 func (c *client) DeleteRequest(
 	ctx context.Context,
 	path string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	objStore, err := c.clientFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return objStore.DeleteRequest(ctx, path, duration)
+	return objStore.DeleteRequest(ctx, path, duration, public)
 }
 
 func (c *client) PutRequest(
 	ctx context.Context,
 	path string,
 	duration time.Duration,
+	public bool,
 ) (*model.Link, error) {
 	objStore, err := c.clientFromContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return objStore.PutRequest(ctx, path, duration)
+	return objStore.PutRequest(ctx, path, duration, public)
 }

--- a/backend/services/deployments/storage/mocks/ObjectStorage.go
+++ b/backend/services/deployments/storage/mocks/ObjectStorage.go
@@ -52,9 +52,9 @@ func (_m *ObjectStorage) DeleteObject(ctx context.Context, path string) error {
 	return r0
 }
 
-// DeleteRequest provides a mock function with given fields: ctx, path, duration
-func (_m *ObjectStorage) DeleteRequest(ctx context.Context, path string, duration time.Duration) (*model.Link, error) {
-	ret := _m.Called(ctx, path, duration)
+// DeleteRequest provides a mock function with given fields: ctx, path, duration, public
+func (_m *ObjectStorage) DeleteRequest(ctx context.Context, path string, duration time.Duration, public bool) (*model.Link, error) {
+	ret := _m.Called(ctx, path, duration, public)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteRequest")
@@ -62,19 +62,19 @@ func (_m *ObjectStorage) DeleteRequest(ctx context.Context, path string, duratio
 
 	var r0 *model.Link
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration) (*model.Link, error)); ok {
-		return rf(ctx, path, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration, bool) (*model.Link, error)); ok {
+		return rf(ctx, path, duration, public)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration) *model.Link); ok {
-		r0 = rf(ctx, path, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration, bool) *model.Link); ok {
+		r0 = rf(ctx, path, duration, public)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Link)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration) error); ok {
-		r1 = rf(ctx, path, duration)
+	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration, bool) error); ok {
+		r1 = rf(ctx, path, duration, public)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -112,9 +112,9 @@ func (_m *ObjectStorage) GetObject(ctx context.Context, path string) (io.ReadClo
 	return r0, r1
 }
 
-// GetRequest provides a mock function with given fields: ctx, path, filename, duration
-func (_m *ObjectStorage) GetRequest(ctx context.Context, path string, filename string, duration time.Duration) (*model.Link, error) {
-	ret := _m.Called(ctx, path, filename, duration)
+// GetRequest provides a mock function with given fields: ctx, path, filename, duration, public
+func (_m *ObjectStorage) GetRequest(ctx context.Context, path string, filename string, duration time.Duration, public bool) (*model.Link, error) {
+	ret := _m.Called(ctx, path, filename, duration, public)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRequest")
@@ -122,19 +122,19 @@ func (_m *ObjectStorage) GetRequest(ctx context.Context, path string, filename s
 
 	var r0 *model.Link
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration) (*model.Link, error)); ok {
-		return rf(ctx, path, filename, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration, bool) (*model.Link, error)); ok {
+		return rf(ctx, path, filename, duration, public)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration) *model.Link); ok {
-		r0 = rf(ctx, path, filename, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, time.Duration, bool) *model.Link); ok {
+		r0 = rf(ctx, path, filename, duration, public)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Link)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, time.Duration) error); ok {
-		r1 = rf(ctx, path, filename, duration)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, time.Duration, bool) error); ok {
+		r1 = rf(ctx, path, filename, duration, public)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -178,9 +178,9 @@ func (_m *ObjectStorage) PutObject(ctx context.Context, path string, src io.Read
 	return r0
 }
 
-// PutRequest provides a mock function with given fields: ctx, path, duration
-func (_m *ObjectStorage) PutRequest(ctx context.Context, path string, duration time.Duration) (*model.Link, error) {
-	ret := _m.Called(ctx, path, duration)
+// PutRequest provides a mock function with given fields: ctx, path, duration, public
+func (_m *ObjectStorage) PutRequest(ctx context.Context, path string, duration time.Duration, public bool) (*model.Link, error) {
+	ret := _m.Called(ctx, path, duration, public)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PutRequest")
@@ -188,19 +188,19 @@ func (_m *ObjectStorage) PutRequest(ctx context.Context, path string, duration t
 
 	var r0 *model.Link
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration) (*model.Link, error)); ok {
-		return rf(ctx, path, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration, bool) (*model.Link, error)); ok {
+		return rf(ctx, path, duration, public)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration) *model.Link); ok {
-		r0 = rf(ctx, path, duration)
+	if rf, ok := ret.Get(0).(func(context.Context, string, time.Duration, bool) *model.Link); ok {
+		r0 = rf(ctx, path, duration, public)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Link)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration) error); ok {
-		r1 = rf(ctx, path, duration)
+	if rf, ok := ret.Get(1).(func(context.Context, string, time.Duration, bool) error); ok {
+		r1 = rf(ctx, path, duration, public)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/backend/services/deployments/storage/objectstore.go
+++ b/backend/services/deployments/storage/objectstore.go
@@ -39,11 +39,11 @@ type ObjectStorage interface {
 
 	// The following interface generates signed URLs.
 	GetRequest(ctx context.Context, path string, filename string,
-		duration time.Duration) (*model.Link, error)
+		duration time.Duration, public bool) (*model.Link, error)
 	DeleteRequest(ctx context.Context, path string,
-		duration time.Duration) (*model.Link, error)
+		duration time.Duration, public bool) (*model.Link, error)
 	PutRequest(ctx context.Context, path string,
-		duration time.Duration) (*model.Link, error)
+		duration time.Duration, public bool) (*model.Link, error)
 }
 
 type ObjectInfo struct {

--- a/backend/services/deployments/storage/s3/s3.go
+++ b/backend/services/deployments/storage/s3/s3.go
@@ -559,12 +559,17 @@ func (s *SimpleStorageService) PutRequest(
 	ctx context.Context,
 	path string,
 	expireAfter time.Duration,
+	public bool,
 ) (*model.Link, error) {
 
 	expireAfter = capDurationToLimits(expireAfter).Truncate(time.Second)
 	opts, err := s.optionsFromContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if !public {
+		opts.ExternalURI = nil
+		opts.ProxyURI = nil
 	}
 
 	params := &s3.PutObjectInput{
@@ -592,12 +597,17 @@ func (s *SimpleStorageService) GetRequest(
 	objectPath string,
 	filename string,
 	expireAfter time.Duration,
+	public bool,
 ) (*model.Link, error) {
 
 	expireAfter = capDurationToLimits(expireAfter).Truncate(time.Second)
 	opts, err := s.optionsFromContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if !public {
+		opts.ExternalURI = nil
+		opts.ProxyURI = nil
 	}
 
 	if _, err := s.StatObject(ctx, objectPath); err != nil {
@@ -631,12 +641,17 @@ func (s *SimpleStorageService) DeleteRequest(
 	ctx context.Context,
 	path string,
 	expireAfter time.Duration,
+	public bool,
 ) (*model.Link, error) {
 
 	expireAfter = capDurationToLimits(expireAfter).Truncate(time.Second)
 	opts, err := s.optionsFromContext(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if !public {
+		opts.ExternalURI = nil
+		opts.ProxyURI = nil
 	}
 
 	params := &s3.DeleteObjectInput{


### PR DESCRIPTION
When generating artifacts, the backend will use the direct access URL instead of rewriting the URL using the configured `storage.proxy_uri` or `aws.external_url`.