### PR TITLE
ci: coveralls publish jobs allowed to fail

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -245,6 +245,7 @@ test:frontend:acceptance:enterprise:
     - npm i -g coveralls
   tags:
     - hetzner-amd-beefy
+  allow_failure: true
 
 publish:frontend:tests:
   extends: .template:publish:frontend:tests


### PR DESCRIPTION
Lately we're experiencing some issues with upstream coveralls API, which seems unreliable and are answering 5xx errors. This commit is to make the reporting jobs allowed to fail, instead of blocking pipelines

Ticket: QA-925