### PR TITLE
MEN-7812: Validate scope in inventory search

### DIFF
--- a/backend/docs/api/inventory_internal_v2.yaml
+++ b/backend/docs/api/inventory_internal_v2.yaml
@@ -127,11 +127,7 @@ components:
           description: |
             A human readable, unique attribute ID, e.g. 'device_type', 'ip_addr', 'cpu_load', etc.
         scope:
-          type: string
-          description: |
-            The scope of the attribute.
-
-            Scope is a string and acts as namespace for the attribute name.
+          $ref: '#/components/schemas/Scope'
         description:
           type: string
           description: Attribute description.
@@ -198,11 +194,7 @@ components:
       type: object
       properties:
         scope:
-          type: string
-          description: |
-            The scope of the attribute.
-
-            Scope is a string and acts as namespace for the attribute name.
+          $ref: '#/components/schemas/Scope'
         attribute:
           type: string
           description: |
@@ -248,8 +240,7 @@ components:
           type: string
           description: Attribute name.
         scope:
-          type: string
-          description: Attribute scope.
+          $ref: '#/components/schemas/Scope'
       description: Inventory attribute
       example:
         attribute: serial_no
@@ -262,11 +253,7 @@ components:
       type: object
       properties:
         scope:
-          type: string
-          description: |
-            The scope of the attribute.
-
-            Scope is a string and acts as namespace for the attribute name.
+          $ref: '#/components/schemas/Scope'
         attribute:
           type: string
           description: |
@@ -285,3 +272,21 @@ components:
         attribute: serial_no
         scope: inventory
         order: asc
+    Scope:
+      type: string
+      description: |
+        The scope of the attribute.
+
+        Scope is a string and acts as namespace for the attribute name.
+
+        * __inventory__: Attributes reported by the device.
+        * __system__: Attributes populated by the mender-server.
+        * __identity__: Device's identity attributes provided in the device's auth request.
+        * __monitor__: Attributes populated by the monitoring add-on.
+        * __tags__: User-defined attributes associated with the device.
+      enum:
+        - system
+        - identity
+        - inventory
+        - monitor
+        - tags

--- a/backend/docs/api/inventory_management_v2.yaml
+++ b/backend/docs/api/inventory_management_v2.yaml
@@ -159,11 +159,7 @@ components:
           description: |
             A human readable, unique attribute ID, e.g. 'device_type', 'ip_addr', 'cpu_load', etc.
         scope:
-          type: string
-          description: |
-            The scope of the attribute.
-
-            Scope is a string and acts as namespace for the attribute name.
+          $ref: '#/components/schemas/Scope'
         description:
           type: string
           description: Attribute description.
@@ -232,8 +228,7 @@ components:
           type: string
           description: Name of the attribute.
         scope:
-          type: string
-          description: Scope of the attribute.
+          $ref: '#/components/schemas/Scope'
         count:
           type: integer
           description: Number of occurrences of the attribute in the database.
@@ -253,7 +248,7 @@ components:
           type: string
           description: Attribute name.
         scope:
-          type: string
+          $ref: '#/components/schemas/Scope'
         type:
           type: string
           description: Type or operator of the filter predicate.
@@ -282,8 +277,7 @@ components:
           type: string
           description: Attribute name.
         scope:
-          type: string
-          description: Attribute scope.
+          $ref: '#/components/schemas/Scope'
       description: Inventory attribute
       example:
         attribute: serial_no
@@ -299,8 +293,7 @@ components:
           type: string
           description: Attribute name.
         scope:
-          type: string
-          description: Attribute scope.
+          $ref: '#/components/schemas/Scope'
         order:
           type: string
           description: "Order direction, ascending (\"asc\") or descending (\"desc\"\
@@ -313,6 +306,24 @@ components:
         attribute: serial_no
         scope: inventory
         order: asc
+    Scope:
+      type: string
+      description: |
+        The scope of the attribute.
+
+        Scope is a string and acts as namespace for the attribute name.
+
+        * __inventory__: Attributes reported by the device.
+        * __system__: Attributes populated by the mender-server.
+        * __identity__: Device's identity attributes provided in the device's auth request.
+        * __monitor__: Attributes populated by the monitoring add-on.
+        * __tags__: User-defined attributes associated with the device.
+      enum:
+        - system
+        - identity
+        - inventory
+        - monitor
+        - tags
   securitySchemes:
     ManagementJWT:
       type: apiKey

--- a/backend/services/inventory/docs/internal_api_v2.yml
+++ b/backend/services/inventory/docs/internal_api_v2.yml
@@ -135,6 +135,7 @@ definitions:
             The scope of the attribute.
 
             Scope is a string and acts as namespace for the attribute name.
