### PR TITLE
chore: quiet docker compose pull progress log

### DIFF
--- a/frontend/tests/e2e_tests/run
+++ b/frontend/tests/e2e_tests/run
@@ -69,7 +69,7 @@ SP_TENANT=tenant-demo@example.com
 PASSWORD=mysecretpassword!123
 
 run_tests() {
-    docker compose down -v --remove-orphans && docker compose up -d
+    docker compose down -v --remove-orphans && docker compose up --quiet-pull -d
     declare retries=5
 
     if [[ $ENTERPRISE -eq 1 ]]; then


### PR DESCRIPTION
Forgot one place in https://github.com/mendersoftware/mender-server/pull/789

- adds `--quiet-pull` flag to `docker compose up` for front-end e2e tests run script 