### PR TITLE
Further pipeline optimizations

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -270,7 +270,7 @@ test:backend:acceptance:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   tags:
-    - hetzner-amd-beefy
+    - hetzner-amd-ax42
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,6 +260,7 @@ test:backend:unit:
 
 test:backend:acceptance:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  extends: .build:base
   stage: test
   rules:
     - changes:

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -75,7 +75,7 @@ test:frontend:unit:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   needs: []
-  timeout: 5 minutes
+  timeout: 10 minutes
   script:
     - cd frontend
     - npm ci
@@ -91,7 +91,7 @@ test:frontend:unit:
       junit: frontend/junit.xml
     when: always
   tags:
-    - hetzner-podman-ax42
+    - k8s
 
 test:frontend:docs-links:
   stage: test

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -168,6 +168,7 @@ build:frontend:docker:
 .template:test:frontend:acceptance:
   stage: test
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  extends: .build:base
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success


### PR DESCRIPTION
1. add docker retry to those jobs that were missing
2. move test:frontend:unit to k8s runner to preserve isolation between with this jobs on other pipelines
3. move test:backend:acceptance to AX42 runner to spread the load