### PR TITLE
Revert heavy duty resource_group by wait for build to finish before running test:frontend:unit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,9 +240,6 @@ test:backend:unit:
       when: on_success
   tags:
     - hetzner-amd-beefy
-  # heavy_duty: global resource group for all jobs that require most of the
-  # resources of the runner - QA-983
-  resource_group: heavy_duty
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:6.0
       alias: mongo
@@ -264,9 +261,6 @@ test:backend:unit:
 test:backend:acceptance:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   stage: test
-  # heavy_duty: global resource group for all jobs that require most of the
-  # resources of the runner - QA-983
-  resource_group: heavy_duty
   rules:
     - changes:
         paths: ["backend/**/*", ".gitlab-ci.yml"]
@@ -303,9 +297,6 @@ test:backend:acceptance:
 test:backend:integration:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   stage: test
-  # heavy_duty: global resource group for all jobs that require most of the
-  # resources of the runner - QA-983
-  resource_group: heavy_duty
   extends: .build:base
   rules:
     - changes:

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -67,9 +67,6 @@ test:frontend:licenses:
 test:frontend:unit:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
-  # heavy_duty: global resource group for all jobs that require most of the
-  # resources of the runner - QA-983
-  resource_group: heavy_duty
   rules:
     - changes:
         paths: ['frontend/**/*']

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -74,7 +74,6 @@ test:frontend:unit:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  needs: []
   timeout: 5 minutes
   script:
     - cd frontend


### PR DESCRIPTION
The resource_group setting was a complete failure: doesn't resolve the job issue and adds time penalty.
Removing `needs: []` to the test:frontend:unit to add job isolation between build and test, mostly for debugging and observation