### PR TITLE
ci: avoid running same e2e from multiple repos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -381,18 +381,21 @@ test:prep:
 
 test:staging-deployment:chrome:
   extends: .template:test:staging-deployment
+  resource_group: test-staging-deployment-chrome
   script:
     - npm run test
   start_in: 10 minutes
 
 test:staging-deployment:firefox:
   extends: .template:test:staging-deployment
+  resource_group: test-staging-deployment-firefox
   script:
     - npm run test -- --browser=firefox
   start_in: 35 minutes
 
 test:staging-deployment:webkit:
   extends: .template:test:staging-deployment
+  resource_group: test-staging-deployment-webkit
   script:
     - npm run test -- --browser=webkit
   start_in: 25 minutes


### PR DESCRIPTION
When two CICD jobs have the same resource_group, only one at a time takes place; this avoids running the same e2e tests from both the mender-server and mender-server-enterprise

Ticket: None
Changelog: None