### PR TITLE
perf(accesslogs): Put routing path and parameters in separate fields

### DIFF
--- a/backend/pkg/accesslog/middleware_gin_test.go
+++ b/backend/pkg/accesslog/middleware_gin_test.go
@@ -159,3 +159,13 @@ func TestMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatPathParams(t *testing.T) {
+	params := []gin.Param{
+		{Key: "foo", Value: "bar"},
+		{Key: "bar", Value: "baz"},
+	}
+	actual := formatPathParams(params)
+	assert.Equal(t, "foo=bar bar=baz", actual)
+	assert.Empty(t, formatPathParams(gin.Params{}))
+}


### PR DESCRIPTION
By separating the two, it is much less complex to index paths in the log parser.