### PR TITLE
Commitlint mandatory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -573,7 +573,6 @@ lint:commit:
   image:
     name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/commitlint/commitlint:latest
     entrypoint: [""]
-  allow_failure: true
   tags:
     - hetzner-amd-beefy
   before_script:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -31,6 +31,8 @@ module.exports = {
     ],
     'subject-case': [1, 'always', ['lower-case', 'sentence-case']],
     'signed-off-by': [2, 'always', 'Signed-off-by'],
+    'body-leading-blank': [2, 'always'], // body must be preceded by a blank line
+                                         // exit with error if not
   },
 
   helpUrl: `


### PR DESCRIPTION
In some cases git cliff is ignoring commits when they don't respect the conventional commit guideline, for example when the body don't start with a blank line.
This is causing issue with the changelog generator (git cliff).

We have two way to prevent this to happen:
1. we don't filter out unconventional commit; see https://github.com/mendersoftware/mendertesting/blob/master/utils/cliff.toml#L89 thus this will lead to unformatted changelog entries
2. we set the commitlinting and the conventional commit as mandatory (this PR) - thus this would cause development friction, also among the contributor 