### PR TITLE
feat(iot-manager): getting events by integration by ID

### DIFF
--- a/backend/services/iot-manager/api/http/management.go
+++ b/backend/services/iot-manager/api/http/management.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -233,6 +233,18 @@ func (h *ManagementHandler) GetEvents(c *gin.Context) {
 			err,
 		)
 		return
+	}
+	integrationID := c.Request.URL.Query().Get(paramQueryIntegrationID)
+	if len(integrationID) > 0 {
+		if err := uuid.Validate(integrationID); err == nil {
+			filter.IntegrationID = &integrationID
+		} else {
+			rest.RenderError(c,
+				http.StatusBadRequest,
+				ErrInvalidIntegrationID,
+			)
+			return
+		}
 	}
 
 	events, err := h.app.GetEvents(ctx, *filter)

--- a/backend/services/iot-manager/api/http/management_state.go
+++ b/backend/services/iot-manager/api/http/management_state.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	paramDeviceID      = "id"
-	paramIntegrationID = "integrationId"
+	paramDeviceID           = "id"
+	paramIntegrationID      = "integrationId"
+	paramQueryIntegrationID = "integration_id"
 )
 
 var (

--- a/backend/services/iot-manager/api/http/management_test.go
+++ b/backend/services/iot-manager/api/http/management_test.go
@@ -1010,6 +1010,7 @@ func (neverExpireContext) Deadline() (time.Time, bool) {
 
 func TestGetEvents(t *testing.T) {
 	t.Parallel()
+	integrationId := uuid.New().String()
 	testCases := []struct {
 		Name string
 
@@ -1060,6 +1061,54 @@ func TestGetEvents(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Response: []map[string]interface{}{{
 				"id":   uuid.Nil,
+				"data": map[string]interface{}{"id": "00000000-0000-0000-0000-000000000000"},
+				"delivery_statuses": []map[string]interface{}{{
+					"integration_id": uuid.Nil,
+					"success":        true,
+					"status_code":    200,
+				}},
+				"time": "0001-01-01T00:00:00Z",
+				"type": "device-provisioned",
+			}},
+		},
+		{
+			Name: "ok with integration id",
+
+			Headers: http.Header{
+				"Authorization": []string{"Bearer " + GenerateJWT(identity.Identity{
+					IsUser:  true,
+					Subject: "829cbefb-70e7-438f-9ac5-35fd131c2111",
+					Tenant:  "123456789012345678901234",
+				})},
+			},
+
+			Url: "http://localhost" + APIURLManagement + APIURLEvents + "?" + paramQueryIntegrationID + "=" + integrationId,
+
+			App: func(t *testing.T) *mapp.App {
+				app := new(mapp.App)
+				app.On("GetEvents", contextMatcher, model.EventsFilter{Limit: 20, IntegrationID: &integrationId}).
+					Return([]model.Event{{
+						WebhookEvent: model.WebhookEvent{
+							ID:      uuid.MustParse(integrationId),
+							Type:    model.EventTypeDeviceProvisioned,
+							Data:    model.DeviceEvent{ID: uuid.Nil.String()},
+							EventTS: time.Time{},
+						},
+						DeliveryStatus: []model.DeliveryStatus{{
+							IntegrationID: uuid.Nil,
+							Success:       true,
+							StatusCode: func() *int {
+								i := 200
+								return &i
+							}(),
+						}},
+					}}, nil)
+				return app
+			},
+
+			StatusCode: http.StatusOK,
+			Response: []map[string]interface{}{{
+				"id":   uuid.MustParse(integrationId),
 				"data": map[string]interface{}{"id": "00000000-0000-0000-0000-000000000000"},
 				"delivery_statuses": []map[string]interface{}{{
 					"integration_id": uuid.Nil,
@@ -1135,6 +1184,26 @@ func TestGetEvents(t *testing.T) {
 			StatusCode: http.StatusBadRequest,
 			Response: map[string]interface{}{
 				"error":      "invalid page query: \"foo\"",
+				"request_id": "test",
+			},
+		},
+		{
+			Name: "bad request with integration id",
+
+			Headers: http.Header{
+				"Authorization": []string{"Bearer " + GenerateJWT(identity.Identity{
+					IsUser:  true,
+					Subject: "829cbefb-70e7-438f-9ac5-35fd131c2111",
+					Tenant:  "123456789012345678901234",
+				})},
+				textproto.CanonicalMIMEHeaderKey(requestid.RequestIdHeader): []string{"test"},
+			},
+
+			Url: "http://localhost" + APIURLManagement + APIURLEvents + "?" + paramQueryIntegrationID + "=trash",
+
+			StatusCode: http.StatusBadRequest,
+			Response: map[string]interface{}{
+				"error":      "integration ID is not a valid UUID",
 				"request_id": "test",
 			},
 		},

--- a/backend/services/iot-manager/api/http/router.go
+++ b/backend/services/iot-manager/api/http/router.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/backend/services/iot-manager/docs/management_api.yml
+++ b/backend/services/iot-manager/docs/management_api.yml
@@ -311,6 +311,13 @@ paths:
           schema:
             type: integer
             default: 20
+        - name: integration_id
+          in: query
+          schema:
+            type: string
+            format: uuid
+          required: false
+          description: The unique ID of the integration to get the events from.
 
       responses:
         200:

--- a/backend/services/iot-manager/model/event.go
+++ b/backend/services/iot-manager/model/event.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -76,8 +76,9 @@ func (typ EventType) Validate() error {
 }
 
 type EventsFilter struct {
-	Skip  int64
-	Limit int64
+	Skip          int64
+	Limit         int64
+	IntegrationID *string
 }
 
 // AuthSet contains a subset of the deviceauth AuthSet definition

--- a/backend/services/iot-manager/store/mongo/datastore_mongo.go
+++ b/backend/services/iot-manager/store/mongo/datastore_mongo.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ const (
 	KeyProvider       = "provider"
 	KeyTenantID       = "tenant_id"
 	KeyCredentials    = "credentials"
+	KeyStatus         = "status"
+	KeyIntegrationID  = "integration_id"
 
 	ConnectTimeoutSeconds = 10
 	defaultAutomigrate    = false
@@ -294,15 +296,8 @@ func (db *DataStoreMongo) CreateIntegration(
 	ctx context.Context,
 	integration model.Integration,
 ) (*model.Integration, error) {
-	var tenantID string
-	if id := identity.FromContext(ctx); id != nil {
-		tenantID = id.Tenant
-	}
 	collIntegrations := db.Collection(CollNameIntegrations)
-
-	// Force a single integration per tenant by utilizing unique '_id' index
-	integration.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(tenantID))
-
+	integration.ID = uuid.New()
 	_, err := collIntegrations.
 		InsertOne(ctx, mstore.WithTenantID(ctx, integration))
 	if err != nil {

--- a/backend/services/iot-manager/store/mongo/datastore_mongo_events.go
+++ b/backend/services/iot-manager/store/mongo/datastore_mongo_events.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -62,8 +62,17 @@ func (db *DataStoreMongo) GetEvents(
 		findOpts.SetLimit(fltr.Limit)
 	}
 
+	filter := bson.D{}
+	if fltr.IntegrationID != nil {
+		filter = append(filter,
+			bson.E{
+				Key:   KeyStatus + "." + KeyIntegrationID,
+				Value: uuid.MustParse(*fltr.IntegrationID),
+			},
+		)
+	}
 	cur, err := collEvents.Find(ctx,
-		mstore.WithTenantID(ctx, bson.D{}),
+		mstore.WithTenantID(ctx, filter),
 		findOpts,
 	)
 	if err != nil {

--- a/backend/services/iot-manager/store/mongo/datastore_mongo_test.go
+++ b/backend/services/iot-manager/store/mongo/datastore_mongo_test.go
@@ -66,7 +66,6 @@ func TestCreateIntegration(t *testing.T) {
 			Tenant: "1234567890",
 		}),
 		Integration: model.Integration{
-			ID:       uuid.NewSHA1(uuid.NameSpaceOID, []byte("1234567890")),
 			Provider: model.ProviderIoTHub,
 			Credentials: model.Credentials{
 				Type: "connection_string",
@@ -82,7 +81,6 @@ func TestCreateIntegration(t *testing.T) {
 
 		CTX: context.Background(),
 		Integration: model.Integration{
-			ID:       uuid.NewSHA1(uuid.NameSpaceOID, []byte("")),
 			Provider: model.ProviderIoTHub,
 			Credentials: model.Credentials{
 				Type: "connection_string",
@@ -154,6 +152,9 @@ func TestCreateIntegration(t *testing.T) {
 
 				var integration model.Integration
 				bson.UnmarshalWithRegistry(newRegistry(), doc, &integration)
+				assert.True(t, uuid.Validate(integration.ID.String()) == nil)
+				integration.ID = uuid.Nil
+				tc.Integration.ID = uuid.Nil
 				assert.Equal(t, tc.Integration, integration)
 			}
 		})

--- a/backend/services/iot-manager/store/mongo/migration_1_2_0.go
+++ b/backend/services/iot-manager/store/mongo/migration_1_2_0.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package mongo
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	mopts "go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/mendersoftware/mender-server/pkg/mongo/migrate"
+)
+
+const (
+	IndexNameOneIntegration = `integration_one_per_tenant`
+)
+
+type migration_1_2_0 struct {
+	client *mongo.Client
+	db     string
+}
+
+// Up creates indexes for fetching event documents
+func (m *migration_1_2_0) Up(from migrate.Version) error {
+	ctx := context.Background()
+	eventModel := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: KeyTenantID, Value: 1},
+		},
+		Options: mopts.Index().
+			SetName(IndexNameOneIntegration).
+			SetUnique(true),
+	}
+	_, err := m.client.
+		Database(m.db).
+		Collection(CollNameIntegrations).
+		Indexes().
+		CreateOne(ctx, eventModel)
+	return err
+}
+
+func (m *migration_1_2_0) Version() migrate.Version {
+	return migrate.MakeVersion(1, 2, 0)
+}

--- a/backend/services/iot-manager/store/mongo/migration_1_2_0_test.go
+++ b/backend/services/iot-manager/store/mongo/migration_1_2_0_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/mendersoftware/mender-server/pkg/mongo/migrate"
+)
+
+func TestMigration_1_2_0(t *testing.T) {
+	ctx := context.Background()
+	client := db.Client()
+	m := &migration_1_2_0{
+		client: client,
+		db:     DbName,
+	}
+	from := migrate.MakeVersion(0, 0, 0)
+
+	err := m.Up(from)
+	require.NoError(t, err)
+	specs, err := client.Database(DbName).
+		Collection(CollNameIntegrations).
+		Indexes().
+		ListSpecifications(ctx)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	var foundIndex bool
+	for _, spec := range specs {
+		if spec == nil {
+			continue
+		}
+		if spec.Name == IndexNameOneIntegration {
+			foundIndex = true
+			assert.True(
+				t,
+				spec.Unique != nil && *spec.Unique,
+				"index must allow only one integration per tenant")
+			var keys bson.M
+			_ = bson.Unmarshal(spec.KeysDocument, &keys)
+			assert.Equal(t,
+				keys,
+				bson.M{KeyTenantID: int32(1)},
+				"unexpected index keys")
+			break
+		}
+	}
+	assert.True(t, foundIndex, "Failed to find index created by migration 1.2.0")
+}

--- a/backend/services/iot-manager/store/mongo/migrations.go
+++ b/backend/services/iot-manager/store/mongo/migrations.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Northern.tech AS
+// Copyright 2025 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import (
 
 const (
 	// DbVersion is the current schema version
-	DbVersion = "1.1.1"
+	DbVersion = "1.2.0"
 
 	// DbName is the database name
 	DbName = "iot_manager"
@@ -63,6 +63,10 @@ func Migrate(ctx context.Context,
 			db:     db,
 		},
 		&migration_1_1_1{
+			client: client,
+			db:     db,
+		},
+		&migration_1_2_0{
 			client: client,
 			db:     db,
 		},


### PR DESCRIPTION
Allows to:
* get device events from iot-manager by integration ID
* creating new integration creates a new ID
* maintains backward compatibility for GET /event
* with UI calling the new endpoint this fixes the showing of events from old webhooks in the integraiton details

Changelog: Do not show events from previous webhooks in the integration details by making possible for the UI to get the events by integration ID, at the same time create new ID on ech integration creation.
Ticket: MEN-7801