### PR TITLE
MEN-7745: Add rate limiting support to authenticated useradm requests

### DIFF
--- a/backend/services/useradm/config.yaml
+++ b/backend/services/useradm/config.yaml
@@ -1,7 +1,6 @@
 # API server listen address
 # Defauls to: ":8080" which will listen on all avalable interfaces.
 listen: :8080
-
 # Private key path - used for JWT signing
 # Defaults to: /etc/useradm/rsa/private.pem
 # Overwrite with environment variable: USERADM_SERVER_PRIV_KEY_PATH
@@ -64,3 +63,38 @@ listen: :8080
 # Path to the file containing plan definitions
 # Defaults to: "/etc/useradm-enterprise/plans.yaml"
 # plan_definitions_path: "/etc/useradm-enterprise/plans.yaml"
+
+# Redis connection string
+#
+# connectionString URL format:
+# Standalone mode:
+# (redis|rediss|unix)://[<user>:<password>@](<host>|<socket path>)[:<port>[/<db_number>]][?option=value]
+# Cluster mode:
+# (redis|rediss|unix)[+srv]://[<user>:<password>@]<host1>[,<host2>[,...]][:<port>][?option=value]
+#
+# The following query parameters are also available:
+# client_name         string
+# conn_max_idle_time  duration
+# conn_max_lifetime   duration
+# dial_timeout        duration
+# max_idle_conns      int
+# max_retries         int
+# max_retry_backoff   duration
+# min_idle_conns      int
+# min_retry_backoff   duration
+# pool_fifo           bool
+# pool_size           int
+# pool_timeout        duration
+# protocol            int
+# read_timeout        duration
+# tls                 bool
+# write_timeout       duration
+#
+# Defaults to: "", which disables the Redis cache
+# Overwrite with environment variable: USERADM_REDIS_CONNECTION_STRING
+# redis_connection_string: ""
+
+# Redis key prefix
+# Defaults to: "useradm:v1"
+# Overwrite with environment variable: USERADM_REDIS_KEY_PREFIX
+# redis_key_prefix: ""

--- a/backend/services/useradm/config.yaml
+++ b/backend/services/useradm/config.yaml
@@ -98,3 +98,44 @@ listen: :8080
 # Defaults to: "useradm:v1"
 # Overwrite with environment variable: USERADM_REDIS_KEY_PREFIX
 # redis_key_prefix: ""
+
+# ratelimits:
+#  # auth configures ratelimits for authenticated requests.
+#   auth:
+#     # enable rate limiting also requires redis_connection_string to be effective.
+#     enable: false
+#     # default rate limit group is the default ratelimiting parameters used when
+#     # no group `match`es the expressions.
+#     default:
+#       quota: 100    # number of request per
+#       interval: 60s # interval
+#       # event_expression is a go template for grouping requests.
+#       # The following attributes are available in the context:
+#       # Identity - contains a subset of the JWT claims:
+#         - .Subject  (jwt:"sub")          string
+#         - .Tenant   (jwt:"mender.tenant) string
+#         - .Plan     (jwt:"mender.plan)   string
+#         - .Addons   (jwt:"mender.addons) struct{Enabled bool; Name string}
+#         - .IsUser   (jwt:"mender.user)   bool
+#         - .IsDevice (jwt:"mender.device) bool
+#         - .Trial    (jwt:"mender.trial)  bool
+#       event_expression: "{{with .Identity}}{{.Subject}}{{end}}"
+#     # groups specify rate limiting groups that overrides the parameters in the
+#     # default group.
+#     groups: []
+#     # Example:
+#     # - name: "slow"
+#     #   quota: 1
+#     #   interval: 30s
+#     #   event_expression: "{{with .Identity}}{{.Tenant}}{{end}}"
+#     # match specifies matching expressions for mapping API requests to rate
+#     # limiting groups.
+#     match: []
+#     # Example:
+#     #   # api_pattern specifies an API path pattern as defined by http.ServeMux
+#     #   # https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+#     # - api_pattern: /api/management/v1/useradm/slow/api
+#     #   # group_expression defines the group for this matching expression.
+#     #   # a group can be selected dynamically using Go templates.
+#     #   # The template context is the same as ratelimits.default.event_expression
+#     #   group_expression: "slow"

