### PR TITLE
fix(workflows): move inventory to end of decommission workflow

### DIFF
--- a/backend/services/workflows/tests/docker-compose.yml
+++ b/backend/services/workflows/tests/docker-compose.yml
@@ -5,9 +5,6 @@ services:
     extends:
       file: ../../../tests/docker-compose.yml
       service: acceptance-tester
-    command: # FIXME(QA-733): Align dockerfile with open source
-      - -k
-      - not test_create_artifacts
     volumes:
       - ".:/testing"
     depends_on:

--- a/backend/services/workflows/tests/docker-compose.yml
+++ b/backend/services/workflows/tests/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       HAVE_DEVICECONFIG: 1
       GOCOVERDIR: /cover
       DEPLOYMENTS_ADDR: "mender-deployments:8080"
-      DEVICE-AUTH_ADDR: "mender-device-auth:8080"
+      DEVICEAUTH_ADDR: "mender-device-auth:8080"
       INVENTORY_ADDR: "mender-inventory:8080"
       TENANTADM_ADDR: "mender-tenantadm:8080"
       USERADM_ADDR: "mender-useradm:8080"

--- a/backend/services/workflows/tests/mmock/deviceauth_DELETE_devices.json
+++ b/backend/services/workflows/tests/mmock/deviceauth_DELETE_devices.json
@@ -1,0 +1,10 @@
+{
+    "description": "deviceauth: DELETE device",
+    "request": {
+        "method": "DELETE",
+        "path": "/api/internal/v1/devauth/tenants//devices/1"
+    },
+    "response": {
+        "statusCode": 202
+    }
+}

--- a/backend/services/workflows/tests/mmock/deviceauth_DELETE_devices_with_tenant_id.json
+++ b/backend/services/workflows/tests/mmock/deviceauth_DELETE_devices_with_tenant_id.json
@@ -1,0 +1,10 @@
+{
+    "description": "deviceauth: DELETE device",
+    "request": {
+        "method": "DELETE",
+        "path": "/api/internal/v1/devauth/tenants/123456789012345678901234/devices/1"
+    },
+    "response": {
+        "statusCode": 202
+    }
+}

--- a/backend/services/workflows/tests/tests/test_decommission_device.py
+++ b/backend/services/workflows/tests/tests/test_decommission_device.py
@@ -57,13 +57,12 @@ def do_decommission_device(mmock_url, workflows_url, tenant_id):
         assert type(response) is dict
         if response["status"] == "done":
             break
+    else:
+        raise TimeoutError("timeout waiting for workflow to finish")
     # verify the status
     assert {"name": "request_id", "value": request_id} in response["inputParameters"]
     assert {"name": "device_id", "value": device_id} in response["inputParameters"]
-    # assert response["status"] == "done"
-    # assert len(response["results"]) == 4
-    # assert response["results"][0]["success"] == True
-    # assert response["results"][0]["httpResponse"]["statusCode"] == 204
+    assert response["status"] == "done"
     # #  verify the mock server has been correctly called
     res = requests.get(mmock_url + "/api/request/all")
     assert res.status_code == 200
