### PR TITLE
revert: "ci: Debug mongodb in backend unit tests"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -257,11 +257,9 @@ test:backend:unit:
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:6.0
       alias: mongo
-      command: [--quiet]
   variables:
     TEST_MONGO_URL: "mongodb://mongo"
     WORKFLOWS_MONGO_URL: "mongodb://mongo"
-    CI_DEBUG_SERVICES: "true" # FIXME: Temporary enable service logs
   before_script:
     - mkdir -p $GOCOVERDIR
   script:


### PR DESCRIPTION
Enabling logging just overflows the log buffer.

See pipeline: https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/10185660413

This reverts commit 6d164c4c70d1fff7d28e88a50390f8afb676c814.