### PR TITLE
ci: switch to podman runner

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -27,8 +27,7 @@ test:frontend:lint:
 test:frontend:license-headers:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/denoland/deno:debian-2.0.2
   tags:
-    # can't use safe sysbox-runc here - see https://northerntech.atlassian.net/browse/QA-866
-    - mender-qa-worker-generic-light
+    - hetzner-podman
   stage: test
   rules:
     - changes:


### PR DESCRIPTION
To prevent build issues with Ubuntu 24.04 and Debian 12, while keeping safety on Hetzner runners

Ticket: QA-866