### PR TITLE
test: specify debian bookworm in acceptance tests container

### DIFF
--- a/backend/tests/Dockerfile.acceptance
+++ b/backend/tests/Dockerfile.acceptance
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim-bookworm
 COPY requirements-acceptance.txt requirements.txt
 RUN apt update && apt install -qy wget && \
     wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_4.1.0-1%2b$(. /etc/os-release; echo $ID)%2b$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb" -O mender-artifact.deb && \


### PR DESCRIPTION
- Sets `python:3.13-slim-bookworm` as the specific Debian version for the base for the acceptance container image
- This should fix the failing mender-server job that tries to download yet non existent (we do not have a trixie version yet) mender-artifact deb package
