### PR TITLE
Global resource groups to avoid running heavy jobs in parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,6 +240,9 @@ test:backend:unit:
       when: on_success
   tags:
     - hetzner-amd-beefy
+  # heavy_duty: global resource group for all jobs that require most of the
+  # resources of the runner - QA-983
+  resource_group: heavy_duty
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:6.0
       alias: mongo
@@ -261,6 +264,9 @@ test:backend:unit:
 test:backend:acceptance:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   stage: test
+  # heavy_duty: global resource group for all jobs that require most of the
+  # resources of the runner - QA-983
+  resource_group: heavy_duty
   rules:
     - changes:
         paths: ["backend/**/*", ".gitlab-ci.yml"]
@@ -297,6 +303,9 @@ test:backend:acceptance:
 test:backend:integration:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   stage: test
+  # heavy_duty: global resource group for all jobs that require most of the
+  # resources of the runner - QA-983
+  resource_group: heavy_duty
   extends: .build:base
   rules:
     - changes:

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -67,6 +67,9 @@ test:frontend:licenses:
 test:frontend:unit:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
+  # heavy_duty: global resource group for all jobs that require most of the
+  # resources of the runner - QA-983
+  resource_group: heavy_duty
   rules:
     - changes:
         paths: ['frontend/**/*']


### PR DESCRIPTION
Ticket: QA-983

To prevent load-biased results on tests. This way the jobs that are
    using the full load of the runner host, should go in a queue and run the
    job one at a time. This should help for reliable test results.