### PR TITLE
chore: improve DX in the CI logs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ variables:
   DOCKER_PLATFORM:
     value: "linux/amd64,linux/arm64"
     description: "Platforms to build container images"
+  FF_TIMESTAMPS: true
 
   RULES_CHANGES_COMPARE_TO_REF:
     value: "refs/heads/main"

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -5,6 +5,7 @@ variables:
   FRONTEND_REPOSITORY: mendersoftware/gui
   DOCS_VERSION: development
   MENDER_IMAGE_GUI: ${MENDER_IMAGE_REGISTRY}/${MENDER_IMAGE_REPOSITORY}/gui:${MENDER_IMAGE_TAG}
+  FF_TIMESTAMPS: true
 
 test:frontend:lint:
   stage: test
@@ -190,7 +191,7 @@ build:frontend:docker:
     - !reference [.requires-docker]
     - !reference [.dind-login]
     - apk add --no-cache bash git jq wget
-    - docker pull ${MENDER_IMAGE_GUI}
+    - docker pull --quiet ${MENDER_IMAGE_GUI}
     # If branch is not protected, use upstream main
     # Otherwise use the local pipeline reference.
     - |

--- a/frontend/tests/e2e_tests/run
+++ b/frontend/tests/e2e_tests/run
@@ -121,7 +121,14 @@ run_tests() {
         # to the playwright packages as we rely on the prebuilt
         # mender-test-containers image
         docker compose run gui-tests-runner \
-          /bin/sh -c 'npm i && npx playwright install chromium && npm run test -- --project=chromium'
+          /bin/sh -c '
+            npm i && 
+              if ! npx playwright install chromium > playwright-install.log 2>&1; then
+                echo "Playwright dependencies installation failed:"
+                cat playwright-install.log
+                exit 1
+              fi &&
+            npm run test -- --project=chromium'
     else
         if test -z "$VISUAL"; then
           npm run test


### PR DESCRIPTION
A small quality of life improvement for people who will be looking at CI logs

- adds timestamps to gitlabCI, 
- suppresses verbose logging of docker pull and playwright deps install