### PR TITLE
MEN-7743: Distributed authentication rate limits (common parts)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.80.2
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/go-viper/mapstructure/v2 v2.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -73,7 +74,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gomodule/redigo v1.9.2 // indirect

--- a/backend/pkg/config/ratelimits/config.go
+++ b/backend/pkg/config/ratelimits/config.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package ratelimits
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mendersoftware/mender-server/pkg/config"
+	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/rate"
+	"github.com/mendersoftware/mender-server/pkg/redis"
+)
+
+type ConfigDisabledError struct {
+	Path string
+}
+
+func (err *ConfigDisabledError) Error() string {
+	return `configuration "` + err.Path + `" disabled`
+}
+
+func init() {
+	config.Config.SetDefault(SettingRatelimitsAuthDefaultInterval, "1m")
+	config.Config.SetDefault(SettingRatelimitsAuthDefaultQuota, "120")
+	config.Config.SetDefault(SettingRatelimitsAuthDefaultEventExpression,
+		"{{with .Identity}}{{.Subject}}{{end}}")
+}
+
+const (
+	SettingRatelimits                           = "ratelimits"
+	SettingRatelimitsAuth                       = SettingRatelimits + ".auth"
+	SettingRatelimitsAuthEnable                 = SettingRatelimitsAuth + ".enable"
+	SettingRatelimitsAuthGroups                 = SettingRatelimitsAuth + ".groups"
+	SettingRatelimitsAuthMatch                  = SettingRatelimitsAuth + ".match"
+	SettingRatelimitsAuthDefault                = SettingRatelimitsAuth + ".default"
+	SettingRatelimitsAuthDefaultQuota           = SettingRatelimitsAuthDefault + ".quota"
+	SettingRatelimitsAuthDefaultInterval        = SettingRatelimitsAuthDefault + ".interval"
+	SettingRatelimitsAuthDefaultEventExpression = SettingRatelimitsAuthDefault +
+		".event_expression"
+)
+
+func LoadRatelimits(c config.Reader) (*RatelimitConfig, error) {
+	if !c.GetBool(SettingRatelimitsAuthEnable) {
+		return nil, nil
+	}
+	ratelimitConfig := RatelimitConfig{
+		DefaultGroup: RatelimitParams{
+			Quota:           int64(c.GetInt(SettingRatelimitsAuthDefaultQuota)),
+			Interval:        config.Duration(c.GetDuration(SettingRatelimitsAuthDefaultInterval)),
+			EventExpression: c.GetString(SettingRatelimitsAuthDefaultEventExpression),
+		},
+	}
+	err := config.UnmarshalSliceSetting(c,
+		SettingRatelimitsAuthGroups,
+		&ratelimitConfig.RatelimitGroups,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error loading rate limit groups: %w", err)
+	}
+
+	err = config.UnmarshalSliceSetting(c,
+		SettingRatelimitsAuthMatch,
+		&ratelimitConfig.MatchExpressions,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error loading rate limit match expressions: %w", err)
+	}
+	return &ratelimitConfig, nil
+}
+
+func SetupRedisRateLimits(
+	redisClient redis.Client,
+	keyPrefix string,
+	c config.Reader,
+) (*rate.HTTPLimiter, error) {
+	if !c.GetBool(SettingRatelimitsAuthEnable) {
+		return nil, &ConfigDisabledError{
+			Path: SettingRatelimitsAuthEnable,
+		}
+	}
+	lims, err := LoadRatelimits(c)
+	if err != nil {
+		return nil, err
+	}
+	log.NewEmpty().Debugf("loaded rate limit configuration: %v", lims)
+	defaultPrefix := fmt.Sprintf("%s:rate:default", keyPrefix)
+	defaultLimiter := redis.NewFixedWindowRateLimiter(
+		redisClient, defaultPrefix,
+		time.Duration(lims.DefaultGroup.Interval), lims.DefaultGroup.Quota,
+	)
+	mux, err := rate.NewHTTPLimiter(
+		defaultLimiter,
+		c.GetString(SettingRatelimitsAuthDefaultEventExpression),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up rate limits: %w", err)
+	}
+	for _, group := range lims.RatelimitGroups {
+		groupPrefix := fmt.Sprintf("%s:rate:g:%s", keyPrefix, group.Name)
+		limiter := redis.NewFixedWindowRateLimiter(
+			redisClient, groupPrefix, time.Duration(group.Interval), group.Quota,
+		)
+		err = mux.AddRateLimitGroup(limiter, group.Name, group.EventExpression)
+		if err != nil {
+			return nil, fmt.Errorf("error setting up rate limit group %s: %w", group.Name, err)
+		}
+	}
+	for _, expr := range lims.MatchExpressions {
+		err = mux.AddMatchExpression(expr.APIPattern, expr.GroupExpression)
+		if err != nil {
+			return nil, fmt.Errorf("error setting up match patterns: %w", err)
+		}
+	}
+	return mux, nil
+}

