### PR TITLE
chore: Clean up unneeded middlewares from Traefik configuration

### DIFF
--- a/compose/config/traefik/middlewares.yaml
+++ b/compose/config/traefik/middlewares.yaml
@@ -24,16 +24,6 @@ http:
         address: "http://useradm:8080/api/internal/v1/useradm/auth/verify"
         authResponseHeaders: "X-MEN-RequestID,X-MEN-RBAC-Inventory-Groups,X-MEN-RBAC-Deployments-Groups,X-MEN-RBAC-Releases-Tags"
 
-    inventoryV1-replacepathregex:
-      replacepathregex:
-        regex: "^/api/devices/v1/inventory/(.*)"
-        replacement: "/api/0.1.0/attributes"
-
-    inventoryMgmtV1-replacepathregex:
-      replacepathregex:
-        regex: "^/api/management/v1/inventory/(.*)"
-        replacement: "/api/0.1.0/$1"
-
     mgmtStack:
       chain:
         middlewares:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,13 +191,11 @@ services:
     labels:
       traefik.enable: "true"
       traefik.http.services.inventory.loadBalancer.server.port: "8080"
-      traefik.http.routers.inventoryDevV1.middlewares: >-
-        devStack@file,inventoryV1-replacepathregex@file
+      traefik.http.routers.inventoryDevV1.middlewares: devStack@file
       traefik.http.routers.inventoryDevV1.rule: >-
         PathRegexp(`/api/devices/v1/inventory`)
       traefik.http.routers.inventoryDevV1.service: inventory
-      traefik.http.routers.inventoryMgmtV1.middlewares: >-
-        mgmtStack@file,inventoryMgmtV1-replacepathregex@file
+      traefik.http.routers.inventoryMgmtV1.middlewares: mgmtStack@file
       traefik.http.routers.inventoryMgmtV1.rule: >-
         PathRegexp(`/api/management/v1/inventory`)
       traefik.http.routers.inventoryMgmtV1.service: inventory


### PR DESCRIPTION
New aliases was setup in the inventory service was fixed before the v4.0.0 release, there's no reason to keep these middlewares around.
https://github.com/mendersoftware/mender-server/pull/395