### PR TITLE
MEN-7632 - chore(gui): switched virtual device onboarding to docker based client

### DIFF
--- a/frontend/src/js/common-ui/dialogs/VirtualDeviceIOnboarding.test.tsx
+++ b/frontend/src/js/common-ui/dialogs/VirtualDeviceIOnboarding.test.tsx
@@ -43,7 +43,7 @@ describe('getDemoDeviceCreationCommand function', () => {
     expect(code).toMatch('./demo --client up');
     code = getDemoDeviceCreationCommand(token, 85);
     expect(code).toMatch(
-      `TENANT_TOKEN='${token}'\ndocker run -it -p 85:85 -e SERVER_URL='https://localhost' \\\n-e TENANT_TOKEN=$TENANT_TOKEN --pull=always mendersoftware/mender-client-qemu`
+      `TENANT_TOKEN='${token}'\ndocker run -it -p 85:85 -e SERVER_URL='https://localhost' \\\n-e TENANT_TOKEN=$TENANT_TOKEN --pull=always mendersoftware/mender-client-docker-addons`
     );
   });
 });

--- a/frontend/src/js/common-ui/dialogs/VirtualDeviceOnboarding.tsx
+++ b/frontend/src/js/common-ui/dialogs/VirtualDeviceOnboarding.tsx
@@ -22,7 +22,7 @@ import DocsLink from '../DocsLink';
 
 export const getDemoDeviceCreationCommand = (tenantToken, demoArtifactPort) =>
   tenantToken
-    ? `TENANT_TOKEN='${tenantToken}'\ndocker run -it -p ${demoArtifactPort}:${demoArtifactPort} -e SERVER_URL='https://${window.location.hostname}' \\\n-e TENANT_TOKEN=$TENANT_TOKEN --pull=always mendersoftware/mender-client-qemu`
+    ? `TENANT_TOKEN='${tenantToken}'\ndocker run -it -p ${demoArtifactPort}:${demoArtifactPort} -e SERVER_URL='https://${window.location.hostname}' \\\n-e TENANT_TOKEN=$TENANT_TOKEN --pull=always mendersoftware/mender-client-docker-addons`
     : './demo --client up';
 
 export const VirtualDeviceOnboarding = () => {

--- a/frontend/src/js/helptips/HelpTooltips.tsx
+++ b/frontend/src/js/helptips/HelpTooltips.tsx
@@ -308,7 +308,8 @@ export const HELPTOOLTIPS = {
     Component: ConfigureRaspberryLedTip,
     isRelevant: ({ device = {} }) => {
       const { attributes = {} } = device;
-      return ['raspberry', 'rpi'].some(type => attributes.device_type?.some(deviceType => deviceType.startsWith(type)));
+      const { device_type = [] } = attributes;
+      return ['raspberry', 'rpi'].some(type => device_type.some(deviceType => deviceType.startsWith(type)));
     }
   },
   configureTimezoneTip: {
@@ -316,7 +317,8 @@ export const HELPTOOLTIPS = {
     Component: ConfigureTimezoneTip,
     isRelevant: ({ device = {} }) => {
       const { attributes = {} } = device;
-      return ['raspberry', 'rpi', 'qemux86-64'].some(type => attributes.device_type?.some(deviceType => deviceType.startsWith(type)));
+      const { device_type = [] } = attributes;
+      return ['generic-x86_64', 'raspberry', 'rpi', 'qemux86-64'].some(type => device_type.some(deviceType => deviceType.startsWith(type)));
     }
   },
   dashboardWidget: { id: 'dashboardWidget', Component: DashboardWidget },

--- a/frontend/src/js/store/onboardingSlice/thunks.ts
+++ b/frontend/src/js/store/onboardingSlice/thunks.ts
@@ -70,7 +70,7 @@ const deductOnboardingState = ({ devicesById, devicesByStatus, onboardingState, 
     ),
     showTips: onboardingState.showTips != null ? onboardingState.showTips : true,
     deviceType,
-    approach: onboardingState.approach || (deviceType.some(type => type.startsWith('qemu')) ? 'virtual' : 'physical'),
+    approach: onboardingState.approach || (deviceType.some(type => type.startsWith('qemu') || type === 'generic-x86_64') ? 'virtual' : 'physical'),
     progress
   };
 };


### PR DESCRIPTION
due to the absence of the qemu device type, checks for a virtual device now rely on the kernel coming from a buildkit system - not sure if that's enough, but I couldn't find an alternative attribute