--- a/backend/pkg/config/ratelimits/ratelimits.go
+++ b/backend/pkg/config/ratelimits/ratelimits.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package ratelimits
+
+import "github.com/mendersoftware/mender-server/pkg/config"
+
+type RatelimitConfig struct {
+	// DefaultGroup configures the fallback ratelimiter when the MatchExpressions
+	// does not match any groups.
+	DefaultGroup RatelimitParams `json:"default"`
+	// RatelimitGroups configures the ratelimiter parameters for a named ratelimit
+	// group.
+	RatelimitGroups []RatelimitGroupParams `json:"groups"`
+	// MatchExpressions configures mathing expressions (API pattern) and mapping
+	// them to a group.
+	MatchExpressions []MatchGroup `json:"match"`
+}
+
+type RatelimitGroupParams struct {
+	// Name of the group
+	Name string `json:"name"`
+	RatelimitParams
+}
+
+type RatelimitParams struct {
+	// Quota is the number of requests that can be made within Interval
+	Quota int64 `json:"quota"`
+
+	// Interval is the time for the rate limit algorithm to reset.
+	Interval config.Duration `json:"interval"`
+
+	// EventExpression specifies a Go template for grouping events (requests)
+	// when invoking the rate limiter. For example:
+	// {{.Identity.Subject}}{{/* Group by JWT subject (user ID) */}}
+	// {{.Identity.Tenant}}{{/* Group by tenant ID (shared quota) */}}
+	EventExpression string `json:"event_expression"`
+}
+
+type MatchGroup struct {
+	// APIPattern matches method and path of the incoming request using pattern
+	// from Go standard library ServeMux.
+	// https://pkg.go.dev/net/http#hdr-Patterns-ServeMux
+	APIPattern string `json:"api_pattern"`
+
+	// GroupExpression is a template string for selecting rate limit group.
+	GroupExpression string `json:"group_expression,omitempty"`
+}

--- a/backend/pkg/config/unmarshal.go
+++ b/backend/pkg/config/unmarshal.go
@@ -19,10 +19,22 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/pkg/errors"
 )
+
+type Duration time.Duration
+
+func (duration *Duration) UnmarshalText(b []byte) error {
+	d, err := time.ParseDuration(string(b))
+	if err != nil {
+		return err
+	}
+	*duration = Duration(d)
+	return nil
+}
 
 // UnmarshalSliceSetting will unmarshal an array of objects into the result T
 // using either newline separated json objects for strings (from env) or

--- a/backend/pkg/config/unmarshal.go
+++ b/backend/pkg/config/unmarshal.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/pkg/errors"
+)
+
+// UnmarshalSliceSetting will unmarshal an array of objects into the result T
+// using either newline separated json objects for strings (from env) or
+// an array of objects (using json struct tag) for any configuration source
+// that is able to express a slice of objects.
+func UnmarshalSliceSetting[T any](c Reader, path string, result *[]T) error {
+	if result == nil {
+		return errors.New("cannot unmarshal setting to nil result")
+	}
+	value := c.Get(path)
+	var err error
+	switch cfg := value.(type) {
+	case string:
+		decoder := json.NewDecoder(strings.NewReader(cfg))
+		for {
+			var elem T
+			err = decoder.Decode(&elem)
+			if err != nil {
+				break
+			}
+			*result = append(*result, elem)
+		}
+		if errors.Is(err, io.EOF) {
+			err = nil
+		}
+	case []any:
+		var decoder *mapstructure.Decoder
+		decoder, err = mapstructure.NewDecoder(
+			&mapstructure.DecoderConfig{
+				TagName: "json",
+				Result:  &result,
+				Squash:  true,
+				DecodeHook: mapstructure.ComposeDecodeHookFunc(
+					mapstructure.TextUnmarshallerHookFunc(),
+					mapstructure.StringToTimeDurationHookFunc(),
+				),
+			},
+		)
+		if err != nil {
+			return err
+		}
+		err = decoder.Decode(value)
+	case nil:
+		// pass (empty config)
+	default:
+		err = fmt.Errorf("invalid config type %T", cfg)
+	}
+	return err
+}

