### PR TITLE
ci: prevent release-please mess up with changelog

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -624,6 +624,9 @@ changelog:
         *saas*)
           if [[ "$CI_PROJECT_NAME" == "mender-server-enterprise" ]]; then
             ./.gitlab/generate_changelog.sh "${RELEASE_VERSION}" "-saas" "${GITHUB_REPO_URL}" "${CI_COMMIT_REF_NAME}"
+          else
+            echo "INFO - Skipping changelog generation for saas release"
+            git add CHANGELOG.md  # restore the original CHANGELOG.md after release-please
           fi
           ;;
         *)


### PR DESCRIPTION
Prevent release-please messing up with the CHANGELOG.md when the release is a saas one. In such a case, we don't need to modify the CHANGELOG.md which is dedicated to Open source changes only.

Ticket: QA-941