### PR TITLE
ci: move test:backend:integration to ax42

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -312,7 +312,7 @@ test:backend:integration:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   tags:
-    - hetzner-amd-beefy
+    - hetzner-amd-ax42
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker


### PR DESCRIPTION
To make it more stable

Ticket: QA-1029