--- a/backend/pkg/config/unmarshal_test.go
+++ b/backend/pkg/config/unmarshal_test.go
@@ -1,0 +1,187 @@
+// Copyright 2025 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+)
+
+type testConfig struct {
+	Foo string   `json:"foo"`
+	Bar float64  `json:"bar"`
+	Dur Duration `json:"dur"`
+}
+
+func TestUnmarshalSliceSetting(t *testing.T) {
+	configData := []testConfig{
+		{Foo: "first_foo", Bar: 9.1, Dur: Duration(time.Nanosecond)},
+		{Foo: "second_foo", Bar: 8.2, Dur: Duration(time.Microsecond)},
+		{Foo: "third_foo", Bar: 7.3, Dur: Duration(time.Millisecond)},
+		{Foo: "fourth_foo", Bar: 6.4, Dur: Duration(time.Second)},
+		{Foo: "fifth_foo", Bar: 5.5, Dur: Duration(time.Minute)},
+		{Foo: "sixth_foo", Bar: 4.6, Dur: Duration(time.Hour)},
+		{Foo: "seventh_foo", Bar: 3.7},
+		{Foo: "eighth_foo", Bar: 2.8},
+		{Foo: "ninth_foo", Bar: 1.9},
+		{Foo: "tenth_foo", Bar: 0.0},
+	}
+	const configFileData = `
+---
+test:
+- foo: first_foo
+  bar: 9.1
+  dur: 1ns
+- foo: second_foo
+  bar: 8.2
+  dur: 1us
+- foo: third_foo
+  bar: 7.3
+  dur: 1ms
+- foo: fourth_foo
+  bar: 6.4
+  dur: 1s
+- foo: fifth_foo
+  bar: 5.5
+  dur: 1m
+- foo: sixth_foo
+  bar: 4.6
+  dur: 1h
+- foo: seventh_foo
+  bar: 3.7
+- foo: eighth_foo
+  bar: 2.8
+- foo: ninth_foo
+  bar: 1.9
+- foo: tenth_foo
+  bar: 0.0
+`
+	const configEnvDataProducts = `
+{"foo": "first_foo",   "bar": 9.1, "dur": "1ns"}
+{"foo": "second_foo",  "bar": 8.2, "dur": "1us"}
+{"foo": "third_foo",   "bar": 7.3, "dur": "1ms"}
+{"foo": "fourth_foo",  "bar": 6.4, "dur": "1s"}
+{"foo": "fifth_foo",   "bar": 5.5, "dur": "1m"}
+{"foo": "sixth_foo",   "bar": 4.6, "dur": "1h"}
+{"foo": "seventh_foo", "bar": 3.7}
+{"foo": "eighth_foo",  "bar": 2.8}
+{"foo": "ninth_foo",   "bar": 1.9}
+{"foo": "tenth_foo",   "bar": 0.0}
+`
+	evalAndCompare := func(cfg *viper.Viper) {
+		var result []testConfig
+		err := UnmarshalSliceSetting(cfg, "test", &result)
+		if err != nil {
+			t.Errorf("error loading offers: %s", err.Error())
+			return
+		}
+		for i, item := range configData {
+			if i >= len(result) {
+				t.Errorf("missing item[%d]: %v", i, item)
+				continue
+			} else if !reflect.DeepEqual(item, result[i]) {
+				t.Errorf("item[%d] does not match expectations: %v (actual) != %v (expected)",
+					i, result[i], item)
+			}
+		}
+	}
+
+	t.Run("load from file", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		err := os.WriteFile(configFile, []byte(configFileData), 0666)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		cfg := viper.New()
+		cfg.SetConfigFile(configFile)
+		err = cfg.ReadInConfig()
+		if err != nil {
+			t.Errorf("unexpected error loading config file: %s", err)
+			return
+		}
+		evalAndCompare(cfg)
+	})
+	t.Run("load from env", func(t *testing.T) {
+		t.Setenv(
+			"TEST",
+			configEnvDataProducts,
+		)
+		cfg := viper.New()
+		cfg.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+		cfg.AutomaticEnv()
+		evalAndCompare(cfg)
+	})
+	t.Run("bad data from config env", func(t *testing.T) {
+		t.Setenv("TEST_CONFIG", "false")
+		var result []testConfig
+		cfg := viper.New()
+		cfg.AutomaticEnv()
+		err := UnmarshalSliceSetting(cfg, "test_config", &result)
+		var target *json.UnmarshalTypeError
+		if err == nil {
+			t.Errorf("expected an error, but got none")
+		} else if !errors.As(err, &target) {
+			t.Errorf("unexpected error type, expected %T error, "+
+				"received: %T %s", target, err, err.Error())
+		}
+	})
+	t.Run("bad data from config", func(t *testing.T) {
+		var result []testConfig
+		cfg := viper.New()
+		cfg.Set("test_config", []any{"foobar"})
+		err := UnmarshalSliceSetting(cfg, "test_config", &result)
+		var target *mapstructure.DecodeError
+		if err == nil {
+			t.Errorf("expected an error, but got none")
+		} else if !errors.As(err, &target) {
+			t.Errorf("unexpected error type, expected %T error, "+
+				"received: %T %s", target, err, err.Error())
+		}
+	})
+	t.Run("invalid config type", func(t *testing.T) {
+		var result []testConfig
+		cfg := viper.New()
+		cfg.Set("test_config", 420.69)
+		err := UnmarshalSliceSetting(cfg, "test_config", &result)
+		if err == nil {
+			t.Errorf("expected an error, but got none")
+		} else if err.Error() != "invalid config type float64" {
+			t.Errorf("unexpected error message: %s", err.Error())
+		}
+	})
+	t.Run("pointer receiver cannot be nil", func(t *testing.T) {
+		var result *[]testConfig
+		cfg := viper.New()
+		cfg.Set("test_config", configEnvDataProducts)
+		err := UnmarshalSliceSetting(cfg, "test_config", result)
+		if err == nil {
+			t.Errorf("expected an error, but got none")
+		} else if err.Error() != "cannot unmarshal setting to nil result" {
+			t.Errorf("unexpected error message: %s", err.Error())
+		}
+	})
+}

