### PR TITLE
ci: remove old check-commits tool

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,6 @@ variables:
 include:
   - project: "Northern.tech/Mender/mendertesting"
     file:
-      - ".gitlab-ci-check-commits.yml"
       - ".gitlab-ci-github-status-updates.yml"
   - local: "/frontend/pipeline.yml"
   - local: "/.gitlab/merge-enterprise.yml"


### PR DESCRIPTION
And retain commitlint job only

Ticket: None
Changelog: None

Signed-off-by: Roberto Giovanardi <roberto.giovanardi@northern.tech>
(cherry picked from commit 79650a5ecee60f4cae3d663b606df976262a7642)