### PR TITLE
fix: Ensure email is always encoded in lowercase when stored

### DIFF
--- a/backend/services/useradm/store/mongo/bson.go
+++ b/backend/services/useradm/store/mongo/bson.go
@@ -1,0 +1,32 @@
+package mongo
+
+import (
+	"reflect"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson/bsoncodec"
+	"go.mongodb.org/mongo-driver/bson/bsonrw"
+
+	"github.com/mendersoftware/mender-server/pkg/mongo/codec"
+	"github.com/mendersoftware/mender-server/services/useradm/model"
+)
+
+func newRegistry() *bsoncodec.Registry {
+	registry := codec.NewRegistry()
+	registry.RegisterTypeEncoder(tEmail, bsoncodec.ValueEncoderFunc(encodeEmail))
+	return registry
+}
+
+var tEmail = reflect.TypeOf(model.Email(""))
+
+func encodeEmail(ec bsoncodec.EncodeContext, w bsonrw.ValueWriter, val reflect.Value) error {
+	if !val.IsValid() || val.Type() != tEmail {
+		return bsoncodec.ValueEncoderError{
+			Name:     "EmailCodec",
+			Types:    []reflect.Type{tEmail},
+			Received: val,
+		}
+	}
+	value := val.Interface().(model.Email)
+	return w.WriteString(strings.ToLower(string(value)))
+}

--- a/backend/services/useradm/store/mongo/datastore_mongo.go
+++ b/backend/services/useradm/store/mongo/datastore_mongo.go
@@ -26,7 +26,6 @@ import (
 	mopts "go.mongodb.org/mongo-driver/mongo/options"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/mendersoftware/mender-server/pkg/mongo/codec"
 	"github.com/mendersoftware/mender-server/pkg/mongo/oid"
 	mstore "github.com/mendersoftware/mender-server/pkg/store/v2"
 
@@ -112,9 +111,8 @@ func NewDataStoreMongoWithClient(client *mongo.Client) (*DataStoreMongo, error) 
 func NewDataStoreMongo(config DataStoreMongoConfig) (*DataStoreMongo, error) {
 	var err error
 	var mongoURL string
-
 	clientOptions := mopts.Client().
-		SetRegistry(codec.NewRegistry())
+		SetRegistry(newRegistry())
 	if !strings.Contains(config.ConnectionString, "://") {
 		mongoURL = "mongodb://" + config.ConnectionString
 	} else {

--- a/backend/services/useradm/store/mongo/datastore_mongo_test.go
+++ b/backend/services/useradm/store/mongo/datastore_mongo_test.go
@@ -390,6 +390,14 @@ func TestMongoGetUserByEmail(t *testing.T) {
 				Password: "passwordhash12345",
 			},
 		},
+		"ok - case case insensitive": {
+			inEmail: "fOO@bAr.cOm",
+			outUser: &model.User{
+				ID:       "1",
+				Email:    "foo@bar.com",
+				Password: "passwordhash12345",
+			},
+		},
 		"ok - found 2": {
 			inEmail: "bar@bar.com",
 			outUser: &model.User{

--- a/backend/services/useradm/store/mongo/main_test.go
+++ b/backend/services/useradm/store/mongo/main_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		status = mtesting.WithDB(func(dbtest mtesting.TestDBRunner) int {
 			db = dbtest
 			return m.Run()
-		}, nil)
+		}, newRegistry())
 	} else {
 		status = m.Run()
 	}


### PR DESCRIPTION
Added a bson codec for model.Email that will ensure that emails are always encoded in lowercase in the database to ensure case insensitive queries.

Changelog: Title
Ticket: MEN-8328