--- a/backend/pkg/rate/limit.go
+++ b/backend/pkg/rate/limit.go
@@ -11,7 +11,17 @@ import (
 // but extending the interface with the ability to expose internal errors.
 type Limiter interface {
 	Reserve(ctx context.Context) (Reservation, error)
-	Tokens(ctx context.Context) (uint64, error)
+}
+
+type LimiterFunc func(context.Context) (Reservation, error)
+
+func (f LimiterFunc) Reserve(ctx context.Context) (Reservation, error) {
+	return f(ctx)
+}
+
+// EventLimiter allows grouping limiters by eventID.
+type EventLimiter interface {
+	ReserveEvent(ctx context.Context, eventID string) (Reservation, error)
 }
 
 // Reservation is a point-in-time reservation of a ratelimit token. If the token
@@ -21,7 +31,7 @@ type Limiter interface {
 type Reservation interface {
 	OK() bool
 	Delay() time.Duration
-	Tokens() uint64
+	Tokens() int64
 }
 
 type limiter rate.Limiter
@@ -38,22 +48,14 @@ func (lim *limiter) Reserve(context.Context) (Reservation, error) {
 		time:        now,
 	}
 	if res.OK() {
-		res.tokens = uint64(goLimiter.TokensAt(now))
+		res.tokens = int64(goLimiter.TokensAt(now))
 	}
 	return res, nil
 }
 
-func (lim *limiter) Tokens(context.Context) (uint64, error) {
-	goLimiter := (*rate.Limiter)(lim)
-	if tokens := goLimiter.Tokens(); tokens > 0 {
-		return uint64(tokens), nil
-	}
-	return 0, nil
-}
-
 type reservation struct {
 	time        time.Time
-	tokens      uint64
+	tokens      int64
 	reservation *rate.Reservation
 }
 
@@ -65,6 +67,6 @@ func (r *reservation) Delay() time.Duration {
 	return r.reservation.DelayFrom(r.time)
 }
 
-func (r *reservation) Tokens() uint64 {
+func (r *reservation) Tokens() int64 {
 	return r.tokens
 }

--- a/backend/pkg/rate/limit_http.go
+++ b/backend/pkg/rate/limit_http.go
@@ -1,0 +1,254 @@
+package rate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"text/template"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mendersoftware/mender-server/pkg/identity"
+	"github.com/mendersoftware/mender-server/pkg/requestid"
+	"github.com/mendersoftware/mender-server/pkg/rest.utils"
+)
+
+// TooManyRequestsError is the error type returned when hitting the rate
+// limits.
+type TooManyRequestsError struct {
+	Delay time.Duration
+}
+
+func (err *TooManyRequestsError) Error() string {
+	return "too many requests"
+}
+
+type templateEventLimiter struct {
+	limiter       EventLimiter
+	eventTemplate *template.Template
+}
+
+// HTTPLimiter combines a set of EventLimiter (groups) and a http.ServeMux
+// for routing API endpoints to a EventLimiter.
+//
+// Every EventLimiter comes with an eventTemplate for grouping events by
+// a Go template expression. The data to the Go template can be customized by
+// calling WithTemplateDataFunc and WithTemplateFuncs.
+//
+// Additional routes are added by calling MatchHTTPPattern which accepts a HTTP
+// pattern and a target group which also accepts Go template expressions.
+//
+// The HTTPLimiter implements both the standard http.Handler and
+// gin.HandlerFunc (see (*HTTPLimiter).MiddlewareGin) for use with either the
+// standard library or as a middleware for the gin-gonic framework.
+type HTTPLimiter struct {
+	// rootTemplate stores the root Template that is inherited by all
+	// template string parameters (event and group strings).
+	rootTemplate *template.Template
+	// templateDataCallback is a callback that is called before executing
+	// template strings and should output the template data used.
+	//
+	// See defaultTemplateData.
+	templateDataCallback func(r *http.Request) any
+
+	// httpMux implements the request router to a ratelimiter match instance
+	httpMux *http.ServeMux
+
+	// defaultLimiter is the default rate limiter if no group matches.
+	defaultLimiter *templateEventLimiter
+	// limiterGroups maps the group name to rate limiters.
+	limiterGroups map[string]*templateEventLimiter
+
+	// rewriteRequests decides whether to autmatically rewrite the request
+	// URL using X-Forwarded-* headers.
+	rewriteRequests bool
+}
+
+// defaultTemplateData is the default callback for executing template strings.
+func defaultTemplateData(r *http.Request) any {
+	id := identity.FromContext(r.Context())
+	ctx := map[string]any{
+		"Identity": id,
+		// "Request":  r, // not needed, but could be handy
+	}
+	return ctx
+}
+
+// NewHTTPLimiter initializes a new HTTPLimiter using defaultLimiter as the
+// default ratelimiter using defaultEventTemplate for grouping events.
+// See HTTPLimiter.
+func NewHTTPLimiter(
+	defaultLimiter EventLimiter,
+	defaultEventTemplate string,
+) (*HTTPLimiter, error) {
+	template, err := template.New("").Parse(defaultEventTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("invalid eventTemplate: %w", err)
+	}
+	return &HTTPLimiter{
+		rootTemplate:         template.New("").Option("missingkey=zero"),
+		httpMux:              http.NewServeMux(),
+		templateDataCallback: defaultTemplateData,
+		defaultLimiter: &templateEventLimiter{
+			limiter:       defaultLimiter,
+			eventTemplate: template,
+		},
+		limiterGroups: make(map[string]*templateEventLimiter),
+	}, nil
+}
+
+func (h *HTTPLimiter) WithTemplateDataFunc(f func(*http.Request) any) *HTTPLimiter {
+	h.templateDataCallback = f
+	return h
+}
+
+func (h *HTTPLimiter) WithTemplateFuncs(funcs map[string]any) *HTTPLimiter {
+	h.rootTemplate.Funcs(funcs)
+	return h
+}
+
+func (h *HTTPLimiter) WithRewriteRequests(rewrite bool) *HTTPLimiter {
+	h.rewriteRequests = rewrite
+	return h
+}
+
+func (h *HTTPLimiter) AddRateLimitGroup(limiter EventLimiter, group, eventTemplate string) error {
+	t, err := h.rootTemplate.Clone()
+	if err == nil {
+		_, err = t.Parse(eventTemplate)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to compile event template: %w", err)
+	}
+	h.limiterGroups[group] = &templateEventLimiter{
+		limiter:       limiter,
+		eventTemplate: t,
+	}
+	return nil
+}
+
+func (h *HTTPLimiter) AddMatchExpression(
+	pattern, groupTemplate string,
+) error {
+	var (
+		t   *template.Template
+		err error
+	)
+	if groupTemplate != "" {
+		// Compile eventTemplate:
+		t, err = h.rootTemplate.Clone()
+		if err == nil {
+			_, err = t.Parse(groupTemplate)
+		}
+		if err != nil {
+			return fmt.Errorf("error parsing group_template: %w", err)
+		}
+	}
+	limiterMatcher := matcher{
+		HTTPLimiter:   h,
+		groupTemplate: t,
+	}
+	h.httpMux.Handle(pattern, limiterMatcher)
+	return nil
+}
+
+// matcher is the HTTPHandle
+type matcher struct {
+	*HTTPLimiter
+	groupTemplate *template.Template
+}
+
+func (h *HTTPLimiter) handleRequest(r *http.Request) error {
+	if h.rewriteRequests {
+		r = rest.RewriteForwardedRequest(r)
+	}
+	res, err := h.Reserve(r)
+	if err != nil {
+		return err
+	}
+	if res == nil || res.OK() {
+		return nil
+	} else {
+		return &TooManyRequestsError{
+			Delay: res.Delay(),
+		}
+	}
+}
+
+func handleError(ctx context.Context, w http.ResponseWriter, err error) {
+	var tooManyRequests *TooManyRequestsError
+	status := http.StatusInternalServerError
+	hdr := w.Header()
+	hdr.Set("Content-Type", "application/json")
+	if errors.As(err, &tooManyRequests) {
+		status = http.StatusTooManyRequests
+		retryAfter := int64(math.Ceil(tooManyRequests.Delay.Abs().Seconds()))
+		hdr.Set("Retry-After", strconv.FormatInt(retryAfter, 10))
+	}
+	w.WriteHeader(status)
+	b, _ := json.Marshal(rest.Error{
+		Err:       err.Error(),
+		RequestID: requestid.FromContext(ctx),
+	})
+	_, _ = w.Write(b)
+}
+
+// ServeHTTP implements a basic http.Handler so that handler can be used
+// as a handler for the mux. It will only write on errors and is expected
+// to continue to the actual handler on success.
+func (h *HTTPLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := h.handleRequest(r)
+	if err != nil {
+		handleError(r.Context(), w, err)
+	}
+}
+
+// MiddlewareGin implements rate limiting as a middleware for gin-gonic
+// web framework.
+func (h *HTTPLimiter) MiddlewareGin(c *gin.Context) {
+	err := h.handleRequest(c.Request)
+	if err != nil {
+		_ = c.Error(err)
+		handleError(c.Request.Context(), c.Writer, err)
+		c.Abort()
+	}
+}
+
+type okReservation struct{}
+
+func (k okReservation) OK() bool             { return true }
+func (k okReservation) Delay() time.Duration { return 0 }
+func (k okReservation) Tokens() int64        { return math.MaxInt64 }
+
+func (m *HTTPLimiter) Reserve(r *http.Request) (Reservation, error) {
+	var b bytes.Buffer
+	eventLimiter := m.defaultLimiter
+	templateData := m.templateDataCallback(r)
+	ctx := r.Context()
+	h, _ := m.httpMux.Handler(r)
+	hh, ok := h.(matcher)
+	if ok {
+		if hh.groupTemplate != nil {
+			err := hh.groupTemplate.Execute(&b, templateData)
+			if err != nil {
+				return nil, fmt.Errorf("error executing ratelimit group template: %w", err)
+			}
+			eventLimiter = m.limiterGroups[b.String()]
+			if eventLimiter == nil {
+				return okReservation{}, nil
+			}
+			b.Reset()
+		}
+	}
+	err := eventLimiter.eventTemplate.Execute(&b, templateData)
+	if err != nil {
+		return nil, fmt.Errorf("error executing template for event ID: %w", err)
+	}
+	return eventLimiter.limiter.ReserveEvent(ctx, b.String())
+}

--- a/backend/pkg/rate/limit_http_test.go
+++ b/backend/pkg/rate/limit_http_test.go
@@ -1,0 +1,181 @@
+package rate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mendersoftware/mender-server/pkg/accesslog"
+	"github.com/mendersoftware/mender-server/pkg/identity"
+)
+
+type eventLimiter struct {
+	limiters map[string]Limiter
+	quota    int
+	interval time.Duration
+	mu       sync.Mutex
+}
+
+func NewEventLimiter(q int, i time.Duration) EventLimiter {
+	return &eventLimiter{
+		quota:    q,
+		interval: i,
+		limiters: make(map[string]Limiter),
+	}
+}
+
+func (lim *eventLimiter) ReserveEvent(ctx context.Context, eventID string) (Reservation, error) {
+	fmt.Fprintf(os.Stderr, "ReserveEvent(ctx, %q)\n", eventID)
+	lim.mu.Lock()
+	if lim.limiters == nil {
+		if lim.limiters == nil {
+			lim.limiters = make(map[string]Limiter)
+		}
+	}
+	l, ok := lim.limiters[eventID]
+	if !ok {
+		l = NewLimiter(lim.quota, lim.interval)
+		lim.limiters[eventID] = l
+	}
+	lim.mu.Unlock()
+	return l.Reserve(ctx)
+}
+
+func newHTTPLimiterForTesting(t *testing.T) *HTTPLimiter {
+	t.Helper()
+	httpLimiter, err := NewHTTPLimiter(NewEventLimiter(10, time.Hour*24), `{{ .Header.Get "X-Userid" }}`)
+	if err != nil {
+		t.Errorf("unexpected error initializing HTTPLimiter: %s", err)
+		return nil
+	}
+	httpLimiter.AddRateLimitGroup(NewEventLimiter(1, time.Hour), "slow", `slow`)
+	httpLimiter.AddRateLimitGroup(NewEventLimiter(1, time.Hour*24), "superslow", `superslow`)
+	httpLimiter.AddRateLimitGroup(NewEventLimiter(1, time.Microsecond), "fast", `fast`)
+	httpLimiter.AddRateLimitGroup(NewEventLimiter(5, time.Hour), "sub", `{{with .Identity }}{{.Subject}}{{end}}`)
+	httpLimiter.AddRateLimitGroup(NewEventLimiter(5, time.Hour), "bad_event", `{{.Foo.Bar | index 123}}`)
+
+	httpLimiter.AddMatchExpression("/slow/", "slow")
+	httpLimiter.AddMatchExpression("POST /slow/superslow", "superslow")
+	httpLimiter.AddMatchExpression("/fast/", "fast")
+	httpLimiter.AddMatchExpression("/group/", `{{ .Header.Get "X-Test-Group"}}`)
+	httpLimiter.AddMatchExpression("/subject/", `sub`)
+	httpLimiter.AddMatchExpression("/bad_event/", `bad_event`)
+	httpLimiter.AddMatchExpression("/bad_group/", `{{.Foo.Bar | index 123}}`)
+	httpLimiter.AddMatchExpression("/okiedokie/", `n/a`) // should return okResrevation
+	return httpLimiter
+}
+
+func TestHTTPLimiter(t *testing.T) {
+	t.Parallel()
+
+	limiter := newHTTPLimiterForTesting(t)
+	limiter.WithTemplateDataFunc(func(r *http.Request) any {
+		return r
+	})
+
+	t.Run("ServeHTTP", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "http://localhost/", nil)
+		for range 10 {
+			w := httptest.NewRecorder()
+			limiter.ServeHTTP(w, req)
+			if w.Code != 200 {
+				t.Errorf("did not expect ServeHTTP to write response: received status %d", w.Code)
+				t.Errorf("response body: %s", w.Body)
+			}
+		}
+		// The 10th request should trip the rate limiter
+		w := httptest.NewRecorder()
+		limiter.ServeHTTP(w, req)
+		if w.Code != http.StatusTooManyRequests {
+			t.Errorf("expected status code %d, received: %d", http.StatusTooManyRequests, w.Code)
+		}
+
+		w = httptest.NewRecorder()
+		req.Header.Set("X-Userid", "another user")
+		limiter.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected status code %d, received: %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("Reserve", func(t *testing.T) {
+		t.Parallel()
+		reqFast, _ := http.NewRequest("GET", "http://localhost/fast/apis", nil)
+		res, _ := limiter.Reserve(reqFast)
+		if !res.OK() {
+			t.Error("unexpected rate limit on first request to fast rate limiter")
+		} else {
+			time.Sleep(time.Microsecond)
+			res, _ = limiter.Reserve(reqFast)
+			if !res.OK() {
+				t.Error("unexpected rate limit after waiting on fast request")
+			}
+		}
+
+		reqSuperSlow, _ := http.NewRequest("POST", "http://localhost/slow/superslow", nil)
+		res, _ = limiter.Reserve(reqSuperSlow)
+		if !res.OK() {
+			t.Errorf("unexpected rate limit for superslow request")
+		} else {
+			res, _ = limiter.Reserve(reqSuperSlow)
+			if res.OK() {
+				t.Errorf("request to superslow should get rate limited")
+			} else if res.Delay() < time.Hour*23 && res.Delay() > time.Hour*25 {
+				t.Errorf("superslow request delay is not close to 24h: actual: %s", res.Delay())
+			}
+		}
+		reqOkieDokie, _ := http.NewRequest("GET", "http://localhost/okiedokie/foobar", nil)
+		res, _ = limiter.Reserve(reqOkieDokie)
+		if _, ok := res.(okReservation); !ok {
+			t.Errorf("expected *okReservation, received: %T", res)
+		} else if !res.OK() {
+			t.Error("the request was not expected to be rate limited")
+		}
+	})
+	const jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+		"eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9" +
+		"lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0." +
+		"KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30"
+	t.Run("MiddlewareGin", func(t *testing.T) {
+		limiterGin := newHTTPLimiterForTesting(t)
+		handler := gin.New()
+		handler.Use(accesslog.Middleware(), identity.Middleware(), limiterGin.MiddlewareGin)
+		handler.Handle("GET", "/subject/foo", func(ctx *gin.Context) { ctx.Status(http.StatusOK) })
+		req, _ := http.NewRequest("GET", "http://localhost/subject/foo", nil)
+		req.Header.Set("Authorization", "Bearer "+jwt)
+		for range 5 {
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("unexpected status code: %d, expected: %d", w.Code, http.StatusOK)
+			}
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusTooManyRequests {
+			t.Errorf("unexpected status code: %d, expected: %d", w.Code, http.StatusTooManyRequests)
+		}
+		req.URL.Path = "/bad_event/"
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("unexpected status code: %d, expected: %d", w.Code, http.StatusInternalServerError)
+			t.Error("expected template execution to fail")
+		}
+		req.URL.Path = "/bad_group/"
+		w = httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("unexpected status code: %d, expected: %d", w.Code, http.StatusInternalServerError)
+			t.Error("expected template execution to fail")
+		}
+	})
+}

