### PR TITLE
ci: fix staging e2e docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -409,6 +409,7 @@ test:prep:
     DEVICE_TYPE: qemux86-64
     DOCKER_CERT_PATH: /certs/client
     DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_CERTDIR: '/certs'
     DOCKER_TLS_VERIFY: 1
     TEST_ENVIRONMENT: staging
   before_script:


### PR DESCRIPTION
By moving to docker tls globally, port 2376

Ticket: QA-1111