### PR TITLE
ci: retry on docker not present in test:prep

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,6 +359,7 @@ test:integration:
 
 test:prep:
   stage: test
+  extends: .build:base
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker
   rules:
     - if: $CI_COMMIT_BRANCH == "main"


### PR DESCRIPTION
Changelog: None
Ticket: QA-988