### PR TITLE
test: add `None` arguments to `typing.Generator`

### DIFF
--- a/backend/tests/integration/testutils/common.py
+++ b/backend/tests/integration/testutils/common.py
@@ -647,7 +647,7 @@ class MockedHttp:
 def retry(
     period: timedelta = timedelta(milliseconds=100),
     timeout: timedelta = timedelta(minutes=2),
-) -> Generator[datetime]:
+) -> Generator[datetime, None, None]:
     if timeout < period:
         raise ValueError(f"retry period {period} is larger than timeout {timeout}")
 


### PR DESCRIPTION
Python versions older than 3.13 raises:
`TypeError: Too few arguments for typing.Generator; actual 1, expected 3`

https://docs.python.org/3/library/typing.html#typing.Generator: `Changed in version 3.13: Default values for the send and return types were added.`