### PR TITLE
chore: Remove gin.Recover middleware in favor of accesslog recover

### DIFF
--- a/backend/services/deviceconnect/api/http/router.go
+++ b/backend/services/deviceconnect/api/http/router.go
@@ -73,7 +73,6 @@ func NewRouter(
 
 	router := gin.New()
 	router.Use(accesslog.Middleware())
-	router.Use(gin.Recovery())
 	router.Use(identity.Middleware(
 		identity.NewMiddlewareOptions().
 			SetPathRegex(`^/api/(devices|management)/v[0-9]/`),


### PR DESCRIPTION
The gin middleware does not provide structured (logfmt) output.