### PR TITLE
ci: Fix release-please updating changelogs maintained by cliff

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -585,11 +585,6 @@ changelog:
     - git config --global user.name "${GITHUB_USER_NAME}"
     # GITHUB_TOKEN for Github cli authentication
     - export GITHUB_TOKEN=${GITHUB_CLI_TOKEN}
-    - cp CHANGELOG.md CHANGELOG.md.${CI_COMMIT_REF_NAME} # Saving the changelog for later
-    - cp CHANGELOG.md CHANGELOG.md.${CI_COMMIT_REF_NAME} || true # Saving the changelog for later
-    - cp CHANGELOG-saas.md CHANGELOG-saas.md.${CI_COMMIT_REF_NAME} || true # Saving the changelog for later
-    - cp CHANGELOG-enterprise.md CHANGELOG-enterprise.md.${CI_COMMIT_REF_NAME} || true # Saving the changelog for later
-    - export CHANGELOG_SUFFIX=""
   script:
     - release-please release-pr
       --token=${GITHUB_BOT_TOKEN_REPO_FULL}
@@ -601,7 +596,9 @@ changelog:
     - gh repo set-default https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
     - RELEASE_PLEASE_PR=$(gh pr list --author "${GITHUB_USER_NAME}" --head "release-please--branches--${CI_COMMIT_REF_NAME}" --json number | jq -r '.[0].number // empty')
     - test -z "$RELEASE_PLEASE_PR" && echo "No release-please PR found" && exit 0
+    - for filename in "CHANGELOG*.md"; do cp "${filename}" "${filename}.${CI_COMMIT_SHA}"; done
     - gh pr checkout --force $RELEASE_PLEASE_PR
+    - for filename in "CHANGELOG*.md.${CI_COMMIT_SHA}"; do mv "${filename}" "${filename%.${CI_COMMIT_SHA}}"; done
     - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
     - RELEASE_VERSION="$(jq -r '.["."]' .release-please-manifest.json)"
     - |

--- a/.gitlab/generate_changelog.sh
+++ b/.gitlab/generate_changelog.sh
@@ -8,7 +8,6 @@ GITHUB_REPO_URL=$3
 CI_COMMIT_REF_NAME=$4
 
 echo "INFO - Generating changelog file CHANGELOG${CHANGELOG_SUFFIX:-}.md for release ${RELEASE_VERSION}"
-mv CHANGELOG${CHANGELOG_SUFFIX}.md.${CI_COMMIT_REF_NAME} CHANGELOG${CHANGELOG_SUFFIX}.md
 if [ "${CHANGELOG_SUFFIX}" == "-saas" ]; then
     git cliff --unreleased --prepend CHANGELOG${CHANGELOG_SUFFIX}.md --github-repo ${GITHUB_REPO_URL} --use-branch-tags --tag ${RELEASE_VERSION}
 else


### PR DESCRIPTION
When not updating the main CHANGELOG.md, release-please will inject the generated changelog there.