### PR TITLE
chore: Upgrade python imaging library (PIL) to 11.2.1

### DIFF
--- a/backend/tests/requirements-integration.txt
+++ b/backend/tests/requirements-integration.txt
@@ -12,7 +12,7 @@ idna==3.10
 iniconfig==2.1.0
 kubernetes==32.0.1
 packaging==24.2
-Pillow==11.2.0
+Pillow==11.2.1
 pluggy==1.5.0
 py==1.11.0
 pycparser==2.22


### PR DESCRIPTION
The release 11.2.0 was withdrawn from the PyPi index.