--- a/backend/services/useradm/config/config.go
+++ b/backend/services/useradm/config/config.go
@@ -54,6 +54,12 @@ const (
 	SettingDbUsername = "mongo_username"
 	SettingDbPassword = "mongo_password"
 
+	SettingRedisConnectionString        = "redis_connection_string"
+	SettingRedisConnectionStringDefault = ""
+
+	SettingRedisKeyPrefix        = "redis_key_prefix"
+	SettingRedisKeyPrefixDefault = "useradm:v1"
+
 	SettingLimitSessionsPerUser        = "limit_sessions_per_user"
 	SettingLimitSessionsPerUserDefault = 10
 
@@ -84,6 +90,8 @@ var (
 		{Key: SettingTenantAdmAddr, Value: SettingTenantAdmAddrDefault},
 		{Key: SettingDbSSL, Value: SettingDbSSLDefault},
 		{Key: SettingDbSSLSkipVerify, Value: SettingDbSSLSkipVerifyDefault},
+		{Key: SettingRedisConnectionString, Value: SettingRedisConnectionStringDefault},
+		{Key: SettingRedisKeyPrefix, Value: SettingRedisKeyPrefixDefault},
 		{Key: SettingLimitSessionsPerUser, Value: SettingLimitSessionsPerUserDefault},
 		{Key: SettingLimitTokensPerUser, Value: SettingLimitTokensPerUserDefault},
 		{Key: SettingTokenLastUsedUpdateFreqMinutes,

--- a/backend/services/useradm/main.go
+++ b/backend/services/useradm/main.go
@@ -163,6 +163,7 @@ func doMain(args []string) error {
 
 		// Enable setting conig values by environment variables
 		config.Config.SetEnvPrefix("USERADM")
+		config.Config.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 		config.Config.AutomaticEnv()
 
 		if config.Config.IsSet(SettingPlanDefinitions) {

--- a/backend/services/useradm/server.go
+++ b/backend/services/useradm/server.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/mendersoftware/mender-server/pkg/config"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/redis"
 
 	api_http "github.com/mendersoftware/mender-server/services/useradm/api/http"
 	"github.com/mendersoftware/mender-server/services/useradm/client/tenant"
@@ -145,6 +146,15 @@ func RunServer(c config.Reader) error {
 		})
 
 		ua = ua.WithTenantVerification(tc)
+	}
+
+	redisConnStr := c.GetString(SettingRedisConnectionString)
+	if redisConnStr != "" {
+		l.Infof("setting up redis cache")
+		client, err := redis.ClientFromConnectionString(context.Background(), redisConnStr)
+		if err != nil {
+			return err
+		}
 	}
 
 	useradmapi := api_http.NewUserAdmApiHandlers(ua, db, jwtHandlers,

--- a/backend/services/useradm/server.go
+++ b/backend/services/useradm/server.go
@@ -42,86 +42,13 @@ import (
 )
 
 func RunServer(c config.Reader) error {
-
 	l := log.New(log.Ctx{})
 
 	authorizer := &SimpleAuthz{}
 
-	// let's now go through all the existing keys and load them
-	jwtHandlers, err := addPrivateKeys(
-		l,
-		filepath.Dir(c.GetString(SettingServerPrivKeyPath)),
-		c.GetString(SettingServerPrivKeyFileNamePattern),
-	)
+	jwtHandlers, jwtFallbackHandler, err := loadJWTHandlers(c, l)
 	if err != nil {
-		return err
-	}
-
-	// the handler for keyId equal 0 is the one associated with the
-	// SettingServerPrivKeyPathDefault key. it is the one serving all the previously
-	// issued tokens (before the kid introduction in the JWTs)
-	defaultHandler, err := jwt.NewJWTHandler(
-		SettingServerPrivKeyPathDefault,
-		c.GetString(SettingServerPrivKeyFileNamePattern),
-	)
-	if err == nil && defaultHandler != nil {
-		// the key with id 0 is by default the default one. this allows
-		// to support tokens without "kid" in the header
-		// it is possible, that you rotated the default key, in which case you have to
-		// set USERADM_SERVER_PRIV_KEY_PATH=/etc/useradm/rsa/private.id.2048.pem
-		// where private.id.2048.pem is the new key, with new id. the new one will by default
-		// be used to issue new tokens, while any other token which has id that we have
-		// will be authorized against its matching key (by id from "kid" in JWT header)
-		// or which does not have "kid" will be authorized against the key with id 0.
-		// in other words: the key with id 0 (if not present as private.id.0.pem)
-		// is the default one, and all the JWT with no "kid" in headers are being
-		// checked against it.
-		jwtHandlers[common.KeyIdZero] = defaultHandler
-	}
-
-	// if the default path is different from the currently set key path
-	// we still have not loaded this key. this happens when the key rotation took place,
-	// someone exported USERADM_SERVER_PRIV_KEY_PATH=path-to-a-new-key and this key
-	// now will serve all. if we do not have this, the Login will fall back to the keyId
-	// from the filename and either use the KeyIdZero key or fail to find the key to issue a
-	// token if the one set in USERADM_SERVER_PRIV_KEY_PATH does have id in the filename
-	// (but does not exist because we have not loaded it)
-	// this also means that careless setting of USERADM_SERVER_PRIV_KEY_PATH to a key that does
-	// not match the SettingServerPrivKeyFileNamePattern will result in
-	// KeyIdZero handler overwrite and lack of back support for tokens signed by it.
-	if c.GetString(SettingServerPrivKeyPath) != SettingServerPrivKeyPathDefault {
-		defaultHandler, err = jwt.NewJWTHandler(
-			c.GetString(SettingServerPrivKeyPath),
-			c.GetString(SettingServerPrivKeyFileNamePattern),
-		)
-		if err == nil && defaultHandler != nil {
-			keyId := common.KeyIdFromPath(
-				c.GetString(SettingServerPrivKeyPath),
-				c.GetString(SettingServerPrivKeyFileNamePattern),
-			)
-			if keyId == common.KeyIdZero {
-				l.Warnf(
-					"currently set private key %s either does not match %s pattern"+
-						" or has explicitly set id=0. we are overridding the default"+
-						" private key handler with id=0",
-					c.GetString(SettingServerPrivKeyPath),
-					c.GetString(SettingServerPrivKeyFileNamePattern),
-				)
-			}
-			jwtHandlers[keyId] = defaultHandler
-		}
-	}
-
-	var jwtFallbackHandler jwt.Handler
-	fallback := c.GetString(SettingServerFallbackPrivKeyPath)
-	if err == nil && fallback != "" {
-		jwtFallbackHandler, err = jwt.NewJWTHandler(
-			fallback,
-			c.GetString(SettingServerPrivKeyFileNamePattern),
-		)
-	}
-	if err != nil {
-		return err
+		return fmt.Errorf("error loading JWT handlers: %w", err)
 	}
 
 	db, err := mongo.GetDataStoreMongo(dataStoreMongoConfigFromAppConfig(c))
@@ -208,11 +135,13 @@ func RunServer(c config.Reader) error {
 	return nil
 }
 
-func addPrivateKeys(
+func loadJWTHandlers(
+	c config.Reader,
 	l *log.Logger,
-	privateKeysDirectory string,
-	privateKeyPattern string,
-) (handlers map[int]jwt.Handler, err error) {
+) (handlers map[int]jwt.Handler, fallbackHandler jwt.Handler, err error) {
+	privateKeysDirectory := filepath.Dir(c.GetString(SettingServerPrivKeyPath))
+	privateKeyPattern := c.GetString(SettingServerPrivKeyFileNamePattern)
+
 	files, err := os.ReadDir(privateKeysDirectory)
 	if err != nil {
 		return
@@ -236,5 +165,72 @@ func addPrivateKeys(
 			handlers[keyId] = handler
 		}
 	}
-	return handlers, nil
+
+	// the handler for keyId equal 0 is the one associated with the
+	// SettingServerPrivKeyPathDefault key. it is the one serving all the previously
+	// issued tokens (before the kid introduction in the JWTs)
+	defaultHandler, err := jwt.NewJWTHandler(
+		SettingServerPrivKeyPathDefault,
+		c.GetString(SettingServerPrivKeyFileNamePattern),
+	)
+	if err == nil && defaultHandler != nil {
+		// the key with id 0 is by default the default one. this allows
+		// to support tokens without "kid" in the header
+		// it is possible, that you rotated the default key, in which case you have to
+		// set USERADM_SERVER_PRIV_KEY_PATH=/etc/useradm/rsa/private.id.2048.pem
+		// where private.id.2048.pem is the new key, with new id. the new one will by default
+		// be used to issue new tokens, while any other token which has id that we have
+		// will be authorized against its matching key (by id from "kid" in JWT header)
+		// or which does not have "kid" will be authorized against the key with id 0.
+		// in other words: the key with id 0 (if not present as private.id.0.pem)
+		// is the default one, and all the JWT with no "kid" in headers are being
+		// checked against it.
+		handlers[common.KeyIdZero] = defaultHandler
+	}
+
+	// if the default path is different from the currently set key path
+	// we still have not loaded this key. this happens when the key rotation took place,
+	// someone exported USERADM_SERVER_PRIV_KEY_PATH=path-to-a-new-key and this key
+	// now will serve all. if we do not have this, the Login will fall back to the keyId
+	// from the filename and either use the KeyIdZero key or fail to find the key to issue a
+	// token if the one set in USERADM_SERVER_PRIV_KEY_PATH does have id in the filename
+	// (but does not exist because we have not loaded it)
+	// this also means that careless setting of USERADM_SERVER_PRIV_KEY_PATH to a key that does
+	// not match the SettingServerPrivKeyFileNamePattern will result in
+	// KeyIdZero handler overwrite and lack of back support for tokens signed by it.
+	if c.GetString(SettingServerPrivKeyPath) != SettingServerPrivKeyPathDefault {
+		defaultHandler, err = jwt.NewJWTHandler(
+			c.GetString(SettingServerPrivKeyPath),
+			c.GetString(SettingServerPrivKeyFileNamePattern),
+		)
+		if err == nil && defaultHandler != nil {
+			keyId := common.KeyIdFromPath(
+				c.GetString(SettingServerPrivKeyPath),
+				c.GetString(SettingServerPrivKeyFileNamePattern),
+			)
+			if keyId == common.KeyIdZero {
+				l.Warnf(
+					"currently set private key %s either does not match %s pattern"+
+						" or has explicitly set id=0. we are overridding the default"+
+						" private key handler with id=0",
+					c.GetString(SettingServerPrivKeyPath),
+					c.GetString(SettingServerPrivKeyFileNamePattern),
+				)
+			}
+			handlers[keyId] = defaultHandler
+		}
+	}
+
+	fallback := c.GetString(SettingServerFallbackPrivKeyPath)
+	if err == nil && fallback != "" {
+		fallbackHandler, err = jwt.NewJWTHandler(
+			fallback,
+			c.GetString(SettingServerPrivKeyFileNamePattern),
+		)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return handlers, fallbackHandler, nil
 }

--- a/backend/services/useradm/server_test.go
+++ b/backend/services/useradm/server_test.go
@@ -17,15 +17,20 @@ import (
 	"testing"
 
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/services/useradm/config"
+	"github.com/spf13/viper"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddPrivateKeys(t *testing.T) {
 	l := log.New(log.Ctx{})
-	handlers, err := addPrivateKeys(l, "user/testdata", "private\\.id\\.([0-9]*)\\.pem")
+	c := viper.New()
+	c.Set(config.SettingServerPrivKeyPath, "./user/testdata/private-826.pem")
+	c.Set(config.SettingServerPrivKeyFileNamePattern, "private\\.id\\.([0-9]*)\\.pem")
+	handlers, fallbackHandler, err := loadJWTHandlers(c, l)
 	assert.NoError(t, err)
-	assert.Equal(t, 10, len(handlers)) // there are 10 keys matching the pattern
+	assert.Len(t, handlers, 11) // there are 10 keys matching the pattern + default key
 	assert.Contains(t, handlers, 1024)
 	assert.Contains(t, handlers, 13102)
 	assert.Contains(t, handlers, 14211)
@@ -36,4 +41,5 @@ func TestAddPrivateKeys(t *testing.T) {
 	assert.Contains(t, handlers, 5539)
 	assert.Contains(t, handlers, 826)
 	assert.Contains(t, handlers, 9478)
+	assert.Nil(t, fallbackHandler)
 }


### PR DESCRIPTION
:warning: NOTE: The 9 first commits are this separate PR: #782 
Please review first before proceeding with this one.

Example override for testing this feature:
```yaml
# docker-compose.override.yml
services:
  useradm:
    command:
      - --debug
      - server
      - --automigrate
    image: localhost:5000/useradm:MEN-7455
    environment:
      USERADM_REDIS_CONNECTION_STRING: "redis://redis"
      USERADM_RATELIMITS_AUTH_ENABLE: "1"
      USERADM_RATELIMITS_AUTH_GROUPS: |
        {"name": "slow", "quota": 1, "interval": "1m", "event_expression": "{{ with .Identity }}{{ .Subject }}{{ end }}"}
      USERADM_RATELIMITS_AUTH_MATCH: |
        {"api_pattern": "/api/management/v1/useradm/slow", "group_expression": "slow"}
        {"api_pattern": "/api/management/v1/useradm/slow/", "group_expression": "slow"}
  redis:
    image: redis:7.2
```
Any request to sub-paths of `/api/management/v1/useradm/slow` will be limited to 1 request per second.