### PR TITLE
MEN-7744: Rate limits for authenticated requests

### DIFF
--- a/backend/services/deviceauth/cache/cache.go
+++ b/backend/services/deviceauth/cache/cache.go
@@ -63,7 +63,6 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
 	"github.com/mendersoftware/mender-server/pkg/ratelimits"
-	mredis "github.com/mendersoftware/mender-server/pkg/redis"
 
 	"github.com/mendersoftware/mender-server/services/deviceauth/model"
 	"github.com/mendersoftware/mender-server/services/deviceauth/utils"
@@ -147,23 +146,17 @@ type RedisCache struct {
 }
 
 func NewRedisCache(
-	ctx context.Context,
-	connectionString string,
+	redisClient redis.Cmdable,
 	prefix string,
 	limitsExpireSec int,
-) (*RedisCache, error) {
-	c, err := mredis.ClientFromConnectionString(ctx, connectionString)
-	if err != nil {
-		return nil, err
-	}
-
+) *RedisCache {
 	return &RedisCache{
-		c:               c,
+		c:               redisClient,
 		LimitsExpireSec: limitsExpireSec,
 		prefix:          prefix,
 		DefaultExpire:   time.Hour * 3,
 		clock:           utils.NewClock(),
-	}, err
+	}
 }
 
 func (rl *RedisCache) WithClock(c utils.Clock) *RedisCache {

--- a/backend/services/deviceauth/config.yaml
+++ b/backend/services/deviceauth/config.yaml
@@ -147,8 +147,48 @@
 # Overwrite with environment variable: DEVICEAUTH_REDIS_LIMITS_EXPIRE_SEC
 # redis_limits_expire_sec: "1800"
 
-
 #    Enable addon feature restrictions.
 #    Defaults to: false
 #    Overwrite with environment variable: DEVICEAUTH_HAVE_ADDONS
 # have_addons: false
+
+# ratelimits:
+#   # auth configures ratelimits for authenticated requests.
+#   auth:
+#     # enable rate limiting also requires redis_connection_string to be effective.
+#     enable: false
+#     # default rate limit group is the default ratelimiting parameters used when
+#     # no group `match`es the expressions.
+#     default:
+#       quota: 100    # number of request per
+#       interval: 60s # interval
+#       # event_expression is a go template for grouping requests.
+#       # The following attributes are available in the context:
+#       # Identity - contains a subset of the JWT claims:
+#         - .Subject  (jwt:"sub")          string
+#         - .Tenant   (jwt:"mender.tenant) string
+#         - .Plan     (jwt:"mender.plan)   string
+#         - .Addons   (jwt:"mender.addons) struct{Enabled bool; Name string}
+#         - .IsUser   (jwt:"mender.user)   bool
+#         - .IsDevice (jwt:"mender.device) bool
+#         - .Trial    (jwt:"mender.trial)  bool
+#       event_expression: "{{with .Identity}}{{.Subject}}{{end}}"
+#     # groups specify rate limiting groups that overrides the parameters in the
+#     # default group.
+#     groups: []
+#     # Example:
+#     # - name: "inventory"
+#     #   quota: 1
+#     #   interval: 60s
+#     #   event_expression: "{{with .Identity}}{{.Subject}}{{end}}"
+#     # match specifies matching expressions for mapping API requests to rate
+#     # limiting groups.
+#     match: []
+#     # Example:
+#     #   # api_pattern specifies an API path pattern as defined by http.ServeMux
+#     #   # https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+#     # - api_pattern: PATCH /api/devices/v1/inventory/device/attributes
+#     #   # group_expression defines the group for this matching expression.
+#     #   # a group can be selected dynamically using Go templates.
+#     #   # The template context is the same as ratelimits.default.event_expression
+#     #   group_expression: "inventory"

--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -1380,7 +1380,7 @@ func (d *DevAuth) cacheThrottleVerify(
 	origMethod,
 	origUri string,
 ) (string, error) {
-	if d.cache == nil {
+	if d.cache == nil || d.cTenant == nil {
 		return "", nil
 	}
 

--- a/backend/services/deviceauth/main.go
+++ b/backend/services/deviceauth/main.go
@@ -233,6 +233,7 @@ func doMain(args []string) {
 
 		// Enable setting config values by environment variables
 		config.Config.SetEnvPrefix("DEVICEAUTH")
+		config.Config.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 		config.Config.AutomaticEnv()
 
 		return nil

--- a/backend/services/deviceauth/server.go
+++ b/backend/services/deviceauth/server.go
@@ -26,7 +26,9 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/mendersoftware/mender-server/pkg/config"
+	"github.com/mendersoftware/mender-server/pkg/config/ratelimits"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/rate"
 	"github.com/mendersoftware/mender-server/pkg/redis"
 
 	api_http "github.com/mendersoftware/mender-server/services/deviceauth/api/http"
@@ -40,7 +42,7 @@ import (
 )
 
 func RunServer(c config.Reader) error {
-	var tenantadmAddr = c.GetString(dconfig.SettingTenantAdmAddr)
+	tenantadmAddr := c.GetString(dconfig.SettingTenantAdmAddr)
 
 	l := log.New(log.Ctx{})
 
@@ -102,35 +104,27 @@ func RunServer(c config.Reader) error {
 		devauth = devauth.WithTenantVerification(tc)
 	}
 
+	var apiOptions []api_http.Option
+
 	cacheConnStr := c.GetString(dconfig.SettingRedisConnectionString)
 	if cacheConnStr == "" {
 		// for backward compatibility check old redis_addr setting
 		cacheConnStr = c.GetString(dconfig.SettingRedisAddr)
 	}
 	if cacheConnStr != "" {
-		l.Infof("setting up redis cache")
-
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		redisClient, err := redis.ClientFromConnectionString(ctx, cacheConnStr)
-		cancel()
+		srvCache, rateLimits, err := setupRedis(c, cacheConnStr)
 		if err != nil {
-			return fmt.Errorf("failed to initialize redis client: %w", err)
+			return err
 		}
-
-		redisKeyPrefix := c.GetString(dconfig.SettingRedisKeyPrefix)
-		cache := cache.NewRedisCache(
-			redisClient,
-			redisKeyPrefix,
-			c.GetInt(dconfig.SettingRedisLimitsExpSec),
-		)
-		devauth = devauth.WithCache(cache)
+		devauth = devauth.WithCache(srvCache)
+		if rateLimits != nil {
+			apiOptions = append(apiOptions,
+				api_http.ConfigAuthVerifyRatelimits(rateLimits.MiddlewareGin),
+			)
+		}
 	}
 
-	apiHandler := api_http.NewRouter(devauth, db)
-
-	if err != nil {
-		return errors.Wrap(err, "device authentication API handlers setup failed")
-	}
+	apiHandler := api_http.NewRouter(devauth, db, apiOptions...)
 
 	addr := c.GetString(dconfig.SettingListen)
 	l.Printf("listening on %s", addr)
@@ -163,4 +157,35 @@ func RunServer(c config.Reader) error {
 		l.Error("error when shutting down the server ", err)
 	}
 	return nil
+}
+
+func setupRedis(c config.Reader, connStr string) (cache.Cache, *rate.HTTPLimiter, error) {
+	l := log.NewEmpty()
+	l.Infof("setting up redis cache")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	redisClient, err := redis.ClientFromConnectionString(ctx, connStr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize redis client: %w", err)
+	}
+
+	redisKeyPrefix := c.GetString(dconfig.SettingRedisKeyPrefix)
+	cache := cache.NewRedisCache(
+		redisClient,
+		redisKeyPrefix,
+		c.GetInt(dconfig.SettingRedisLimitsExpSec),
+	)
+
+	rateLimiter, err := ratelimits.SetupRedisRateLimits(
+		redisClient, c.GetString(dconfig.SettingRedisKeyPrefix), c,
+	)
+	if err != nil {
+		var configDisabled *ratelimits.ConfigDisabledError
+		if errors.As(err, &configDisabled) {
+			return cache, nil, nil
+		}
+		return nil, nil, fmt.Errorf("error configuring rate limits: %w", err)
+	}
+	return cache, rateLimiter, nil
 }


### PR DESCRIPTION
:warning: This PR uses #782

To test the rate limiting, you can use the following compose override which limits all deployments next calls to once per minute per device:
```bash
# Execute in the root of mender-server repository.
cat > docker-compose.override.yml <<EOF
services:
  deviceauth:
    command:
      - --debug
      - server
    environment:
      DEVICEAUTH_REDIS_CONNECTION_STRING: "redis://redis"
      DEVICEAUTH_RATELIMITS_AUTH_ENABLE: "1"
      DEVICEAUTH_RATELIMITS_AUTH_GROUPS: |
        {"name": "slow", "quota": 1, "interval": "1m", "event_expression": "{{ with .Identity }}{{ .Subject }}{{ end }}"}
      DEVICEAUTH_RATELIMITS_AUTH_MATCH: |
        {"api_pattern": "/api/devices/v1/deployments/", "group_expression": "slow"}
        {"api_pattern": "/api/devices/v2/deployments/", "group_expression": "slow"}
        {"api_pattern": "/api/devices/v1/deployments/device/deployments/next", "group_expression": "slow"}
  redis:
    image: redis:7.2

EOF
docker compose build deviceauth
docker compose up -d
```

<details>
<summary>docker-compose.override.yml</summary>

Following is an alternative compose override for configuring using YAML file:

```yaml
services:
  deviceauth:
    command:
      - --debug
      - server
    environment:
      DEVICEAUTH_REDIS_CONNECTION_STRING: "redis://redis"
    configs:
      - source: config.yaml
        target: /etc/deviceauth/config.yaml
  redis:
    image: redis:7.2

configs:
  config.yaml:
    content: |
      ratelimits:
        auth:
          enable: true
          groups:
            - name: slow
              quota: 1
              interval: 1m
              event_expression: "{{with .Identity}}{{.Subject}}{{end}}"
          match:
            - api_pattern: /api/devices/v1/deployments/
              group_expression: "slow"
```

</detalis>