### PR TITLE
Ci/staging rated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,9 +335,9 @@ test:integration:
 test:prep:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: on_success
+  # rules:
+  #   - if: $CI_COMMIT_BRANCH == "main"
+  #     when: on_success
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
@@ -352,13 +352,13 @@ test:prep:
 
 .template:test:staging-deployment:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mendersoftware/mender-test-containers:gui-e2e-testing
-  stage: .post
+  stage: test
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
-  only:
-    - main # can't use rules with delays: https://gitlab.com/gitlab-org/gitlab/-/issues/424203
-  when: delayed
+  # only:
+  #   - main # can't use rules with delays: https://gitlab.com/gitlab-org/gitlab/-/issues/424203
+  # when: delayed
   needs:
     - job: test:prep
       artifacts: true
@@ -392,7 +392,7 @@ test:staging-deployment:chrome:
   script:
     - npx playwright install chromium
     - npm run test
-  start_in: 15 minutes
+  # start_in: 15 minutes
 
 test:staging-deployment:firefox:
   extends: .template:test:staging-deployment
@@ -400,7 +400,7 @@ test:staging-deployment:firefox:
   script:
     - npx playwright install firefox
     - npm run test -- --browser=firefox
-  start_in: 40 minutes
+  # start_in: 40 minutes
 
 test:staging-deployment:webkit:
   extends: .template:test:staging-deployment
@@ -409,7 +409,7 @@ test:staging-deployment:webkit:
   script:
     - npx playwright install webkit
     - npm run test -- --browser=webkit
-  start_in: 30 minutes
+  # start_in: 30 minutes
 
 publish:backend:coverage:
   stage: publish

--- a/frontend/tests/e2e_tests/fixtures/fixtures.ts
+++ b/frontend/tests/e2e_tests/fixtures/fixtures.ts
@@ -68,7 +68,7 @@ const test = (process.env.TEST_ENVIRONMENT === 'staging' ? nonCoveredTest : cove
     await loginCommon(page, username, use, context);
   },
   loggedInTenantPage: async ({ baseUrl, context, password, spTenantUsername }, use) => {
-    const page = await prepareNewPage({ baseUrl, context, password, username: spTenantUsername });
+    const page = await prepareNewPage({ baseUrl, context, hasSessionCaching: false, password, username: spTenantUsername });
     await loginCommon(page, spTenantUsername, use, context);
   },
   // eslint-disable-next-line no-empty-pattern

