### PR TITLE
fix: Disable s3 checksum trailer by default

### DIFF
--- a/backend/services/deployments/storage/s3/s3.go
+++ b/backend/services/deployments/storage/s3/s3.go
@@ -116,7 +116,9 @@ func newClient(
 	}
 
 	clientOpts, presignOpts := opt.toS3Options()
-	client := s3.NewFromConfig(cfg, clientOpts)
+	client := s3.NewFromConfig(cfg, clientOpts, func(o *s3.Options) {
+		o.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
 	presignClient := s3.NewPresignClient(client, presignOpts)
 
 	return &SimpleStorageService{


### PR DESCRIPTION
This is a follow-up from upgrading
`github.com/aws/aws-sdk-go-v2/service/s3` to preserve backward compatibility.

Changelog: None
Ticket: None