### PR TITLE
ci(gui): adjusted the way pending devices are seen in UI after dependency updates

### DIFF
--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -117,7 +117,7 @@ test.describe('Settings', () => {
       await startClient(baseUrl, token, 50);
       await page.goto(`${baseUrl}ui/devices`);
       await page.getByRole('link', { name: /pending/i }).waitFor({ timeout: timeouts.fifteenSeconds });
-      const pendingNotification = await page.$eval('a [href="/ui/devices/pending"]', el => el.textContent);
+      const pendingNotification = await page.getByRole('link', { name: /pending/i }).innerText();
       expect(Number(pendingNotification.split(' ')[0])).toBeGreaterThan(10);
     });
   });


### PR DESCRIPTION
looks like the stress-test-runner wasn't at fault, but more likely the playwright update that changed the style in browser locators work 🙈