### PR TITLE
fix(gui): restored error handling on user edits

### DIFF
--- a/frontend/src/js/store/usersSlice/thunks.ts
+++ b/frontend/src/js/store/usersSlice/thunks.ts
@@ -277,12 +277,14 @@ export const removeUser = createAsyncThunk(`${sliceName}/removeUser`, (userId, {
 );
 
 export const editUser = createAsyncThunk(`${sliceName}/editUser`, ({ id, ...userData }, { dispatch, getState }) =>
-  GeneralApi.put(`${useradmApiUrl}/users/${id}`, userData).then(() =>
-    Promise.all([
-      dispatch(actions.updatedUser({ ...userData, id: id === OWN_USER_ID ? getCurrentUser(getState()).id : id })),
-      dispatch(setSnackbar(userActions.edit.successMessage))
-    ])
-  )
+  GeneralApi.put(`${useradmApiUrl}/users/${id}`, userData)
+    .then(() =>
+      Promise.all([
+        dispatch(actions.updatedUser({ ...userData, id: id === OWN_USER_ID ? getCurrentUser(getState()).id : id })),
+        dispatch(setSnackbar(userActions.edit.successMessage))
+      ])
+    )
+    .catch(err => userActionErrorHandler(err, 'edit', dispatch))
 );
 
 export const addUserToCurrentTenant = createAsyncThunk(`${sliceName}/addUserToTenant`, (userId, { dispatch, getState }) => {


### PR DESCRIPTION
This got lost in the prior repo by accident in [5888d3e](https://github.com/mendersoftware/gui/commit/5888d3e3ee47b764b256e89da9419f903936e4f3#diff-ad63de55e82266c6c2e5254193475883281b44f2a3a2ac2c0b0bab847ab43b5cL215-R205).