### PR TITLE
revert: Gin utility for applying middleware to routes

### DIFF
--- a/backend/pkg/rest.utils/utils.go
+++ b/backend/pkg/rest.utils/utils.go
@@ -29,9 +29,3 @@ func RenderError(c *gin.Context, code int, err error) {
 	}
 	c.JSON(code, err)
 }
-
-func ApplyMiddlewareToRoutes(middleware gin.HandlerFunc, routes ...gin.IRoutes) {
-	for _, route := range routes {
-		route.Use(middleware)
-	}
-}


### PR DESCRIPTION
The func does not implement what it is intended to do and instead applies the middleware to all routes in the group.