+        enum: [system, identity, inventory, monitor, tags]
       description:
         type: string
         description: Attribute description.
@@ -209,6 +210,7 @@ definitions:
             The scope of the attribute.
 
             Scope is a string and acts as namespace for the attribute name.
+        enum: [system, identity, inventory, monitor, tags]
       attribute:
         type: string
         description: |
@@ -254,6 +256,7 @@ definitions:
       scope:
         type: string
         description: Attribute scope.
+        enum: [system, identity, inventory, monitor, tags]
     example:
       attribute: "serial_no"
       scope: "inventory"
@@ -272,6 +275,7 @@ definitions:
             The scope of the attribute.
 
             Scope is a string and acts as namespace for the attribute name.
+        enum: [system, identity, inventory, monitor, tags]
       attribute:
         type: string
         description: |

--- a/backend/services/inventory/docs/management_api_v2.yml
+++ b/backend/services/inventory/docs/management_api_v2.yml
@@ -251,6 +251,7 @@ definitions:
       scope:
         type: string
         description: Scope of the attribute.
+        enum: [system, identity, inventory, monitor, tags]
       count:
         type: integer
         description: Number of occurrences of the attribute in the database.
@@ -272,6 +273,7 @@ definitions:
         description: Attribute name.
       scope:
         type: string
+        enum: [system, identity, inventory, monitor, tags]
       type:
         type: string
         description: Type or operator of the filter predicate.
@@ -300,6 +302,7 @@ definitions:
       scope:
         type: string
         description: Attribute scope.
+        enum: [system, identity, inventory, monitor, tags]
     example:
       attribute: "serial_no"
       scope: "inventory"
@@ -318,6 +321,7 @@ definitions:
       scope:
         type: string
         description: Attribute scope.
+        enum: [system, identity, inventory, monitor, tags]
       order:
         type: string
         description: Order direction, ascending ("asc") or descending ("desc").

--- a/backend/services/inventory/model/filters.go
+++ b/backend/services/inventory/model/filters.go
@@ -14,17 +14,16 @@
 package model
 
 import (
+	"slices"
+	"strings"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pkg/errors"
 )
 
-var validSelectors = []interface{}{
-	"$eq",
-	"$in",
-	"$nin",
-}
-
+var validSelectors = []interface{}{"$eq", "$in", "$nin"}
 var validSortOrders = []interface{}{"asc", "desc"}
