### PR TITLE
test: Fix timing issue in acceptance tests

### DIFF
--- a/backend/services/workflows/tests/tests/test_decommission_device.py
+++ b/backend/services/workflows/tests/tests/test_decommission_device.py
@@ -48,6 +48,8 @@ def do_decommission_device(mmock_url, workflows_url, tenant_id):
         res = requests.get(
             workflows_url + "/api/v1/workflow/decommission_device/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_deploy_device_configuration.py
+++ b/backend/services/workflows/tests/tests/test_deploy_device_configuration.py
@@ -48,6 +48,8 @@ def test_deploy_device_configuration(mmock_url, workflows_url):
             + "/api/v1/workflow/deploy_device_configuration/"
             + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_provision_device.py
+++ b/backend/services/workflows/tests/tests/test_provision_device.py
@@ -49,6 +49,8 @@ def do_provision_device(mmock_url, workflows_url, tenant_id):
         res = requests.get(
             workflows_url + "/api/v1/workflow/provision_device/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_reindex_inventory.py
+++ b/backend/services/workflows/tests/tests/test_reindex_inventory.py
@@ -44,6 +44,8 @@ def test_reindex_inventory(mmock_url, workflows_url):
         res = requests.get(
             workflows_url + "/api/v1/workflow/reindex_inventory/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_reindex_reporting.py
+++ b/backend/services/workflows/tests/tests/test_reindex_reporting.py
@@ -44,6 +44,8 @@ def test_reindex_reporting(mmock_url, workflows_url):
         res = requests.get(
             workflows_url + "/api/v1/workflow/reindex_reporting/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_reindex_reporting_deployment.py
+++ b/backend/services/workflows/tests/tests/test_reindex_reporting_deployment.py
@@ -46,8 +46,12 @@ def test_reindex_reporting_deployment(mmock_url, workflows_url):
     for i in range(10):
         time.sleep(1)
         res = requests.get(
-            workflows_url + "/api/v1/workflow/reindex_reporting_deployment/" + response["id"]
+            workflows_url
+            + "/api/v1/workflow/reindex_reporting_deployment/"
+            + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_update_device_inventory.py
+++ b/backend/services/workflows/tests/tests/test_update_device_inventory.py
@@ -45,6 +45,8 @@ def test_update_device_inventory(mmock_url, workflows_url):
         res = requests.get(
             workflows_url + "/api/v1/workflow/update_device_inventory/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()

--- a/backend/services/workflows/tests/tests/test_update_device_status.py
+++ b/backend/services/workflows/tests/tests/test_update_device_status.py
@@ -50,6 +50,8 @@ def test_update_device_status(mmock_url, workflows_url):
         res = requests.get(
             workflows_url + "/api/v1/workflow/update_device_status/" + response["id"]
         )
+        if res.status_code == 404:
+            continue
         assert res.status_code == 200
         # if status is done, break
         response = res.json()


### PR DESCRIPTION
The polling loop does not handle the case when the job has not persisted to the database yet. Causing the job to fail even though it might still be in progress.