### PR TITLE
ci: enforce e2e isolation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -385,9 +385,11 @@ test:prep:
   only:
     - main # can't use rules with delays: https://gitlab.com/gitlab-org/gitlab/-/issues/424203
   when: delayed
+  resource_group: test_staging_e2e
   needs:
     - job: test:prep
       artifacts: true
+    - job: mender-helm-version-bump:staging
   variables:
     CI: 1
     DEVICE_TYPE: qemux86-64
@@ -414,28 +416,25 @@ test:prep:
 
 test:staging-deployment:chrome:
   extends: .template:test:staging-deployment
-  resource_group: test-staging-deployment-chrome
   script:
     - npx playwright install chromium
     - npm run test -- --project=chromium
-  start_in: 15 minutes
+  start_in: 3 minutes
 
 test:staging-deployment:firefox:
   extends: .template:test:staging-deployment
-  resource_group: test-staging-deployment-firefox
   script:
     - npx playwright install firefox
     - npm run test -- --project=firefox
-  start_in: 40 minutes
+  start_in: 10 minutes
 
 test:staging-deployment:webkit:
   extends: .template:test:staging-deployment
-  resource_group: test-staging-deployment-webkit
   allow_failure: true
   script:
     - npx playwright install webkit
     - npm run test -- --project=webkit
-  start_in: 30 minutes
+  start_in: 15 minutes
 
 publish:backend:coverage:
   stage: publish


### PR DESCRIPTION
Don't run more than one e2e job on staging at a time globally

Ticket: None