### PR TITLE
ci: Remove tag override for `test-integration` Makefile target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -296,7 +296,9 @@ test:backend:integration:
     - mkdir -p ${GOCOVERDIR}/integration
     - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
   script:
-    - make -C backend test-integration GOCOVERDIR=${GOCOVERDIR}/integration
+    - make -C backend test-integration
+      GOCOVERDIR=${GOCOVERDIR}/integration
+      MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
   artifacts:
     expire_in: 1w
     when: always

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,6 @@
 MENDER_IMAGE_REGISTRY ?= docker.io
 MENDER_IMAGE_REPOSITORY ?= mendersoftware
 MENDER_IMAGE_TAG ?= latest
-MENDER_IMAGE_TAG_TEST ?= test
 
 MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSTIORY ?= mendersoftware
@@ -67,7 +66,6 @@ $(TEST_ACCEPTANCE_TARGETS):
 	@$(MAKE) -C services/$(subst -test-acceptance,,$@) test-acceptance-run
 
 .PHONY: test-integration
-test-integration: export MENDER_IMAGE_TAG=$(MENDER_IMAGE_TAG_TEST)
 test-integration:
 	./tests/integration/run $(args)
 


### PR DESCRIPTION
This is only making local tests more confusing. Putting the image tag override in CI to use images built with coverage instrumentation.