### PR TITLE
ci: retry on exit code 2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,6 +130,7 @@ default:
   retry:
     max: 2
     exit_codes:
+      - 2
       - 137
       - 192
 


### PR DESCRIPTION
This exit code usually on docker build failure because of external sources temporary unavailable or other conditions

Ticket: None