### PR TITLE
test(deviceconnect): Increase test timeout for TestSetSessionRecording

### DIFF
--- a/backend/services/deviceconnect/store/mongo/datastore_mongo_test.go
+++ b/backend/services/deviceconnect/store/mongo/datastore_mongo_test.go
@@ -646,7 +646,7 @@ func TestSetSessionRecording(t *testing.T) {
 				recordingExpire: tc.Expiration,
 			}
 			defer ds.DropDatabase()
-			ctx, cancel := context.WithTimeout(tc.Ctx, time.Minute)
+			ctx, cancel := context.WithTimeout(tc.Ctx, time.Minute*5)
 			defer cancel()
 
 			database := db.Client().Database(DbName)


### PR DESCRIPTION
The mongodb TTL expire routine does not always seem to be running within the one minute deadline for this test.