--- a/backend/pkg/rest.utils/request.go
+++ b/backend/pkg/rest.utils/request.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package rest
+
+import (
+	"net/http"
+	"net/url"
+)
+
+const (
+	HeaderForwardedURI    = "X-Forwarded-Uri"
+	HeaderForwardedHost   = "X-Forwarded-Host"
+	HeaderForwardedMethod = "X-Forwarded-Method"
+)
+
+// RewriteForwardedRequest makes a shallow clone of request and replaces
+// the URL and Method with X-Forwarded-* headers.
+func RewriteForwardedRequest(request *http.Request) *http.Request {
+	if request == nil {
+		return nil
+	}
+	newRequest := new(http.Request)
+	*newRequest = *request
+	uri := request.Header.Get(HeaderForwardedURI)
+	if uri != "" {
+		var err error
+		newRequest.URL, err = url.ParseRequestURI(uri)
+		if err != nil {
+			panic(err)
+		}
+		newRequest.RequestURI = uri
+	} else {
+		newRequest.URL = new(url.URL)
+		*newRequest.URL = *request.URL
+	}
+	host := request.Header.Get(HeaderForwardedHost)
+	if host != "" {
+		newRequest.URL.Host = host
+	}
+	method := request.Header.Get(HeaderForwardedMethod)
+	if method != "" {
+		newRequest.Method = method
+	}
+	return newRequest
+}

