### PR TITLE
ci: retry on lookup docker fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,7 @@ default:
   retry:
     max: 2
     exit_codes:
+      - 2
       - 137
       - 192
 


### PR DESCRIPTION
Retry when exit code is 2: dial tcp: lookup docker on *:53: no such host

Ticket: QA-1018