### PR TITLE
Fix `pkg` unit tests not run in CI

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -40,7 +40,7 @@ $(BUILD_TARGETS):
 
 
 .PHONY: test
-test: $(TEST_TARGETS) pkg-test test-integration
+test: test-unit test-integration
 
 .PHONY: $(TEST_TARGETS)
 $(TEST_TARGETS):
@@ -48,10 +48,10 @@ $(TEST_TARGETS):
 
 .PHONY: pkg-test
 pkg-test:
-	@$(MAKE) -C pkg/
+	@$(MAKE) -C pkg/ test
 
 .PHONY: test-unit
-test-unit: $(TEST_UNIT_TARGETS)
+test-unit: pkg-test $(TEST_UNIT_TARGETS)
 
 .PHONY: $(TEST_UNIT_TARGETS)
 $(TEST_UNIT_TARGETS):

--- a/backend/pkg/Makefile
+++ b/backend/pkg/Makefile
@@ -2,10 +2,11 @@ LDFLAGS ?= "-s -w"
 BUILDFLAGS ?= -trimpath -ldflags $(LDFLAGS)
 TESTFLAGS ?=
 
+.PHONY: test
+test:
+	go test $(BUILDFLAGS) $(TESTFLAGS) ./...
+
 .PHONY: generate
 generate:
 	go generate ./...
 
-.PHONY: test
-test:
-	go test $(BUILDFLAGS) $(TESTFLAGS) ./...


### PR DESCRIPTION
Since the default target changed to `generate`, the unit tests has not been running in CI.
Also added `pkg` unit tests to the root `test-unit` Makefile target.