--- a/backend/pkg/rest.utils/request_test.go
+++ b/backend/pkg/rest.utils/request_test.go
@@ -1,0 +1,32 @@
+package rest
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRewriteForwardedRequest(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "http://localhost/foo/bar", nil)
+	r.Header.Set("X-Forwarded-Method", http.MethodPost)
+	r.Header.Set("X-Forwarded-Host", "hosted.mender.io")
+	r.Header.Set("X-Forwarded-Uri", "/bar/baz")
+
+	rf := RewriteForwardedRequest(r)
+	if rf.Method != http.MethodPost {
+		t.Errorf("unexpected method in forwarded request: %s (actual) != %s (expected)",
+			rf.Method, http.MethodPost)
+	}
+
+	if rf.URL.Host != "hosted.mender.io" {
+		t.Errorf("unexpected host in forwarded request: %s (actual) != hosted.mender.io",
+			rf.URL.Host)
+	}
+
+	if rf.URL.Path != "/bar/baz" {
+		t.Errorf("unexpected path in forwraded request: %s (actual) != /bar/baz", rf.URL.Path)
+	}
+
+	if r := RewriteForwardedRequest(nil); r != nil {
+		t.Errorf("unexpected result rewriting nil request: %v", *r)
+	}
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,6 +6,7 @@ const commonScopes = [
   'deviceconnect',
   'inventory',
   'iot-manager',
+  'pkg',
   'reporting',
   'useradm',
   'workflows',


### PR DESCRIPTION
This PR contains the common parts for useradm and deviceauth for creating distributed ratelimits for authenticated requests (for token verification). The PR contains the following components:
* Extending the existing rate limiting interface with `EventLimiter`
* A new HTTPLimiter implementation
  * Maps request patterns to different rate limiting instances
    * Allows independent rate limiting (with different parameters) for different API groups
  * Is currently only using the existing Redis-based fixed-window rate limiting algorithm 
* A shared configuration component that takes care of parsing the configuration for ratelimits