### PR TITLE
ci: Fix broken merge snippet

### DIFF
--- a/.gitlab/merge-enterprise.yml
+++ b/.gitlab/merge-enterprise.yml
@@ -41,13 +41,14 @@ merge-to-enterprise:
       This is an automated PR by @mender-test-bot. To complete the PR please follow the following steps:
       1. Merge the PR into ${CI_COMMIT_BRANCH}:
          \`\`\`bash
-         git fetch git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} ${CI_COMMIT_BRANCH} && git checkout FETCH_HEAD
-         git merge --no-ff git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} refs/heads/${PR_BRANCH}
+         git pull -f git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} ${CI_COMMIT_BRANCH} && \
+            git checkout ${CI_COMMIT_BRANCH} && \
+            git pull --no -ff git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} refs/heads/${PR_BRANCH}:${CI_COMMIT_BRANCH}
          \`\`\`
       2. Resolve any conflicts (if any).
       3. Push the changes to this branch.
          \`\`\`bash
-         git push git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} HEAD:refs/heads/${PR_BRANCH}
+         git push git@github.com:${GITHUB_REPOSITORY_ENTERPRISE} ${CI_COMMIT_BRANCH}:refs/heads/${PR_BRANCH}
          \`\`\`
       4. Remove the \`[NOCI]\` prefix in the PR title to start the pipeline
       EOF


### PR DESCRIPTION
The new snippets creates/overwrites the branch refs when merging to enterprise.