@@ -71,87 +70,127 @@ def do_decommission_device(mmock_url, workflows_url, tenant_id):
     # assert len(response) == 4
     expected = [
         {
-            "request": {
-                "scheme": "http",
-                "host": "mender-deployments",
-                "port": "8080",
-                "method": "DELETE",
-                "path": "/api/internal/v1/deployments/tenants/" + tenant_id + "/deployments/devices/"
-                + device_id,
-                "queryStringParameters": {},
-                "fragment": "",
-                "headers": {
-                    "Accept-Encoding": ["gzip"],
-                    "User-Agent": ["Go-http-client/1.1"],
-                    "X-Men-Requestid": [request_id],
-                },
-                "cookies": {},
-                "body": "",
+            "scheme": "http",
+            "host": "mender-deployments",
+            "port": "8080",
+            "method": "DELETE",
+            "path": "/api/internal/v1/deployments/tenants/"
+            + tenant_id
+            + "/deployments/devices/"
+            + device_id,
+            "queryStringParameters": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": ["gzip"],
+                "User-Agent": ["Go-http-client/1.1"],
+                "X-Men-Requestid": [request_id],
             },
+            "cookies": {},
+            "body": "",
         },
         {
-            "request": {
-                "scheme": "http",
-                "host": "mender-deviceconnect",
-                "port": "8080",
-                "method": "DELETE",
-                "path": "/api/internal/v1/deviceconnect/tenants/"
-                + tenant_id
-                + "/devices/"
-                + device_id,
-                "queryStringParameters": {},
-                "fragment": "",
-                "headers": {
-                    "Accept-Encoding": ["gzip"],
-                    "User-Agent": ["Go-http-client/1.1"],
-                    "X-Men-Requestid": [request_id],
-                },
-                "cookies": {},
-                "body": "",
+            "scheme": "http",
+            "host": "mender-deviceconnect",
+            "port": "8080",
+            "method": "DELETE",
+            "path": "/api/internal/v1/deviceconnect/tenants/"
+            + tenant_id
+            + "/devices/"
+            + device_id,
+            "queryStringParameters": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": ["gzip"],
+                "User-Agent": ["Go-http-client/1.1"],
+                "X-Men-Requestid": [request_id],
             },
+            "cookies": {},
+            "body": "",
         },
         {
-            "request": {
-                "scheme": "http",
-                "host": "mender-deviceconfig",
-                "port": "8080",
-                "method": "DELETE",
-                "path": "/api/internal/v1/deviceconfig/tenants/"
-                + tenant_id
-                + "/devices/"
-                + device_id,
-                "queryStringParameters": {},
-                "fragment": "",
-                "headers": {
-                    "Accept-Encoding": ["gzip"],
-                    "User-Agent": ["Go-http-client/1.1"],
-                    "X-Men-Requestid": [request_id],
-                },
-                "cookies": {},
-                "body": "",
+            "scheme": "http",
+            "host": "mender-deviceconfig",
+            "port": "8080",
+            "method": "DELETE",
+            "path": "/api/internal/v1/deviceconfig/tenants/"
+            + tenant_id
+            + "/devices/"
+            + device_id,
+            "queryStringParameters": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": ["gzip"],
+                "User-Agent": ["Go-http-client/1.1"],
+                "X-Men-Requestid": [request_id],
             },
+            "cookies": {},
+            "body": "",
         },
         {
-            "request": {
-                "scheme": "http",
-                "host": "mender-inventory",
-                "port": "8080",
-                "method": "DELETE",
-                "path": "/api/internal/v1/inventory/tenants/" + tenant_id + "/devices/"
-                + device_id,
-                "queryStringParameters": {},
-                "fragment": "",
-                "headers": {
-                    "Accept-Encoding": ["gzip"],
-                    "User-Agent": ["Go-http-client/1.1"],
-                    "X-Men-Requestid": [request_id],
-                },
-                "cookies": {},
-                "body": "",
+            "body": "",
+            "cookies": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": [
+                    "gzip",
+                ],
+                "User-Agent": [
+                    "Go-http-client/1.1",
+                ],
+                "X-Men-Requestid": [
+                    "1234567890",
+                ],
             },
+            "host": "mender-iot-manager",
+            "method": "DELETE",
+            "path": f"/api/internal/v1/iot-manager/tenants/{tenant_id}/devices/{device_id}",
+            "port": "8080",
+            "queryStringParameters": {},
+            "scheme": "http",
+        },
+        {
+            "body": "",
+            "cookies": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": [
+                    "gzip",
+                ],
+                "User-Agent": [
+                    "Go-http-client/1.1",
+                ],
+                "X-Men-Requestid": [
+                    "1234567890",
+                ],
+            },
+            "host": "mender-inventory",
+            "method": "DELETE",
+            "path": f"/api/internal/v1/inventory/tenants/{tenant_id}/devices/{device_id}",
+            "port": "8080",
+            "queryStringParameters": {},
+            "scheme": "http",
+        },
+        {
+            "body": "",
+            "cookies": {},
+            "fragment": "",
+            "headers": {
+                "Accept-Encoding": [
+                    "gzip",
+                ],
+                "User-Agent": [
+                    "Go-http-client/1.1",
+                ],
+                "X-Men-Requestid": [
+                    "1234567890",
+                ],
+            },
+            "host": "mender-device-auth",
+            "method": "DELETE",
+            "path": f"/api/internal/v1/devauth/tenants/{tenant_id}/devices/{device_id}",
+            "port": "8080",
+            "queryStringParameters": {},
+            "scheme": "http",
         },
     ]
