### PR TITLE
ME-542 - device reports per widget only

### DIFF
--- a/frontend/src/js/components/App.test.tsx
+++ b/frontend/src/js/components/App.test.tsx
@@ -58,8 +58,6 @@ describe('App Component', () => {
   it(
     'renders correctly',
     async () => {
-      const DeviceActions = await import('@northern.tech/store/devicesSlice/thunks');
-      const reportsSpy = vi.spyOn(DeviceActions, 'getReportsDataWithoutBackendSupport');
       vi.spyOn(window.mender_environment, 'integrationVersion', 'get').mockImplementation(() => 'next');
       // vi.replaceProperty(window.mender_environment, 'integrationVersion', 'next');
 
@@ -68,7 +66,6 @@ describe('App Component', () => {
         preloadedState: { ...preloadedState, users: { ...preloadedState.users, currentSession: getSessionInfo() } }
       });
       await waitFor(() => expect(screen.queryByText(/see all deployments/i)).toBeInTheDocument(), { timeout: TIMEOUTS.threeSeconds });
-      await waitFor(() => expect(reportsSpy).toHaveBeenCalled(), { timeout: TIMEOUTS.threeSeconds });
       await waitFor(() => rerender(ui));
       const view = asFragment().querySelector('#app');
       await waitFor(() => expect(document.querySelector('.loaderContainer')).not.toBeInTheDocument());
@@ -85,8 +82,6 @@ describe('App Component', () => {
   it(
     'works as intended',
     async () => {
-      const DeviceActions = await import('@northern.tech/store/devicesSlice/thunks');
-      const reportsSpy = vi.spyOn(DeviceActions, 'getReportsDataWithoutBackendSupport');
       const currentSession = { expiresAt: new Date().toISOString(), token };
       window.localStorage.getItem.mockImplementation(name => (name === 'JWT' ? JSON.stringify(currentSession) : undefined));
 
@@ -94,7 +89,6 @@ describe('App Component', () => {
       const { rerender } = render(ui, {
         preloadedState: { ...preloadedState, users: { ...preloadedState.users, currentSession, currentUser: 'a1' } }
       });
-      await waitFor(() => expect(reportsSpy).toHaveBeenCalled(), { timeout: TIMEOUTS.threeSeconds });
       await act(async () => {
         vi.advanceTimersByTime(maxSessionAge * 1000 + 500);
         vi.runAllTicks();
@@ -108,8 +102,6 @@ describe('App Component', () => {
         vi.runOnlyPendingTimers();
         vi.runAllTicks();
       });
-
-      reportsSpy.mockClear();
       window.localStorage.getItem.mockReset();
     },
     20 * TIMEOUTS.oneSecond
@@ -118,8 +110,6 @@ describe('App Component', () => {
   it(
     'is embedded in working providers',
     async () => {
-      const DeviceActions = await import('@northern.tech/store/devicesSlice/thunks');
-      const reportsSpy = vi.spyOn(DeviceActions, 'getReportsDataWithoutBackendSupport');
       window.localStorage.getItem.mockImplementation(name => (name === 'JWT' ? JSON.stringify({ token }) : undefined));
 
       const ui = <AppProviders basename="" />;
@@ -127,7 +117,6 @@ describe('App Component', () => {
       await waitFor(() => screen.queryByText('Software distribution'), { timeout: TIMEOUTS.fiveSeconds });
       await waitFor(() => rerender(ui));
       await waitFor(() => expect(document.querySelector('.loaderContainer')).not.toBeInTheDocument());
-      await waitFor(() => expect(reportsSpy).toHaveBeenCalled(), { timeout: TIMEOUTS.fiveSeconds });
       const view = baseElement.lastElementChild;
       expect(view).toMatchSnapshot();
       expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/frontend/src/js/components/dashboard/Devices.tsx
+++ b/frontend/src/js/components/dashboard/Devices.tsx
@@ -68,11 +68,6 @@ export const Devices = ({ clickHandle }) => {
     refreshDevices();
   }, [refreshDevices]);
 
-  useEffect(() => {
-    refreshDevices();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(availableIssueOptions), refreshDevices]);
-
   const onConnectClick = () => {
     dispatch(setShowConnectingDialog(true));
     navigate('/devices/accepted');

--- a/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
+++ b/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
@@ -19,7 +19,7 @@ import { Typography } from '@mui/material';
 
 import Loader from '@northern.tech/common-ui/Loader';
 import { SupportLink } from '@northern.tech/common-ui/SupportLink';
-import { MAX_PAGE_SIZE, TIMEOUTS, defaultReports, rootfsImageVersion, softwareTitleMap } from '@northern.tech/store/constants';
+import { MAX_PAGE_SIZE, TIMEOUTS, defaultReports, rootfsImageVersion, softwareIndicator, softwareTitleMap } from '@northern.tech/store/constants';
 import {
   getAcceptedDevices,
   getAttributesList,
@@ -41,7 +41,7 @@ const getLayerKey = ({ title, key }, parent) => `${parent.length ? `${parent}.` 
 
 const generateLayer = (softwareLayer, parentKey = '', nestingLevel = 0) => {
   const { children, key, title } = softwareLayer;
-  const suffix = title === key ? '.version' : '';
+  const suffix = title === key ? softwareIndicator : '';
   const layerKey = getLayerKey(softwareLayer, parentKey);
   const layerTitle = `${layerKey}${suffix}`;
   let headerItems = [{ title, nestingLevel, value: layerKey }];

--- a/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
+++ b/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
@@ -19,7 +19,7 @@ import { Typography } from '@mui/material';
 
 import Loader from '@northern.tech/common-ui/Loader';
 import { SupportLink } from '@northern.tech/common-ui/SupportLink';
-import { MAX_PAGE_SIZE, TIMEOUTS, defaultReportType, defaultReports, rootfsImageVersion, softwareTitleMap } from '@northern.tech/store/constants';
+import { MAX_PAGE_SIZE, TIMEOUTS, defaultReports, rootfsImageVersion, softwareTitleMap } from '@northern.tech/store/constants';
 import {
   getAcceptedDevices,
   getAttributesList,
@@ -35,11 +35,7 @@ import { isEmpty } from '@northern.tech/utils/helpers';
 import { extractSoftwareInformation } from '../devices/device-details/InstalledSoftware';
 import BaseWidget from './widgets/BaseWidget';
 import ChartAdditionWidget from './widgets/ChartAddition';
-import DistributionReport from './widgets/Distribution';
-
-const reportTypes = {
-  distribution: DistributionReport
-};
+import { DistributionReport } from './widgets/Distribution';
 
 const getLayerKey = ({ title, key }, parent) => `${parent.length ? `${parent}.` : parent}${key.length <= title.length ? key : title}`;
 
@@ -171,18 +167,15 @@ export const SoftwareDistribution = () => {
   }
   return hasDevices ? (
     <div className="dashboard margin-bottom-large">
-      {reports.slice(0, visibleCount).map((report, index) => {
-        const Component = reportTypes[report.type || defaultReportType];
-        return (
-          <Component
-            key={`report-${report.group}-${index}`}
-            onClick={() => removeReport(report)}
-            onSave={change => onSaveChangedReport(change, index)}
-            selection={{ ...report, index }}
-            software={software}
-          />
-        );
-      })}
+      {reports.slice(0, visibleCount).map((report, index) => (
+        <DistributionReport
+          key={`report-${report.group}-${index}`}
+          onClick={() => removeReport(report)}
+          onSave={change => onSaveChangedReport(change, index)}
+          selection={{ ...report, index }}
+          software={software}
+        />
+      ))}
       {visibleCount < reports.length && (
         <div className="widget chart-widget flexbox centered">
           <Loader show style={{ width: '100%' }} />

--- a/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
+++ b/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
@@ -144,6 +144,7 @@ export const SoftwareDistribution = () => {
     const newReports = [...reports];
     newReports.splice(index, 1, change);
     dispatch(saveUserSettings({ reports: newReports }));
+    dispatch(getReportDataWithoutBackendSupport(index));
   };
 
   const removeReport = removedReport => dispatch(saveUserSettings({ reports: reports.filter(report => report !== removedReport) }));

--- a/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
+++ b/frontend/src/js/components/dashboard/SoftwareDistribution.tsx
@@ -44,7 +44,7 @@ const generateLayer = (softwareLayer, parentKey = '', nestingLevel = 0) => {
   const suffix = title === key ? softwareIndicator : '';
   const layerKey = getLayerKey(softwareLayer, parentKey);
   const layerTitle = `${layerKey}${suffix}`;
-  let headerItems = [{ title, nestingLevel, value: layerKey }];
+  let headerItems = [{ title, nestingLevel, value: layerTitle }]; // this should be the case if there are no children == lowest level information, so we give the full version string
   if (softwareTitleMap[layerTitle]) {
     headerItems = [
       { subheader: title, nestingLevel, value: `${layerTitle}-subheader` },
@@ -146,7 +146,7 @@ export const SoftwareDistribution = () => {
   const removeReport = removedReport => dispatch(saveUserSettings({ reports: reports.filter(report => report !== removedReport) }));
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const software = useMemo(() => listSoftware([rootfsImageVersion]), [JSON.stringify(attributes)]);
+  const software = useMemo(() => listSoftware([rootfsImageVersion, ...attributes]), [JSON.stringify(attributes)]);
 
   if (!isEnterprise) {
     return (

--- a/frontend/src/js/components/dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -466,7 +466,7 @@ exports[`Dashboard Component > renders correctly 1`] = `
   margin-right: 8px;
 }
 
-.emotion-19 {
+.emotion-21 {
   background-color: #f7f7f7;
   padding: 10px 20px;
   border-radius: 4px;
@@ -477,61 +477,61 @@ exports[`Dashboard Component > renders correctly 1`] = `
   min-height: 70px;
 }
 
-.emotion-19 .chart-container {
+.emotion-21 .chart-container {
   min-height: 70px;
 }
 
-.emotion-19 .progress-chart {
+.emotion-21 .progress-chart {
   min-height: 45px;
 }
 
-.emotion-19 .compact .progress-step,
-.emotion-19 .detailed .progress-step {
+.emotion-21 .compact .progress-step,
+.emotion-21 .detailed .progress-step {
   min-height: 45px;
 }
 
-.emotion-19 .progress-step,
-.emotion-19 .detailed .progress-step-total {
+.emotion-21 .progress-step,
+.emotion-21 .detailed .progress-step-total {
   position: absolute;
   border-right-style: none;
 }
 
-.emotion-19 .progress-step-total .progress-bar {
+.emotion-21 .progress-step-total .progress-bar {
   background-color: #d4e9e7;
 }
 
-.emotion-19 .progress-step-number {
+.emotion-21 .progress-step-number {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
   margin-top: -4px;
 }
 
-.emotion-19.minimal {
+.emotion-21.minimal {
   padding: initial;
 }
 
-.emotion-19.no-background {
+.emotion-21.no-background {
   background: none;
 }
 
-.emotion-19.stepped-progress .progress-step-total {
+.emotion-21.stepped-progress .progress-step-total {
   margin-left: -0.25%;
   width: 100.5%;
 }
 
-.emotion-19.stepped-progress .progress-step-total .progress-bar {
+.emotion-21.stepped-progress .progress-step-total .progress-bar {
   background-color: #fff;
   border: 1px solid #a9a9a9;
   border-radius: 2px;
   height: 12px;
 }
 
-.emotion-19.stepped-progress .detailed .progress-step {
+.emotion-21.stepped-progress .detailed .progress-step {
   min-height: 20px;
 }
 
-.emotion-22 {
+.emotion-26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -542,32 +542,32 @@ exports[`Dashboard Component > renders correctly 1`] = `
   max-width: 500px;
 }
 
-.emotion-22>time {
+.emotion-26>time {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: flex-end;
   align-self: flex-end;
   margin-right: 6px;
 }
 
-.emotion-24 {
+.emotion-28 {
   background: #fff;
   border-radius: 4px;
   padding: 4px;
 }
 
-.emotion-25 {
+.emotion-29 {
   -webkit-column-gap: 8px;
   column-gap: 8px;
   display: grid;
   grid-template-columns: repeat(auto-fit, 32px);
 }
 
-.emotion-25>div {
+.emotion-29>div {
   -webkit-column-gap: 4px;
   column-gap: 4px;
 }
 
-.emotion-25 .disabled {
+.emotion-29 .disabled {
   opacity: 0.1;
 }
 
@@ -769,6 +769,38 @@ exports[`Dashboard Component > renders correctly 1`] = `
           class="clickable emotion-14"
         >
           <div>
+            <div />
+            <div
+              class=""
+              title="Test"
+            >
+              Test
+            </div>
+          </div>
+          <div
+            class="flexbox center-aligned"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4M12,10.5A1.5,1.5 0 0,1 13.5,12A1.5,1.5 0 0,1 12,13.5A1.5,1.5 0 0,1 10.5,12A1.5,1.5 0 0,1 12,10.5M7.5,10.5A1.5,1.5 0 0,1 9,12A1.5,1.5 0 0,1 7.5,13.5A1.5,1.5 0 0,1 6,12A1.5,1.5 0 0,1 7.5,10.5M16.5,10.5A1.5,1.5 0 0,1 18,12A1.5,1.5 0 0,1 16.5,13.5A1.5,1.5 0 0,1 15,12A1.5,1.5 0 0,1 16.5,10.5Z"
+              />
+            </svg>
+            <span
+              class="margin-left-small"
+            >
+              Queued to start
+            </span>
+          </div>
+        </div>
+        <div
+          class="clickable emotion-14"
+        >
+          <div>
             <div>
               r1
             </div>
@@ -842,6 +874,123 @@ exports[`Dashboard Component > renders correctly 1`] = `
           class="clickable emotion-14"
         >
           <div>
+            <div />
+            <div
+              class=""
+              title="Test"
+            >
+              Test
+            </div>
+          </div>
+          <div
+            class="relative emotion-21 minimal "
+          >
+            <div
+              class="chart-container"
+            >
+              <div
+                class="progress-chart relative detailed"
+              >
+                <div
+                  class="progress-step"
+                  style="left: 0%; width: 2%;"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step"
+                  style="left: 2%; width: 3%;"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step"
+                  style="left: 5%; width: 5%;"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step"
+                  style="left: 10%; width: 5%;"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step"
+                  style="left: 15%; width: 85%;"
+                >
+                  <div
+                    style="display: contents;"
+                  >
+                    <div
+                      class="progress-bar green"
+                      style="width: 0%;"
+                    />
+                    <div
+                      class="progress-bar warning"
+                      style="left: 0%; width: 0%;"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="progress-step relative flexbox progress-step-total"
+                >
+                  <div
+                    class="progress-bar"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="clickable emotion-14"
+        >
+          <div>
             <div>
               r1
             </div>
@@ -853,7 +1002,7 @@ exports[`Dashboard Component > renders correctly 1`] = `
             </div>
           </div>
           <div
-            class="relative emotion-19 minimal "
+            class="relative emotion-21 minimal "
           >
             <div
               class="chart-container"
@@ -933,11 +1082,112 @@ exports[`Dashboard Component > renders correctly 1`] = `
           Finished
         </h5>
         <div
-          class="emotion-22"
+          class="emotion-26"
         >
           <time
             class="muted slightly-smaller"
-            datetime="2019-01-13T13:00:00+00:00"
+            datetime="2019-01-13T13:00:03+00:00"
+          >
+            2019-01-13 13:00
+          </time>
+          <div
+            class="clickable emotion-14"
+          >
+            <div>
+              <div />
+              <div
+                class=""
+                title="Test"
+              >
+                Test
+              </div>
+            </div>
+            <div
+              class="emotion-28"
+            >
+              <div
+                class="flexbox emotion-29 "
+              >
+                <div
+                  aria-label="Skipped"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="/src/assets/img/skipped_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Pending"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="/src/assets/img/pending_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="In progress"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="/src/assets/img/progress_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Successful"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="/src/assets/img/success_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+                <div
+                  aria-label="Failed"
+                  class="flexbox centered disabled"
+                  data-mui-internal-clone-element="true"
+                >
+                  <img
+                    src="/src/assets/img/error_status.png"
+                  />
+                  <div
+                    class="status"
+                  >
+                    0
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="emotion-26"
+        >
+          <time
+            class="muted slightly-smaller"
+            datetime="2019-01-13T13:00:03+00:00"
           >
             2019-01-13 13:00
           </time>
@@ -956,10 +1206,10 @@ exports[`Dashboard Component > renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="emotion-24"
+              class="emotion-28"
             >
               <div
-                class="flexbox emotion-25 "
+                class="flexbox emotion-29 "
               >
                 <div
                   aria-label="Skipped"
@@ -1036,11 +1286,11 @@ exports[`Dashboard Component > renders correctly 1`] = `
           </div>
         </div>
         <div
-          class="emotion-22"
+          class="emotion-26"
         >
           <time
             class="muted slightly-smaller"
-            datetime="2019-01-13T13:00:00+00:00"
+            datetime="2019-01-13T13:00:03+00:00"
           >
             2019-01-13 13:00
           </time>
@@ -1059,10 +1309,10 @@ exports[`Dashboard Component > renders correctly 1`] = `
               </div>
             </div>
             <div
-              class="emotion-24"
+              class="emotion-28"
             >
               <div
-                class="flexbox emotion-25 "
+                class="flexbox emotion-29 "
               >
                 <div
                   aria-label="Skipped"

--- a/frontend/src/js/components/dashboard/__snapshots__/SoftwareDistribution.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/__snapshots__/SoftwareDistribution.test.tsx.snap
@@ -2,6 +2,504 @@
 
 exports[`Devices Component > renders correctly 1`] = `
 .emotion-0 {
+  min-height: 30px;
+}
+
+.emotion-0 .MuiSvgIcon-root {
+  margin-left: 8px;
+}
+
+.emotion-1 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.3929rem;
+}
+
+.emotion-1 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  text-align: center;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  font-size: 1.3929rem;
+  padding: 8px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.54);
+  -webkit-transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  --IconButton-hoverBg: rgba(0, 0, 0, 0.04);
+  padding: 5px;
+  font-size: 1.0446rem;
+  font-size: 1.2rem;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.emotion-2::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-2.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-2 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-2:hover {
+  background-color: var(--IconButton-hoverBg);
+}
+
+@media (hover: none) {
+  .emotion-2:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-2.Mui-disabled {
+  background-color: transparent;
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-2.MuiIconButton-loading {
+  color: transparent;
+}
+
+.emotion-3 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.1607rem;
+}
+
+.emotion-3 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-6 {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  margin-bottom: 16px;
+}
+
+.emotion-6>.flexbox.column>* {
+  height: 20px;
+}
+
+.emotion-6 .barchart .MuiLinearProgress-root {
+  background-color: #f7f7f7;
+}
+
+.emotion-6 .barchart .color-f7f7f7 .MuiLinearProgress-barColorPrimary {
+  background-color: #f7f7f7;
+}
+
+.emotion-6 .barchart .color-337a87 .MuiLinearProgress-barColorPrimary {
+  background-color: #337a87;
+}
+
+.emotion-6 .barchart .color-a31773 .MuiLinearProgress-barColorPrimary {
+  background-color: #a31773;
+}
+
+.emotion-6 .barchart .color-00859e .MuiLinearProgress-barColorPrimary {
+  background-color: #00859e;
+}
+
+.emotion-6 .barchart .color-14cfda .MuiLinearProgress-barColorPrimary {
+  background-color: #14cfda;
+}
+
+.emotion-6 .barchart .color-9bfff0 .MuiLinearProgress-barColorPrimary {
+  background-color: #9bfff0;
+}
+
+.emotion-6 .barchart .color-d5d5d5 .MuiLinearProgress-barColorPrimary {
+  background-color: #d5d5d5;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+}
+
+.emotion-7.indicating {
+  grid-template-columns: min-content 1fr max-content;
+  -webkit-column-gap: 8px;
+  column-gap: 8px;
+}
+
+.emotion-8 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.3929rem;
+  font-size: 10px;
+  min-width: initial;
+  margin-left: 4px;
+}
+
+.emotion-8 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-9 {
+  gap: 16px;
+}
+
+.emotion-10 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.3929rem;
+  color: #337a87;
+}
+
+.emotion-10 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-10.read {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-11 {
+  position: absolute;
+  top: -5px;
+  bottom: 0;
+  left: -5px;
+  right: -5px;
+  border: 1px dashed #337a87;
+  border-radius: 50%;
+}
+
+.emotion-11.read {
+  border-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-12 {
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+<div>
+  <div
+    class="dashboard margin-bottom-large"
+  >
+    <div
+      class="widget chart-widget"
+    >
+      <div
+        class="margin-bottom-small"
+      >
+        <div
+          class="flexbox space-between margin-bottom-small"
+        >
+          <div
+            class="flexbox center-aligned emotion-0"
+          >
+            Software distribution
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-1"
+              data-testid="PieChartOutlineIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2m1 2.07c3.61.45 6.48 3.33 6.93 6.93H13zM4 12c0-4.06 3.07-7.44 7-7.93v15.87c-3.93-.5-7-3.88-7-7.94m9 7.93V13h6.93c-.45 3.61-3.32 6.48-6.93 6.93"
+              />
+            </svg>
+          </div>
+          <div
+            class="flexbox center-aligned"
+            style="z-index: 1;"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-2"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
+                data-testid="SettingsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
+                />
+              </svg>
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-2"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
+                data-testid="ClearIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="flexbox space-between slightly-smaller"
+        >
+          <div>
+            Root filesystem
+          </div>
+          <div>
+            All devices
+          </div>
+        </div>
+      </div>
+      <div
+        class="emotion-6"
+        style="height: -30px;"
+      >
+        <div
+          class="flexbox column"
+        >
+          <div
+            class="clickable emotion-7 indicating"
+            title="undefined"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+              data-testid="SquareIcon"
+              focusable="false"
+              style="fill: #337a87;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M3 3h18v18H3z"
+              />
+            </svg>
+            <div
+              class="text-overflow"
+            >
+              undefined
+            </div>
+            <div>
+              2
+            </div>
+          </div>
+        </div>
+        <div
+          class="VictoryContainer"
+          style="height: -30px; pointer-events: none; position: relative;"
+        >
+          <svg
+            height="400"
+            role="img"
+            style="width: 100%; height: 100%; pointer-events: all;"
+            viewBox="0 0 400 400"
+            width="400"
+          >
+            <g>
+              <path
+                d="M1.1787225441793275e-14,-192.5A192.5,192.5,0,1,1,-1.1787225441793275e-14,192.5A192.5,192.5,0,1,1,1.1787225441793275e-14,-192.5Z"
+                role="presentation"
+                shape-rendering="auto"
+                style="fill: #337a87; padding: 10px; stroke: transparent; stroke-width: 1;"
+                transform="translate(200, 192.5)"
+              />
+            </g>
+          </svg>
+          <div
+            style="width: 100%; height: 100%; z-index: 99; position: absolute; top: 0px; left: 0px;"
+          >
+            <svg
+              height="400"
+              style="width: 100%; height: 100%; overflow: visible;"
+              viewBox="0 0 400 400"
+              width="400"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="widget chart-widget flexbox centered"
+    >
+      <div
+        class="loaderContainer"
+        style="width: 100%;"
+      >
+        <div
+          class="  loader"
+        >
+          <span
+            class="dot dot_1"
+          />
+          <span
+            class="dot dot_2"
+          />
+          <span
+            class="dot dot_3"
+          />
+          <span
+            class="dot dot_4"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      class="widget"
+    >
+      <div
+        class="flexbox center-aligned  emotion-9"
+        style="align-items: end;"
+      >
+        <div
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <div
+            class="relative"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium emotion-10"
+              data-testid="HelpIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m1 17h-2v-2h2zm2.07-7.75-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25"
+              />
+            </svg>
+            <div
+              class="emotion-11 "
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="flexbox centered muted emotion-12"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-1"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+          />
+        </svg>
+        <span
+          class="emotion-12"
+        >
+          add a widget
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Devices Component > renders correctly for non-enterprise 1`] = `
+.emotion-0 {
   gap: 16px;
 }
 
@@ -321,7 +819,89 @@ exports[`Devices Component > renders correctly 1`] = `
 </div>
 `;
 
-exports[`Devices Component > renders correctly for enterprise 1`] = `
+exports[`Devices Component > renders correctly for too many devices 1`] = `
+.emotion-0 {
+  margin: 0;
+  font-family: Lato,sans-serif;
+  font-weight: 500;
+  font-size: 0.8125rem;
+  line-height: 1.57;
+}
+
+.emotion-1 {
+  margin: 0;
+  font-family: Lato,sans-serif;
+  font-weight: 400;
+  font-size: 0.6964rem;
+  line-height: 1.66;
+}
+
+<div>
+  <div
+    class="dashboard margin-bottom-large"
+  >
+    <h6
+      class="MuiTypography-root MuiTypography-subtitle2 emotion-0"
+    >
+      Device and Group Limit Exceeded
+    </h6>
+    <span
+      class="MuiTypography-root MuiTypography-caption emotion-1"
+    >
+      Your current number of devices and groups exceeds the limits of our present implementation. To ensure you continue to gain optimal insights and to better understand your specific requirements, we encourage you to reach out to 
+      <a
+        class=""
+        href="mailto:support@mender.io"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        contact our team
+      </a>
+      . By providing us with more details about your use case, we can improve potential solutions to best accommodate your needs when the feature gets added to our backend.
+    </span>
+  </div>
+</div>
+`;
+
+exports[`Devices Component > renders correctly while waiting for initialization 1`] = `
+<div>
+  <div
+    class="dashboard margin-bottom-large"
+  >
+    <div
+      class="widget chart-widget flexbox centered"
+    >
+      <div
+        class="widgetMainContent"
+      >
+        <div
+          class="loaderContainer"
+          style="width: 100%;"
+        >
+          <div
+            class="  loader"
+          >
+            <span
+              class="dot dot_1"
+            />
+            <span
+              class="dot dot_2"
+            />
+            <span
+              class="dot dot_3"
+            />
+            <span
+              class="dot dot_4"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Devices Component > renders correctly without data retrieval 1`] = `
 .emotion-0 {
   min-height: 30px;
 }
@@ -519,6 +1099,30 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
 }
 
 .emotion-8 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.3929rem;
+  font-size: 10px;
+  min-width: initial;
+  margin-left: 4px;
+}
+
+.emotion-8 iconButton {
+  margin-right: 8px;
+}
+
+.emotion-17 {
   position: relative;
   overflow: hidden;
   display: block;
@@ -528,13 +1132,13 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
 }
 
 @media print {
-  .emotion-8 {
+  .emotion-17 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-9 {
+.emotion-18 {
   width: 100%;
   position: absolute;
   left: 0;
@@ -548,11 +1152,11 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
   transition: transform .4s linear;
 }
 
-.emotion-10 {
+.emotion-19 {
   gap: 16px;
 }
 
-.emotion-11 {
+.emotion-20 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -570,15 +1174,15 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
   color: #337a87;
 }
 
-.emotion-11 iconButton {
+.emotion-20 iconButton {
   margin-right: 8px;
 }
 
-.emotion-11.read {
+.emotion-20.read {
   color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-12 {
+.emotion-21 {
   position: absolute;
   top: -5px;
   bottom: 0;
@@ -588,11 +1192,11 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
   border-radius: 50%;
 }
 
-.emotion-12.read {
+.emotion-21.read {
   border-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-13 {
+.emotion-22 {
   font-size: 1rem;
   cursor: pointer;
 }
@@ -601,6 +1205,149 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
   <div
     class="dashboard margin-bottom-large"
   >
+    <div
+      class="widget chart-widget"
+    >
+      <div
+        class="margin-bottom-small"
+      >
+        <div
+          class="flexbox space-between margin-bottom-small"
+        >
+          <div
+            class="flexbox center-aligned emotion-0"
+          >
+            Software distribution
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-1"
+              data-testid="PieChartOutlineIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2m1 2.07c3.61.45 6.48 3.33 6.93 6.93H13zM4 12c0-4.06 3.07-7.44 7-7.93v15.87c-3.93-.5-7-3.88-7-7.94m9 7.93V13h6.93c-.45 3.61-3.32 6.48-6.93 6.93"
+              />
+            </svg>
+          </div>
+          <div
+            class="flexbox center-aligned"
+            style="z-index: 1;"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-2"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
+                data-testid="SettingsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
+                />
+              </svg>
+            </button>
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-2"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
+                data-testid="ClearIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="flexbox space-between slightly-smaller"
+        >
+          <div>
+            Root filesystem
+          </div>
+          <div>
+            All devices
+          </div>
+        </div>
+      </div>
+      <div
+        class="emotion-6"
+        style="height: -30px;"
+      >
+        <div
+          class="flexbox column"
+        >
+          <div
+            class="clickable emotion-7 indicating"
+            title="undefined"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+              data-testid="SquareIcon"
+              focusable="false"
+              style="fill: #337a87;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M3 3h18v18H3z"
+              />
+            </svg>
+            <div
+              class="text-overflow"
+            >
+              undefined
+            </div>
+            <div>
+              2
+            </div>
+          </div>
+        </div>
+        <div
+          class="VictoryContainer"
+          style="height: -30px; pointer-events: none; position: relative;"
+        >
+          <svg
+            height="400"
+            role="img"
+            style="width: 100%; height: 100%; pointer-events: all;"
+            viewBox="0 0 400 400"
+            width="400"
+          >
+            <g>
+              <path
+                d="M1.1787225441793275e-14,-192.5A192.5,192.5,0,1,1,-1.1787225441793275e-14,192.5A192.5,192.5,0,1,1,1.1787225441793275e-14,-192.5Z"
+                role="presentation"
+                shape-rendering="auto"
+                style="fill: #337a87; padding: 10px; stroke: transparent; stroke-width: 1;"
+                transform="translate(200, 192.5)"
+              />
+            </g>
+          </svg>
+          <div
+            style="width: 100%; height: 100%; z-index: 99; position: absolute; top: 0px; left: 0px;"
+          >
+            <svg
+              height="400"
+              style="width: 100%; height: 100%; overflow: visible;"
+              viewBox="0 0 400 400"
+              width="400"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
     <div
       class="widget chart-widget"
     >
@@ -673,7 +1420,7 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
             artifact_name
           </div>
           <div>
-            All devices
+            testGroup
           </div>
         </div>
       </div>
@@ -685,12 +1432,12 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
         >
           <div
             class="clickable emotion-7 "
-            title="raspotifyInstaller"
+            title="undefined"
           >
             <div
               class="text-overflow"
             >
-              raspotifyInstaller
+              undefined
             </div>
             <div>
               2
@@ -703,19 +1450,19 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
           <div
             class="clickable flexbox column barchart"
             style="justify-content: center;"
-            title="raspotifyInstaller"
+            title="undefined"
           >
             <span
               aria-valuemax="100"
               aria-valuemin="0"
-              aria-valuenow="0"
-              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-337a87 emotion-8"
+              aria-valuenow="100"
+              class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate color-337a87 emotion-17"
               role="progressbar"
               style="height: 8px;"
             >
               <span
-                class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-9"
-                style="transform: translateX(-100%);"
+                class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate emotion-18"
+                style="transform: translateX(0%);"
               />
             </span>
           </div>
@@ -726,7 +1473,7 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
       class="widget"
     >
       <div
-        class="flexbox center-aligned  emotion-10"
+        class="flexbox center-aligned  emotion-19"
         style="align-items: end;"
       >
         <div
@@ -738,7 +1485,7 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium emotion-11"
+              class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium emotion-20"
               data-testid="HelpIcon"
               focusable="false"
               viewBox="0 0 24 24"
@@ -748,13 +1495,13 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
               />
             </svg>
             <div
-              class="emotion-12 "
+              class="emotion-21 "
             />
           </div>
         </div>
       </div>
       <div
-        class="flexbox centered muted emotion-13"
+        class="flexbox centered muted emotion-22"
       >
         <svg
           aria-hidden="true"
@@ -768,7 +1515,7 @@ exports[`Devices Component > renders correctly for enterprise 1`] = `
           />
         </svg>
         <span
-          class="emotion-13"
+          class="emotion-22"
         >
           add a widget
         </span>

--- a/frontend/src/js/components/dashboard/widgets/Distribution.test.tsx
+++ b/frontend/src/js/components/dashboard/widgets/Distribution.test.tsx
@@ -11,6 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+import { TIMEOUTS } from '@northern.tech/store/constants';
+import { act } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { undefineds } from '../../../../../tests/mockData';
@@ -19,7 +21,19 @@ import { DistributionReport } from './Distribution';
 
 describe('Distribution Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(<DistributionReport attribute="artifact_name" getGroupDevices={vi.fn()} group="test" devices={{}} groups={{}} />);
+    const { baseElement } = render(
+      <DistributionReport
+        onClick={vi.fn}
+        onSave={vi.fn}
+        selection={{ group: '', attribute: 'artifact_name', index: 0, type: 'distribution', chartType: 'pie' }}
+        software={{}}
+      />
+    );
+    await act(async () => {
+      vi.runAllTimers();
+      vi.runAllTicks();
+      return new Promise(resolve => resolve(), TIMEOUTS.oneSecond);
+    });
     const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));

--- a/frontend/src/js/components/dashboard/widgets/Distribution.tsx
+++ b/frontend/src/js/components/dashboard/widgets/Distribution.tsx
@@ -20,7 +20,7 @@ import { IconButton, LinearProgress, linearProgressClasses } from '@mui/material
 import { makeStyles } from 'tss-react/mui';
 
 import Loader from '@northern.tech/common-ui/Loader';
-import { ALL_DEVICES, TIMEOUTS, chartTypes, rootfsImageVersion, softwareTitleMap } from '@northern.tech/store/constants';
+import { ALL_DEVICES, TIMEOUTS, chartTypes, rootfsImageVersion, softwareIndicator, softwareTitleMap } from '@northern.tech/store/constants';
 import { getDeviceReports, getGroupsById } from '@northern.tech/store/selectors';
 import { getReportDataWithoutBackendSupport, updateReportData } from '@northern.tech/store/thunks';
 import { ensureVersionString } from '@northern.tech/store/utils';
@@ -225,6 +225,14 @@ interface DistributionReportProps {
   software?: SoftwareLayer;
 }
 
+const cleanSoftwareTitle = (software: string) => {
+  let cleanedSoftware = softwareTitleMap[software] ? softwareTitleMap[software].title : software;
+  cleanedSoftware = cleanedSoftware.endsWith(softwareIndicator)
+    ? cleanedSoftware.substring(0, cleanedSoftware.lastIndexOf(softwareIndicator))
+    : cleanedSoftware;
+  return cleanedSoftware;
+};
+
 export const DistributionReport = ({ onClick, onSave, selection = {}, software: softwareTree }: DistributionReportProps) => {
   const { attribute, chartType = chartTypes.bar.key, group, index: reportIndex, software: softwareSelection } = selection;
   const software = softwareSelection || attribute || rootfsImageVersion;
@@ -314,7 +322,7 @@ export const DistributionReport = ({ onClick, onSave, selection = {}, software: 
           </div>
         </div>
         <div className="flexbox space-between slightly-smaller">
-          <div>{softwareTitleMap[software] ? softwareTitleMap[software].title : software}</div>
+          <div>{cleanSoftwareTitle(software)}</div>
           <div>{group || ALL_DEVICES}</div>
         </div>
       </div>

--- a/frontend/src/js/components/dashboard/widgets/Distribution.tsx
+++ b/frontend/src/js/components/dashboard/widgets/Distribution.tsx
@@ -205,7 +205,27 @@ const initDistribution = ({ data, theme }) => {
   return { distribution, totals };
 };
 
-export const DistributionReport = ({ onClick, onSave, selection = {}, software: softwareTree }) => {
+interface DistributionReport {
+  attribute: string;
+  chartType: string;
+  group: string;
+  index: number;
+  software: string;
+  type: string;
+}
+
+type SoftwareLayer = {
+  [key: string]: SoftwareLayer | string;
+};
+
+interface DistributionReportProps {
+  onClick?: () => void;
+  onSave: (selection: Partial<DistributionReport>) => void;
+  selection?: Partial<DistributionReport>;
+  software?: SoftwareLayer;
+}
+
+export const DistributionReport = ({ onClick, onSave, selection = {}, software: softwareTree }: DistributionReportProps) => {
   const { attribute, chartType = chartTypes.bar.key, group, index: reportIndex, software: softwareSelection } = selection;
   const software = softwareSelection || attribute || rootfsImageVersion;
   const [editing, setEditing] = useState(false);

--- a/frontend/src/js/components/dashboard/widgets/__snapshots__/Distribution.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/widgets/__snapshots__/Distribution.test.tsx.snap
@@ -136,6 +136,91 @@ exports[`Distribution Component > renders correctly 1`] = `
   margin-right: 8px;
 }
 
+.emotion-6 {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  margin-bottom: 16px;
+}
+
+.emotion-6>.flexbox.column>* {
+  height: 20px;
+}
+
+.emotion-6 .barchart .MuiLinearProgress-root {
+  background-color: #f7f7f7;
+}
+
+.emotion-6 .barchart .color-f7f7f7 .MuiLinearProgress-barColorPrimary {
+  background-color: #f7f7f7;
+}
+
+.emotion-6 .barchart .color-337a87 .MuiLinearProgress-barColorPrimary {
+  background-color: #337a87;
+}
+
+.emotion-6 .barchart .color-a31773 .MuiLinearProgress-barColorPrimary {
+  background-color: #a31773;
+}
+
+.emotion-6 .barchart .color-00859e .MuiLinearProgress-barColorPrimary {
+  background-color: #00859e;
+}
+
+.emotion-6 .barchart .color-14cfda .MuiLinearProgress-barColorPrimary {
+  background-color: #14cfda;
+}
+
+.emotion-6 .barchart .color-9bfff0 .MuiLinearProgress-barColorPrimary {
+  background-color: #9bfff0;
+}
+
+.emotion-6 .barchart .color-d5d5d5 .MuiLinearProgress-barColorPrimary {
+  background-color: #d5d5d5;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+}
+
+.emotion-7.indicating {
+  grid-template-columns: min-content 1fr max-content;
+  -webkit-column-gap: 8px;
+  column-gap: 8px;
+}
+
+.emotion-8 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.3929rem;
+  font-size: 10px;
+  min-width: initial;
+  margin-left: 4px;
+}
+
+.emotion-8 iconButton {
+  margin-right: 8px;
+}
+
 <body>
   <div>
     <div
@@ -154,12 +239,12 @@ exports[`Distribution Component > renders correctly 1`] = `
             <svg
               aria-hidden="true"
               class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-1"
-              data-testid="BarChartIcon"
+              data-testid="PieChartOutlineIcon"
               focusable="false"
               viewBox="0 0 24 24"
             >
               <path
-                d="M4 9h4v11H4zm12 4h4v7h-4zm-6-9h4v16h-4z"
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2m1 2.07c3.61.45 6.48 3.33 6.93 6.93H13zM4 12c0-4.06 3.07-7.44 7-7.93v15.87c-3.93-.5-7-3.88-7-7.94m9 7.93V13h6.93c-.45 3.61-3.32 6.48-6.93 6.93"
               />
             </svg>
           </div>
@@ -207,7 +292,7 @@ exports[`Distribution Component > renders correctly 1`] = `
           class="flexbox space-between slightly-smaller"
         >
           <div>
-            Root filesystem
+            artifact_name
           </div>
           <div>
             All devices
@@ -215,9 +300,70 @@ exports[`Distribution Component > renders correctly 1`] = `
         </div>
       </div>
       <div
-        class="muted flexbox centered"
+        class="emotion-6"
+        style="height: -30px;"
       >
-        There are no devices that match the selected criteria.
+        <div
+          class="flexbox column"
+        >
+          <div
+            class="clickable emotion-7 indicating"
+            title="undefined"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+              data-testid="SquareIcon"
+              focusable="false"
+              style="fill: #337a87;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M3 3h18v18H3z"
+              />
+            </svg>
+            <div
+              class="text-overflow"
+            >
+              undefined
+            </div>
+            <div>
+              2
+            </div>
+          </div>
+        </div>
+        <div
+          class="VictoryContainer"
+          style="height: -30px; pointer-events: none; position: relative;"
+        >
+          <svg
+            height="400"
+            role="img"
+            style="width: 100%; height: 100%; pointer-events: all;"
+            viewBox="0 0 400 400"
+            width="400"
+          >
+            <g>
+              <path
+                d="M1.1787225441793275e-14,-192.5A192.5,192.5,0,1,1,-1.1787225441793275e-14,192.5A192.5,192.5,0,1,1,1.1787225441793275e-14,-192.5Z"
+                role="presentation"
+                shape-rendering="auto"
+                style="fill: #337a87; padding: 10px; stroke: transparent; stroke-width: 1;"
+                transform="translate(200, 192.5)"
+              />
+            </g>
+          </svg>
+          <div
+            style="width: 100%; height: 100%; z-index: 99; position: absolute; top: 0px; left: 0px;"
+          >
+            <svg
+              height="400"
+              style="width: 100%; height: 100%; overflow: visible;"
+              viewBox="0 0 400 400"
+              width="400"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/js/store/devicesSlice/thunks.tsx
+++ b/frontend/src/js/store/devicesSlice/thunks.tsx
@@ -630,12 +630,7 @@ export const getAllDevicesByStatus = createAsyncThunk(`${sliceName}/getAllDevice
       if (total > perPage * page) {
         return getAllDevices(perPage, page + 1, deviceAccu.ids);
       }
-      const tasks = [dispatch(actions.setDevicesByStatus({ deviceIds: deviceAccu.ids, forceUpdate: true, status, total: deviceAccu.ids.length }))];
-      if (status === DEVICE_STATES.accepted && deviceAccu.ids.length === total) {
-        tasks.push(dispatch(deriveInactiveDevices(deviceAccu.ids)));
-        tasks.push(dispatch(deriveReportsData()));
-      }
-      return Promise.all(tasks);
+      return Promise.resolve();
     });
   return getAllDevices();
 });

--- a/frontend/src/js/store/releasesSlice/constants.ts
+++ b/frontend/src/js/store/releasesSlice/constants.ts
@@ -14,5 +14,6 @@
 export const ARTIFACT_GENERATION_TYPE = { SINGLE_FILE: 'single_file' };
 
 export const currentArtifact = 'artifact_name';
+export const softwareIndicator = '.version';
 export const rootfsImageVersion = 'rootfs-image.version';
 export const softwareTitleMap = { [rootfsImageVersion]: { title: 'Root filesystem', priority: 0, key: rootfsImageVersion } };

--- a/frontend/src/js/store/usersSlice/selectors.ts
+++ b/frontend/src/js/store/usersSlice/selectors.ts
@@ -21,6 +21,7 @@ import { READ_STATES, twoFAStates } from './constants';
 export const getRolesById = state => state.users.rolesById;
 export const getTooltipsById = state => state.users.tooltips.byId;
 export const getGlobalSettings = state => state.users.globalSettings;
+export const getUserSettingsInitialized = state => state.users.settingsInitialized;
 
 const getCurrentUserId = state => state.users.currentUser;
 export const getUsersById = state => state.users.byId;

--- a/frontend/src/js/store/utils.ts
+++ b/frontend/src/js/store/utils.ts
@@ -22,7 +22,8 @@ import {
   deploymentDisplayStates,
   deploymentStatesToSubstates,
   deploymentStatesToSubstatesWithSkipped,
-  emptyFilter
+  emptyFilter,
+  softwareIndicator
 } from './constants';
 
 // for some reason these functions can not be stored in the deviceConstants...
@@ -156,7 +157,7 @@ export const preformatWithRequestID = (res, failMsg) => {
 };
 
 export const ensureVersionString = (software, fallback) =>
-  software.length && software !== 'artifact_name' ? (software.endsWith('.version') ? software : `${software}.version`) : fallback;
+  software.length && software !== 'artifact_name' ? (software.endsWith(softwareIndicator) ? software : `${software}${softwareIndicator}`) : fallback;
 
 export const getComparisonCompatibleVersion = version => (isNaN(version.charAt(0)) && version !== 'next' ? 'master' : version);
 

--- a/frontend/tests/mockData.js
+++ b/frontend/tests/mockData.js
@@ -609,7 +609,15 @@ export const defaultState = {
     },
     rolesInitialized: true,
     settingsInitialized: true,
-    userSettings: { columnSelection: [], onboarding: { something: 'here' }, tooltips: {} }
+    userSettings: {
+      columnSelection: [],
+      onboarding: { something: 'here' },
+      tooltips: {},
+      reports: [
+        { attribute: 'artifact_name', chartType: 'pie', group: null, software: 'rootfs-image.version', type: 'distribution' },
+        { attribute: 'artifact_name', chartType: 'bar', group: 'testGroup', software: 'artifact_name', type: 'distribution' }
+      ]
+    }
   }
 };
 


### PR DESCRIPTION
This should limit device data retrieval to the visible device reports only + stagger the retrieval to reduce the likelihood of running into rate limits while doing so. Still there might be data retrieval duplication if devices correspond to multiple groups with different selected attributes/ all devices get retrieved with multiple attributes/ ...

Device retrieval is also further limited with this change + points users to contact support for clarification until backend support lands.