### PR TITLE
ci: avoid saas jobs on maintenance branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -749,6 +749,8 @@ release:mender-docs-changelog:saas:
     - if: '$CI_PROJECT_NAME == "mender-server"'
       when: never
     - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+(?:-saas\.*\d*)?$/'
+    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
+      when: never
   before_script:
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
@@ -772,6 +774,8 @@ release:mender-docs-changelog:saas:
       when: on_success
     - if: $CI_COMMIT_TAG =~ "/^v\d+\.\d+\.\d+(?:-rc(?:[\.\d]*))*$/"
       when: on_success
+    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
+      when: never
   allow_failure: true
   tags:
     - hetzner-amd-beefy


### PR DESCRIPTION
as an alternative to https://github.com/mendersoftware/mender-server/pull/432 - as that stops the CI pipeline from running on cherry-picks (e.g. https://github.com/mendersoftware/mender-server/pull/660 => https://gitlab.com/Northern.tech/Mender/mender-server/-/ci/editor?branch_name=5c70d0e568f1c7b7ae8dcdc457abfa646ac1a067)