-    assert expected[0]["request"] == response[0]["request"]
-    assert expected[1]["request"] == response[1]["request"]
-    assert expected[2]["request"] == response[2]["request"]
-    assert expected[3]["request"] == response[3]["request"]
+    assert expected == [actual["request"] for actual in response]

--- a/backend/services/workflows/tests/tests/test_decommission_device.py
+++ b/backend/services/workflows/tests/tests/test_decommission_device.py
@@ -73,25 +73,6 @@ def do_decommission_device(mmock_url, workflows_url, tenant_id):
         {
             "request": {
                 "scheme": "http",
-                "host": "mender-inventory",
-                "port": "8080",
-                "method": "DELETE",
-                "path": "/api/internal/v1/inventory/tenants/" + tenant_id + "/devices/"
-                + device_id,
-                "queryStringParameters": {},
-                "fragment": "",
-                "headers": {
-                    "Accept-Encoding": ["gzip"],
-                    "User-Agent": ["Go-http-client/1.1"],
-                    "X-Men-Requestid": [request_id],
-                },
-                "cookies": {},
-                "body": "",
-            },
-        },
-        {
-            "request": {
-                "scheme": "http",
                 "host": "mender-deployments",
                 "port": "8080",
                 "method": "DELETE",
@@ -138,6 +119,25 @@ def do_decommission_device(mmock_url, workflows_url, tenant_id):
                 "path": "/api/internal/v1/deviceconfig/tenants/"
                 + tenant_id
                 + "/devices/"
+                + device_id,
+                "queryStringParameters": {},
+                "fragment": "",
+                "headers": {
+                    "Accept-Encoding": ["gzip"],
+                    "User-Agent": ["Go-http-client/1.1"],
+                    "X-Men-Requestid": [request_id],
+                },
+                "cookies": {},
+                "body": "",
+            },
+        },
+        {
+            "request": {
+                "scheme": "http",
+                "host": "mender-inventory",
+                "port": "8080",
+                "method": "DELETE",
+                "path": "/api/internal/v1/inventory/tenants/" + tenant_id + "/devices/"
                 + device_id,
                 "queryStringParameters": {},
                 "fragment": "",

--- a/backend/services/workflows/worker/workflows/decommission_device.json
+++ b/backend/services/workflows/worker/workflows/decommission_device.json
@@ -1,22 +1,8 @@
 {
     "name": "decommission_device",
     "description": "Removes device info from all services.",
-    "version": 10,
+    "version": 11,
     "tasks": [
-        {
-            "name": "delete_device_inventory",
-            "type": "http",
-            "retries": 3,
-            "http": {
-                "uri": "http://${env.INVENTORY_ADDR|mender-inventory:8080}/api/internal/v1/inventory/tenants/${encoding=url;workflow.input.tenant_id}/devices/${encoding=url;workflow.input.device_id}",
-                "method": "DELETE",
-                "headers": {
-                    "X-MEN-RequestID": "${workflow.input.request_id}"
-                },
-                "connectionTimeOut": 8000,
-                "readTimeOut": 8000
-            }
-        },
         {
             "name": "delete_device_deployments",
             "type": "http",
@@ -84,6 +70,20 @@
                     204,
                     404
                 ]
+            }
+        },
+        {
+            "name": "delete_device_inventory",
+            "type": "http",
+            "retries": 3,
+            "http": {
+                "uri": "http://${env.INVENTORY_ADDR|mender-inventory:8080}/api/internal/v1/inventory/tenants/${encoding=url;workflow.input.tenant_id}/devices/${encoding=url;workflow.input.device_id}",
+                "method": "DELETE",
+                "headers": {
+                    "X-MEN-RequestID": "${workflow.input.request_id}"
+                },
+                "connectionTimeOut": 8000,
+                "readTimeOut": 8000
             }
         },
         {


### PR DESCRIPTION
To lower the probability of failed decommission causing the device not to show up in the UI. By not removing the device from inventory it is possible to initiate the retry from the UI.

Ticket: None