### PR TITLE
docs(deviceauth): Rename operation id for removing device authentication

### DIFF
--- a/backend/services/deviceauth/docs/management_api.yml
+++ b/backend/services/deviceauth/docs/management_api.yml
@@ -278,10 +278,10 @@ paths:
 
   /devices/{id}/auth/{aid}:
     delete:
-      operationId: Reject authentication
+      operationId: Remove authentication
       security:
         - ManagementJWT: []
-      summary: Remove the device authentication set
+      summary: Remove (dismiss) the device authentication set
       description: |
         Removes the device authentication set.
         Removing 'accepted' authentication set is equivalent

--- a/backend/services/deviceauth/tests/tests/client.py
+++ b/backend/services/deviceauth/tests/tests/client.py
@@ -182,7 +182,7 @@ class ManagementClient(SwaggerApiClient):
         )
 
     def delete_authset(self, devid, aid, **kwargs):
-        return self.client.reject_authentication(id=devid, aid=aid)
+        return self.client.remove_authentication(id=devid, aid=aid)
 
     def count_devices(self, status=None, **kwargs):
         count = self.client.count_devices(status=status, **kwargs)


### PR DESCRIPTION
"Reject" is in the UI associated with updating the authentication status where as "dismiss" is used for removing authentication.