+var validScopes = []string{"system", "identity", "inventory", "monitor", "tags"}
 
 type SearchParams struct {
 	Page       int               `json:"page"`
@@ -43,21 +42,30 @@ type Filter struct {
 }
 
 type FilterPredicate struct {
-	Scope     string      `json:"scope" bson:"scope"`
+	Scope     Scope       `json:"scope" bson:"scope"`
 	Attribute string      `json:"attribute" bson:"attribute"`
 	Type      string      `json:"type" bson:"type"`
 	Value     interface{} `json:"value" bson:"value"`
 }
 
 type SortCriteria struct {
-	Scope     string `json:"scope"`
+	Scope     Scope  `json:"scope"`
 	Attribute string `json:"attribute"`
 	Order     string `json:"order"`
 }
 
 type SelectAttribute struct {
-	Scope     string `json:"scope" bson:"scope"`
+	Scope     Scope  `json:"scope" bson:"scope"`
 	Attribute string `json:"attribute" bson:"attribute"`
+}
+
+type Scope string
+
+func (s Scope) Validate() error {
+	if !slices.Contains(validScopes, string(s)) {
+		return errors.Errorf("must be one of %s", strings.Join(validScopes, ", "))
+	}
+	return nil
 }
 
 func (sp SearchParams) Validate() error {

--- a/backend/services/inventory/model/filters_test.go
+++ b/backend/services/inventory/model/filters_test.go
@@ -32,7 +32,7 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Filters: []FilterPredicate{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Type:      "$eq",
 						Value:     "value",
@@ -44,7 +44,7 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Filters: []FilterPredicate{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Type:      "$in",
 						Value:     []string{"value1", "value2"},
@@ -56,7 +56,7 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Filters: []FilterPredicate{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Type:      "$nin",
 						Value:     []string{"value1", "value2"},
@@ -68,7 +68,7 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Filters: []FilterPredicate{
 					{
-						Scope: "scope",
+						Scope: "system",
 						Type:  "$eq",
 						Value: "value",
 					},
@@ -80,7 +80,7 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Filters: []FilterPredicate{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Type:      "$regex",
 						Value:     "value",
@@ -93,25 +93,57 @@ func TestSearchParams(t *testing.T) {
 			params: &SearchParams{
 				Sort: []SortCriteria{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Order:     "asc",
 					},
 				},
 			},
 		},
-		"ko, sort": {
+		"ko, sort, missing attribute": {
 			params: &SearchParams{
 				Sort: []SortCriteria{
 					{
-						Scope: "scope",
+						Scope: "system",
 						Order: "asc",
 					},
 				},
 			},
 			err: errors.New("attribute: cannot be blank."),
 		},
+		"ko, sort, invalid scope": {
+			params: &SearchParams{
+				Sort: []SortCriteria{
+					{
+						Scope:     "scope",
+						Order:     "asc",
+						Attribute: "attribute",
+					},
+				},
+			},
+			err: errors.New("scope: must be one of system, identity, inventory, monitor, tags."),
+		},
 		"ok, attributes": {
+			params: &SearchParams{
+				Attributes: []SelectAttribute{
+					{
+						Scope:     "system",
+						Attribute: "attribute",
+					},
+				},
+			},
+		},
+		"ko, attributes, missing attribute": {
+			params: &SearchParams{
+				Attributes: []SelectAttribute{
+					{
+						Scope: "system",
+					},
+				},
+			},
+			err: errors.New("attribute: cannot be blank."),
+		},
+		"ko, attributes, invalid scope": {
 			params: &SearchParams{
 				Attributes: []SelectAttribute{
 					{
@@ -120,16 +152,7 @@ func TestSearchParams(t *testing.T) {
 					},
 				},
 			},
-		},
-		"ko, attributes": {
-			params: &SearchParams{
-				Attributes: []SelectAttribute{
-					{
-						Scope: "scope",
-					},
-				},
-			},
-			err: errors.New("attribute: cannot be blank."),
+			err: errors.New("scope: must be one of system, identity, inventory, monitor, tags."),
 		},
 	}
 
@@ -155,7 +178,7 @@ func TestFilter(t *testing.T) {
 				Name: "name",
 				Terms: []FilterPredicate{
 					{
-						Scope:     "scope",
+						Scope:     "system",
 						Attribute: "attribute",
 						Type:      "$eq",
 						Value:     "",
@@ -178,13 +201,27 @@ func TestFilter(t *testing.T) {
 				Name: "name",
 				Terms: []FilterPredicate{
 					{
-						Scope: "scope",
+						Scope: "system",
 						Type:  "$eq",
 						Value: "",
 					},
 				},
 			},
 			err: errors.New("validation failed for term: attribute: cannot be blank."),
+		},
+		"ko, scope": {
+			filter: &Filter{
+				Name: "name",
+				Terms: []FilterPredicate{
+					{
+						Scope:     "scope",
+						Type:      "$eq",
+						Attribute: "attribute",
+						Value:     "value",
+					},
+				},
+			},
+			err: errors.New("validation failed for term: scope: must be one of system, identity, inventory, monitor, tags."),
 		},
 	}
 


### PR DESCRIPTION
**Description**

This change introduces input validation of `scope` properties used with the inventory filter search endpoint. The `scope`  the `filter`, `sort` and `attributes` property of the input search query now has to be one of: 
```
"system"
"identity"
"inventory"
"monitor"
"tags"
```
 Any other value will result in a `400 - Bad Request` result  from the search endpoint.

Introducing this validation also fixes the problem described in the bug report where a malformed `scope` property would produce a `500 - Internal Server Error` when `mongodb` attempted to execute the search query. The reported issue was caused by the scope property containing multiple (2 or more) period signs in direct sequence (ex: `"something..else"` or `"../../something"`) which is incompatible with `mongodb` projection and sort operations. 

Introducing input validation addresses both the original issue and clearly communicates to users of the endpoint what scopes are actually supported by the system and this is therefore (imo) a good solution to the original issue.

**Other notes / questions**

* I'm not exactly 100% sure the list of accepted values for `scope` in this pull request is the complete set of values that should be allowed. I have searched around and these are the ones I could find in use by the UI and Client (afaict), but it's absolutely possible that I have missed some, so please do let me know if that's the case.
* I have taken the liberty of restructuring the inventory integration tests as part of this PR. This is to run search tests on open source _and_ enterprise (not only enterprise as it was before) and was a pre-requisite for me to add tests to cover this change in open source. I have tried to follow established patterns, but my `python` and `pytest` fu is somewhat weak so please do let me know if I could have done things better here.
* I have had a look at the commit structure and conventions used by others in this repository and tried to follow suit. If I've made mistakes or otherwise done things in ways that are not ok - do let me know! 