--- a/frontend/tests/e2e_tests/fixtures/fixtures.ts
+++ b/frontend/tests/e2e_tests/fixtures/fixtures.ts
@@ -75,14 +75,14 @@ const loginCommon = async ({
   await use(page);
 };
 const test = (process.env.TEST_ENVIRONMENT === 'staging' ? nonCoveredTest : coveredTest).extend<TestFixtures>({
-  loggedInPage: async ({ baseUrl, context, password, username }, use) => {
-    test.use({ storageState: storagePath });
+  loggedInPage: async ({ baseUrl, browser, password, username }, use) => {
+    const context = await browser.newContext({ storageState: storagePath });
     const page = await prepareNewPage({ baseUrl, context, password, username });
     await loginCommon({ page, username, use, context });
   },
-  loggedInTenantPage: async ({ baseUrl, context, password, spTenantUsername }, use) => {
+  loggedInTenantPage: async ({ baseUrl, browser, password, spTenantUsername }, use) => {
     const storageLocation = `tenant-${storagePath}`;
-    test.use({ storageState: storageLocation });
+    const context = await browser.newContext({ storageState: storageLocation });
     const page = await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
     await loginCommon({ page, username: spTenantUsername, use, context });
   },

--- a/frontend/tests/e2e_tests/fixtures/fixtures.ts
+++ b/frontend/tests/e2e_tests/fixtures/fixtures.ts
@@ -76,17 +76,19 @@ const loginCommon = async ({
 };
 const test = (process.env.TEST_ENVIRONMENT === 'staging' ? nonCoveredTest : coveredTest).extend<TestFixtures>({
   loggedInPage: async ({ baseUrl, context, password, username }, use) => {
+    test.use({ storageState: storagePath });
     const page = await prepareNewPage({ baseUrl, context, password, username });
     await loginCommon({ page, username, use, context });
   },
   loggedInTenantPage: async ({ baseUrl, context, password, spTenantUsername }, use) => {
     const storageLocation = `tenant-${storagePath}`;
+    test.use({ storageState: storageLocation });
     const page = await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
     await loginCommon({ page, username: spTenantUsername, use, context });
   },
   // eslint-disable-next-line no-empty-pattern
   environment: async ({}, use) => {
-    const environment = process.env.TEST_ENVIRONMENT ? process.env.TEST_ENVIRONMENT : 'localhost';
+    const environment = (process.env.TEST_ENVIRONMENT ? process.env.TEST_ENVIRONMENT : 'localhost') as TestEnvironment;
     await use(environment);
   },
   spTenantUsername: async ({ environment }, use) => {

--- a/frontend/tests/e2e_tests/integration/00-setup.spec.ts
+++ b/frontend/tests/e2e_tests/integration/00-setup.spec.ts
@@ -79,7 +79,7 @@ test.describe('Test setup', () => {
       await isLoggedIn(page, timeouts.fifteenSeconds);
 
       // the following sets the UI up for easier navigation by disabling onboarding
-      const newPage = await prepareNewPage({ baseUrl, context, password, username });
+      const newPage = await prepareNewPage({ baseUrl, context, hasSessionCaching: false, password, username });
       await isLoggedIn(newPage);
       await context.storageState({ path: storagePath });
     });
@@ -89,7 +89,7 @@ test.describe('Test setup', () => {
     test('supports tenant token retrieval', async ({ baseUrl, context, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
       console.log(`logging in user with username: ${username} and password: ${password}`);
-      const page = await prepareNewPage({ baseUrl, context, password, username });
+      const page = await prepareNewPage({ baseUrl, context, hasSessionCaching: false, password, username });
       await page.goto(`${baseUrl}ui/settings`);
       const isVisible = await page.getByRole('button', { name: /change email/i }).isVisible();
       if (!isVisible) {

--- a/frontend/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
+++ b/frontend/tests/e2e_tests/integration/02-layoutAssertions.spec.ts
@@ -12,10 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
-import { selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { selectors, timeouts } from '../utils/constants.ts';
 
 test.describe('Layout assertions', () => {
-  test.use({ storageState: storagePath });
   let navbar;
   test.beforeEach(async ({ loggedInPage: page }) => {
     navbar = page.locator('.leftFixed.leftNav');

--- a/frontend/tests/e2e_tests/integration/03-files.spec.ts
+++ b/frontend/tests/e2e_tests/integration/03-files.spec.ts
@@ -22,7 +22,7 @@ import { parse } from 'yaml';
 
 import test, { expect } from '../fixtures/fixtures.ts';
 import { getTokenFromStorage, isEnterpriseOrStaging, tagRelease } from '../utils/commands.ts';
-import { releaseTag, selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { releaseTag, selectors, timeouts } from '../utils/constants.ts';
 
 dayjs.extend(isBetween);
 
@@ -32,8 +32,6 @@ const demoArtifactLocation = `https://dgsbl4vditpls.cloudfront.net/${fileName}`;
 const fileLocation = `fixtures/${fileName}`;
 
 test.describe('Files', () => {
-  test.use({ storageState: storagePath });
-
   let navbar;
   test.beforeEach(async ({ browserName, loggedInPage: page }) => {
     navbar = page.locator('.leftFixed.leftNav');

--- a/frontend/tests/e2e_tests/integration/03-files.spec.ts
+++ b/frontend/tests/e2e_tests/integration/03-files.spec.ts
@@ -86,7 +86,7 @@ test.describe('Files', () => {
     await page.getByRole('button', { name: /next/i }).click();
     await page.getByRole('button', { name: /upload artifact/i }).click();
     await page.getByText('1-2 of 2').waitFor();
-    const token = await getTokenFromStorage(baseUrl);
+    const { token } = await getTokenFromStorage(baseUrl);
     await tagRelease(releaseName, 'customRelease', baseUrl, token);
     await page.waitForTimeout(timeouts.oneSecond); // some extra time for the release to be tagged in the backend
     await page.keyboard.press('Escape');

--- a/frontend/tests/e2e_tests/integration/04-deployments.spec.ts
+++ b/frontend/tests/e2e_tests/integration/04-deployments.spec.ts
@@ -16,7 +16,7 @@ import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween.js';
 
 import test, { expect } from '../fixtures/fixtures';
-import { selectors, storagePath, timeouts } from '../utils/constants';
+import { selectors, timeouts } from '../utils/constants';
 
 dayjs.extend(isBetween);
 
@@ -29,8 +29,6 @@ const checkTimeFilter = async (page: Page, name: string, isSetToday?: boolean) =
 };
 
 test.describe('Deployments', () => {
-  test.use({ storageState: storagePath });
-
   test.beforeEach(async ({ baseUrl, loggedInPage: page }) => {
     await page.goto(`${baseUrl}ui/devices`);
     await page.waitForTimeout(timeouts.default);

--- a/frontend/tests/e2e_tests/integration/05-deviceDetails.spec.ts
+++ b/frontend/tests/e2e_tests/integration/05-deviceDetails.spec.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'url';
 
 import test, { expect } from '../fixtures/fixtures.ts';
 import { compareImages, isEnterpriseOrStaging } from '../utils/commands.ts';
-import { selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { selectors, timeouts } from '../utils/constants.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -29,7 +29,6 @@ const terminalReferenceFileMap = {
 const rootfs = 'rootfs-image.version';
 
 test.describe('Device details', () => {
-  test.use({ storageState: storagePath });
   test.beforeEach(async ({ baseUrl, loggedInPage: page }) => {
     await page.goto(`${baseUrl}ui/devices`);
   });

--- a/frontend/tests/e2e_tests/integration/06-auditlogs.spec.ts
+++ b/frontend/tests/e2e_tests/integration/06-auditlogs.spec.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'url';
 
 import test, { expect } from '../fixtures/fixtures.ts';
 import { compareImages, isEnterpriseOrStaging } from '../utils/commands.ts';
-import { selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { selectors, timeouts } from '../utils/constants.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -71,7 +71,6 @@ const checkDownloadedReplayForSecret = async (path, secret) => {
 };
 
 test.describe('Auditlogs', () => {
-  test.use({ storageState: storagePath });
   let navbar;
   test.beforeEach(async ({ loggedInPage: page }) => {
     navbar = page.locator('.leftFixed.leftNav');

--- a/frontend/tests/e2e_tests/integration/07-saml.spec.ts
+++ b/frontend/tests/e2e_tests/integration/07-saml.spec.ts
@@ -17,7 +17,7 @@ import * as https from 'node:https';
 
 import test, { expect } from '../fixtures/fixtures.ts';
 import { getTokenFromStorage, isEnterpriseOrStaging, isLoggedIn, startIdpServer } from '../utils/commands.ts';
-import { storagePath, timeouts } from '../utils/constants.ts';
+import { timeouts } from '../utils/constants.ts';
 
 dns.setDefaultResultOrder('ipv4first');
 
@@ -37,7 +37,6 @@ let acsUrl = '';
 let metadataLocation = '';
 
 test.describe('SAML Login via sso/id/login', () => {
-  test.use({ storageState: storagePath });
   test.afterAll(async ({ environment, baseUrl, browserName }, testInfo) => {
     if (testInfo.status === 'skipped' || !isEnterpriseOrStaging(environment)) {
       return;

--- a/frontend/tests/e2e_tests/integration/07-saml.spec.ts
+++ b/frontend/tests/e2e_tests/integration/07-saml.spec.ts
@@ -42,7 +42,7 @@ test.describe('SAML Login via sso/id/login', () => {
     if (testInfo.status === 'skipped' || !isEnterpriseOrStaging(environment)) {
       return;
     }
-    const token = await getTokenFromStorage(baseUrl);
+    const { token } = await getTokenFromStorage(baseUrl);
     const requestInfo = { headers: { ...defaultHeaders, Authorization: `Bearer ${token}` }, httpsAgent, method: 'GET' };
     console.log(`Finished ${testInfo.title} with status ${testInfo.status}. Cleaning up.`);
     const response = await axios({
@@ -107,7 +107,7 @@ test.describe('SAML Login via sso/id/login', () => {
     expect(downloadTargetPath).toBeTruthy();
     const dialog = await page.locator('text=SAML metadata >> .. >> ..');
     await dialog.locator('data-testid=CloseIcon').click();
-    const token = await getTokenFromStorage(baseUrl);
+    const { token } = await getTokenFromStorage(baseUrl);
     const requestInfo = { method: 'GET', headers: { ...defaultHeaders, Authorization: `Bearer ${token}` }, httpsAgent };
     const { data } = await axios({ ...requestInfo, url: `${baseUrl}api/management/v1/useradm/sso/idp/metadata` });
     const metadataId = data[0].id;

--- a/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
+++ b/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
@@ -13,7 +13,7 @@
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
 import { isEnterpriseOrStaging, prepareNewPage } from '../utils/commands.ts';
-import { releaseTag, selectors, timeouts } from '../utils/constants.ts';
+import { releaseTag, selectors, storagePath, timeouts } from '../utils/constants.ts';
 
 const releaseRoles = [
   { name: 'test-releases-role', permissions: ['Read'], tag: undefined },
@@ -23,6 +23,7 @@ const releaseRoles = [
 
 test.describe('RBAC functionality', () => {
   test.describe('configuration', () => {
+    test.use({ storageState: storagePath });
     test.beforeEach(async ({ baseUrl, loggedInPage: page }) => {
       await page.goto(`${baseUrl}ui/settings`);
       await page.getByText(/Global settings/i).waitFor();

--- a/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
+++ b/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
-import { isEnterpriseOrStaging, prepareNewPage } from '../utils/commands.ts';
+import { isEnterpriseOrStaging, prepareIsolatedNewPage } from '../utils/commands.ts';
 import { releaseTag, selectors, storagePath, timeouts } from '../utils/constants.ts';
 
 const releaseRoles = [
@@ -114,7 +114,7 @@ test.describe('RBAC functionality', () => {
   test.describe('has working RBAC limitations for', () => {
     test('device groups', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-${username}` });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: `limited-${username}` });
       await page.getByRole('link', { name: /devices/i }).click({ force: true, timeout: timeouts.tenSeconds });
       await page.locator(`css=${selectors.deviceListItem} div:last-child`).last().click();
       // the created role does have permission to configure devices, so the section should be visible
@@ -123,7 +123,7 @@ test.describe('RBAC functionality', () => {
     });
     test('read-only all releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-ro-releases-${username}` });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: `limited-ro-releases-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be multiple releases present
       await expect(page.getByText('1-2 of 2')).toBeVisible();
@@ -134,7 +134,7 @@ test.describe('RBAC functionality', () => {
     });
     test('read-only tagged releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-ro-${releaseTag}-${username}` });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: `limited-ro-${releaseTag}-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be only one release tagged with the releaseTag
       await expect(page.getByText('1-1 of 1')).toBeVisible();
@@ -143,7 +143,7 @@ test.describe('RBAC functionality', () => {
     });
     test('manage tagged releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-manage-${releaseTag}-${username}` });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: `limited-manage-${releaseTag}-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be only one release tagged with the releaseTag
       await expect(page.getByText('1-1 of 1')).toBeVisible();

--- a/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
+++ b/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
@@ -13,7 +13,7 @@
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
 import { isEnterpriseOrStaging, prepareIsolatedNewPage } from '../utils/commands.ts';
-import { releaseTag, selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { releaseTag, selectors, timeouts } from '../utils/constants.ts';
 
 const releaseRoles = [
   { name: 'test-releases-role', permissions: ['Read'], tag: undefined },
@@ -23,7 +23,6 @@ const releaseRoles = [
 
 test.describe('RBAC functionality', () => {
   test.describe('configuration', () => {
-    test.use({ storageState: storagePath });
     test.beforeEach(async ({ baseUrl, loggedInPage: page }) => {
       await page.goto(`${baseUrl}ui/settings`);
       await page.getByText(/Global settings/i).waitFor();

--- a/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
+++ b/frontend/tests/e2e_tests/integration/08-rbac.spec.ts
@@ -113,7 +113,7 @@ test.describe('RBAC functionality', () => {
   test.describe('has working RBAC limitations for', () => {
     test('device groups', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, password, username: `limited-${username}` });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-${username}` });
       await page.getByRole('link', { name: /devices/i }).click({ force: true, timeout: timeouts.tenSeconds });
       await page.locator(`css=${selectors.deviceListItem} div:last-child`).last().click();
       // the created role does have permission to configure devices, so the section should be visible
@@ -122,7 +122,7 @@ test.describe('RBAC functionality', () => {
     });
     test('read-only all releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, password, username: `limited-ro-releases-${username}` });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-ro-releases-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be multiple releases present
       await expect(page.getByText('1-2 of 2')).toBeVisible();
@@ -133,7 +133,7 @@ test.describe('RBAC functionality', () => {
     });
     test('read-only tagged releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, password, username: `limited-ro-${releaseTag}-${username}` });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-ro-${releaseTag}-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be only one release tagged with the releaseTag
       await expect(page.getByText('1-1 of 1')).toBeVisible();
@@ -142,7 +142,7 @@ test.describe('RBAC functionality', () => {
     });
     test('manage tagged releases', async ({ baseUrl, browser, environment, password, username }) => {
       test.skip(!isEnterpriseOrStaging(environment));
-      const page = await prepareNewPage({ baseUrl, browser, password, username: `limited-manage-${releaseTag}-${username}` });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password, username: `limited-manage-${releaseTag}-${username}` });
       await page.getByRole('link', { name: /releases/i }).click({ force: true, timeout: timeouts.tenSeconds });
       // there should be only one release tagged with the releaseTag
       await expect(page.getByText('1-1 of 1')).toBeVisible();

--- a/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
-import { timeouts } from '../utils/constants.ts';
+import { prepareNewPage } from '../utils/commands.ts';
+import { storagePath, timeouts } from '../utils/constants.ts';
 
 const tenant = {
   name: 'Child Tenant',
@@ -25,6 +26,11 @@ const tenantRole = {
   description: 'Test role for SP tenant'
 };
 test.describe('Tenant Functionality', () => {
+  test.beforeAll(async ({ baseUrl, context, password, spTenantUsername }) => {
+    const storageLocation = `tenant-${storagePath}`;
+    await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
+    await context.storageState({ path: storageLocation });
+  });
   test.beforeEach(async ({ loggedInTenantPage: page, environment }) => {
     test.skip(environment !== 'enterprise', 'not available in OS');
     await page

--- a/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
@@ -12,7 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 import test, { expect } from '../fixtures/fixtures.ts';
-import { timeouts } from '../utils/constants.js';
+import { timeouts } from '../utils/constants.ts';
 
 const tenant = {
   name: 'Child Tenant',

--- a/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
@@ -28,7 +28,7 @@ const tenantRole = {
 test.describe('Tenant Functionality', () => {
   test.beforeAll(async ({ baseUrl, browser, password, spTenantUsername }) => {
     const storageLocation = `tenant-${storagePath}`;
-    const context = await browser.newContext();
+    const context = await browser.newContext({ storageState: storageLocation });
     await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
     await context.storageState({ path: storageLocation });
   });

--- a/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
@@ -11,6 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+import * as fs from 'fs';
+
 import test, { expect } from '../fixtures/fixtures.ts';
 import { prepareNewPage } from '../utils/commands.ts';
 import { storagePath, timeouts } from '../utils/constants.ts';
@@ -28,7 +30,8 @@ const tenantRole = {
 test.describe('Tenant Functionality', () => {
   test.beforeAll(async ({ baseUrl, browser, password, spTenantUsername }) => {
     const storageLocation = `tenant-${storagePath}`;
-    const context = await browser.newContext({ storageState: storageLocation });
+    fs.writeFileSync(storageLocation, JSON.stringify({ cookies: [], origins: [] }));
+    const context = await browser.newContext();
     await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
     await context.storageState({ path: storageLocation });
   });

--- a/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-tenant.spec.ts
@@ -26,8 +26,9 @@ const tenantRole = {
   description: 'Test role for SP tenant'
 };
 test.describe('Tenant Functionality', () => {
-  test.beforeAll(async ({ baseUrl, context, password, spTenantUsername }) => {
+  test.beforeAll(async ({ baseUrl, browser, password, spTenantUsername }) => {
     const storageLocation = `tenant-${storagePath}`;
+    const context = await browser.newContext();
     await prepareNewPage({ baseUrl, context, password, storageLocation, username: spTenantUsername });
     await context.storageState({ path: storageLocation });
   });

--- a/frontend/tests/e2e_tests/integration/10-webhooks.spec.ts
+++ b/frontend/tests/e2e_tests/integration/10-webhooks.spec.ts
@@ -15,13 +15,12 @@ import { Server } from 'net';
 
 import test, { expect } from '../fixtures/fixtures.ts';
 import { startWebhookServer } from '../utils/commands.ts';
-import { selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { selectors, timeouts } from '../utils/constants.ts';
 
 const baseWebhookLocation = 'http://docker.mender.io:9000/webhooks';
 
 test.describe('Webhooks Functionality', () => {
   let server: Server;
-  test.use({ storageState: storagePath });
   test.beforeAll(({ environment }) => {
     test.skip(environment === 'staging');
     server = startWebhookServer();

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -262,7 +262,7 @@ test.describe('Settings', () => {
 
     test('allows changing the password back', async ({ baseUrl, browserName, browser, password, username }) => {
       test.skip(browserName === 'webkit');
-      const page = await prepareNewPage({ baseUrl, browser, password: replacementPassword, username });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password: replacementPassword, username });
       await page.getByRole('button', { name: username }).click();
       await page.getByText(/my profile/i).click();
       await page.getByRole('button', { name: /change password/i }).click();
@@ -293,7 +293,7 @@ test.describe('Settings', () => {
       await loggedInPage.click('text=/user management/i');
       const hasUserAlready = await loggedInPage.getByText(secondaryUser).isVisible();
       test.skip(hasUserAlready, `${secondaryUser} was added in a previous run, but success notification wasn't caught`);
-      const page = await prepareNewPage({ baseUrl, browser, username: secondaryUser, password });
+      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, username: secondaryUser, password });
       await page.goto(`${baseUrl}ui/settings/my-account`);
       await page
         .getByText(/User ID/i)

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -185,6 +185,7 @@ test.describe('Settings', () => {
       test.skip(hasUserAlready, `${secondaryUser} was added in a previous run, but success notification wasn't caught`);
       const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: secondaryUser });
       await page.goto(`${baseUrl}ui/settings/my-account`);
+      await page.screenshot({ path: './test-results/secondary-account.png' });
       await page
         .getByText(/User ID/i)
         .locator('..')

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -16,23 +16,11 @@ import jsQR from 'jsqr';
 import { PNG } from 'pngjs';
 
 import test, { expect } from '../fixtures/fixtures.ts';
-import {
-  baseUrlToDomain,
-  generateOtp,
-  isLoggedIn,
-  login,
-  prepareCookies,
-  prepareIsolatedNewPage,
-  prepareNewPage,
-  processLoginForm,
-  startClient,
-  tenantTokenRetrieval
-} from '../utils/commands.ts';
-import { selectors, storagePath, timeouts } from '../utils/constants.ts';
+import { generateOtp, isLoggedIn, login, prepareIsolatedNewPage, processLoginForm, startClient, tenantTokenRetrieval } from '../utils/commands.ts';
+import { selectors, timeouts } from '../utils/constants.ts';
 
 test.describe('Settings', () => {
   test.describe('access token feature', () => {
-    test.use({ storageState: storagePath });
     test('allows access to access tokens', async ({ baseUrl, loggedInPage: page }) => {
       await page.goto(`${baseUrl}ui/settings`);
       const tokenGenerationButton = await page.getByRole('button', { name: /Generate a token/i });
@@ -87,7 +75,6 @@ test.describe('Settings', () => {
     });
   });
   test.describe('account upgrades', () => {
-    test.use({ storageState: storagePath });
     test('allows upgrading to Professional', async ({ environment, loggedInPage: page }) => {
       test.skip(environment !== 'staging');
       await page.waitForTimeout(timeouts.default);
@@ -127,7 +114,6 @@ test.describe('Settings', () => {
   });
 
   test.describe('2FA setup', () => {
-    test.use({ storageState: storagePath });
     test('supports regular 2fa setup', async ({ baseUrl, environment, loggedInPage: page }) => {
       test.skip(environment !== 'staging');
       let tfaSecret;
@@ -190,7 +176,6 @@ test.describe('Settings', () => {
   });
 
   test.describe('Basic setting features', () => {
-    test.use({ storageState: storagePath });
     const replacementPassword = 'mysecretpassword!456';
 
     test('allows access to user management', async ({ baseUrl, loggedInPage: page }) => {
@@ -230,13 +215,9 @@ test.describe('Settings', () => {
       await page.click(`button:has-text('Save')`);
       await expect(page.getByText('Gaustadalleen 12')).toBeVisible();
     });
-    test('allows changing the password', async ({ baseUrl, browserName, context, environment, username, password }) => {
+    test('allows changing the password', async ({ baseUrl, browserName, browser, environment, username, password }) => {
       test.skip(browserName === 'webkit');
-      const domain = baseUrlToDomain(baseUrl);
-      context = await prepareCookies(context, domain, '');
-      const page = await context.newPage();
-      await page.goto(`${baseUrl}ui/`);
-      await processLoginForm({ username, password, page, environment });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username });
       await page.getByRole('button', { name: username }).click();
       await page.getByText(/my profile/i).click();
       await page.getByRole('button', { name: /change password/i }).click();
@@ -289,7 +270,6 @@ test.describe('Settings', () => {
   });
 
   test.describe('Multi tenant access', () => {
-    test.use({ storageState: storagePath });
     const secondaryUser = 'demo-secondary@example.com';
     test('allows adding users to tenants', async ({ baseUrl, browser, browserName, environment, loggedInPage, password }) => {
       test.skip('enterprise' !== environment || browserName !== 'chromium');

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -127,6 +127,7 @@ test.describe('Settings', () => {
   });
 
   test.describe('2FA setup', () => {
+    test.use({ storageState: storagePath });
     test('supports regular 2fa setup', async ({ baseUrl, environment, loggedInPage: page }) => {
       test.skip(environment !== 'staging');
       let tfaSecret;
@@ -189,6 +190,7 @@ test.describe('Settings', () => {
   });
 
   test.describe('Basic setting features', () => {
+    test.use({ storageState: storagePath });
     const replacementPassword = 'mysecretpassword!456';
 
     test('allows access to user management', async ({ baseUrl, loggedInPage: page }) => {
@@ -287,6 +289,7 @@ test.describe('Settings', () => {
   });
 
   test.describe('Multi tenant access', () => {
+    test.use({ storageState: storagePath });
     const secondaryUser = 'demo-secondary@example.com';
     test('allows adding users to tenants', async ({ baseUrl, browser, browserName, environment, loggedInPage, password }) => {
       test.skip('enterprise' !== environment || browserName !== 'chromium');

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -263,9 +263,9 @@ test.describe('Settings', () => {
       await expect(page.getByRole('button', { name: /log in/i })).toBeVisible();
     });
 
-    test('allows changing the password back', async ({ baseUrl, browserName, browser, password, username }) => {
+    test('allows changing the password back', async ({ baseUrl, browserName, browser, environment, password, username }) => {
       test.skip(browserName === 'webkit');
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, password: replacementPassword, username });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password: replacementPassword, username });
       await page.getByRole('button', { name: username }).click();
       await page.getByText(/my profile/i).click();
       await page.getByRole('button', { name: /change password/i }).click();

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -22,6 +22,7 @@ import {
   isLoggedIn,
   login,
   prepareCookies,
+  prepareIsolatedNewPage,
   prepareNewPage,
   processLoginForm,
   startClient,
@@ -293,7 +294,7 @@ test.describe('Settings', () => {
       await loggedInPage.click('text=/user management/i');
       const hasUserAlready = await loggedInPage.getByText(secondaryUser).isVisible();
       test.skip(hasUserAlready, `${secondaryUser} was added in a previous run, but success notification wasn't caught`);
-      const page = await prepareNewPage({ baseUrl, browser, hasSessionCaching: false, username: secondaryUser, password });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: secondaryUser });
       await page.goto(`${baseUrl}ui/settings/my-account`);
       await page
         .getByText(/User ID/i)
@@ -323,12 +324,7 @@ test.describe('Settings', () => {
     test('allows switching tenants', async ({ baseUrl, browser, browserName, environment, loggedInPage, password }) => {
       test.skip('enterprise' !== environment || browserName !== 'chromium');
       // here we can't use prepareNewPage as it sets the initial JWT to be used on every page init
-      const domain = baseUrlToDomain(baseUrl);
-      let newContext = await browser.newContext();
-      newContext = await prepareCookies(newContext, domain, '');
-      const page = await newContext.newPage();
-      await page.goto(`${baseUrl}ui/`);
-      await processLoginForm({ username: secondaryUser, password, page, environment });
+      const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: secondaryUser });
       await page.getByRole('button', { name: secondaryUser }).click();
       await expect(page.getByRole('menuitem', { name: /secondary/i })).toBeVisible();
       await page.getByText(/switch organization/i).click({ force: true });

--- a/frontend/tests/e2e_tests/integration/99-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/99-settings.spec.ts
@@ -184,6 +184,7 @@ test.describe('Settings', () => {
       const hasUserAlready = await loggedInPage.getByText(secondaryUser).isVisible();
       test.skip(hasUserAlready, `${secondaryUser} was added in a previous run, but success notification wasn't caught`);
       const page = await prepareIsolatedNewPage({ baseUrl, browser, environment, password, username: secondaryUser });
+      await page.screenshot({ path: './test-results/secondary-account-login.png' });
       await page.goto(`${baseUrl}ui/settings/my-account`);
       await page.screenshot({ path: './test-results/secondary-account.png' });
       await page

--- a/frontend/tests/e2e_tests/utils/commands.ts
+++ b/frontend/tests/e2e_tests/utils/commands.ts
@@ -83,6 +83,28 @@ export const prepareCookies = async (context: BrowserContext, domain: string, us
   return context;
 };
 
+export const prepareIsolatedNewPage = async ({
+  baseUrl,
+  browser,
+  environment,
+  password,
+  username
+}: {
+  baseUrl: string;
+  browser?: Browser;
+  environment: TestEnvironment;
+  password: string;
+  username: string;
+}) => {
+  const domain = baseUrlToDomain(baseUrl);
+  let newContext = await browser.newContext();
+  newContext = await prepareCookies(newContext, domain, '');
+  const page = await newContext.newPage();
+  await page.goto(`${baseUrl}ui/`);
+  await processLoginForm({ username, password, page, environment });
+  return page;
+};
+
 export const prepareNewPage = async ({
   baseUrl,
   browser,

--- a/frontend/tests/e2e_tests/utils/commands.ts
+++ b/frontend/tests/e2e_tests/utils/commands.ts
@@ -104,6 +104,7 @@ export const prepareIsolatedNewPage = async ({
   const domain = baseUrlToDomain(baseUrl);
   let newContext = await browser.newContext();
   newContext = await prepareCookies(newContext, domain, '');
+  await newContext.addInitScript(() => window.localStorage.setItem(`onboardingComplete`, 'true'));
   const page = await newContext.newPage();
   await page.goto(`${baseUrl}ui/`);
   await processLoginForm({ username, password, page, environment });

--- a/frontend/tests/e2e_tests/utils/commands.ts
+++ b/frontend/tests/e2e_tests/utils/commands.ts
@@ -130,7 +130,7 @@ export const prepareNewPage = async ({
 }) => {
   let context = passedContext;
   if (!context) {
-    context = await browser.newContext();
+    context = await browser.newContext({ storageState: storageLocation });
   }
   if (context.browser()?.browserType().name() === 'chromium') {
     await context.grantPermissions(['clipboard-read'], { origin: baseUrl });


### PR DESCRIPTION
WIP for now:
tried reusing session data in multiple test runs, but we depend on non-authenticated + SP session data, which OTOH breaks test storage definitions + makes it tricky to rely on the test results (e.g. screenshots/ failure info bleeds into other tests based on session storage info + we lost video recordings for most tests due to https://github.com/microsoft/playwright/issues/14813)