### PR TITLE
test(gui): silenced more warnings about non-seriables

### DIFF
--- a/frontend/src/js/components/auditlogs/Auditlogs.test.tsx
+++ b/frontend/src/js/components/auditlogs/Auditlogs.test.tsx
@@ -84,7 +84,10 @@ describe('Auditlogs Component', () => {
     await user.type(input, 'art');
     await selectMaterialUiSelectOption(input, /artifact/i, user);
     await user.click(screen.getByText(/clear filter/i));
+    const anchorClickHandler = HTMLAnchorElement.prototype.click; // we need to mock the click handler to avoid errors when the download is created artificially
+    HTMLAnchorElement.prototype.click = vi.fn(); // this should only affect the final download helper function as the trigger is a `button` element and no `a`
     await user.click(screen.getByRole('button', { name: /Download results as csv/i }));
+    HTMLAnchorElement.prototype.click = anchorClickHandler;
     await user.click(screen.getByText(/open_terminal/i));
   });
 

--- a/frontend/src/js/store/store.ts
+++ b/frontend/src/js/store/store.ts
@@ -121,7 +121,7 @@ export const getConfiguredStore = (options = {}) => {
         },
         serializableCheck: {
           ignoredActions: [organizationActions.receiveExternalDeviceIntegrations.name, setSnackbar.name, uploadProgress.name],
-          ignoredActionPaths: ['uploads', 'snackbar', /payload\..*$/],
+          ignoredActionPaths: ['uploads', 'snackbar', /payload\..*$/, 'meta.arg.file', 'meta.arg.integration.configHint'],
           ignoredPaths: ['app.uploadsById', 'app.snackbar', 'organization.externalDeviceIntegrations']
         }
       }).concat(rejectionLoggerMiddleware)

--- a/frontend/src/js/store/store.ts
+++ b/frontend/src/js/store/store.ts
@@ -120,9 +120,9 @@ export const getConfiguredStore = (options = {}) => {
           ignoredPaths: ['app.uploadsById']
         },
         serializableCheck: {
-          ignoredActions: [organizationActions.receiveExternalDeviceIntegrations.name, setSnackbar.name, uploadProgress.name],
-          ignoredActionPaths: ['uploads', 'snackbar', /payload\..*$/, 'meta.arg.file', 'meta.arg.integration.configHint'],
-          ignoredPaths: ['app.uploadsById', 'app.snackbar', 'organization.externalDeviceIntegrations']
+          ignoredActions: [organizationActions.receiveExternalDeviceIntegrations.name, uploadProgress.name],
+          ignoredActionPaths: ['uploads', /payload\..*$/, 'meta.arg.file', 'meta.arg.integration.configHint'],
+          ignoredPaths: ['app.uploadsById', 'organization.externalDeviceIntegrations']
         }
       }).concat(rejectionLoggerMiddleware)
   });


### PR DESCRIPTION
- referencing uploads where we need file references until the upload is done + device twin integration references that come with an explanatory info component