### PR TITLE
ci: retry on docker not running.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,9 @@ default:
   tags:
     - hetzner-amd-beefy
 
+.requires-docker: &requires-docker
+  - echo
+
 .dind-login: &dind-login
   - mkdir -p $HOME/.docker && echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
   - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY


### PR DESCRIPTION
Everyday we have a failure of this sort:
dial tcp: lookup docker on 185.12.64.2:53: no such host https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/9724540362

Let's retry job on simple docker not running.
Tested with mender-dist-packages.

Changelog: Title
Ticket: QA-988