### PR TITLE
chore: define a starting point for `find` commands

### DIFF
--- a/backend/services/Makefile.common
+++ b/backend/services/Makefile.common
@@ -17,8 +17,8 @@ GIT_ROOT := $(shell git rev-parse --show-toplevel)
 MAKEDIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 DOCFILES := $(wildcard docs/*_api.yml)
 
-GOFILES := $(shell find -name '*.go' -not -name '_test.go')
-GOTESTFILES := $(shell find -name '_test.go')
+GOFILES := $(shell find ./ -name '*.go' -not -name '_test.go')
+GOTESTFILES := $(shell find ./ -name '_test.go')
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)


### PR DESCRIPTION
**Description**
Explicitly define the starting point of `find` commands as `find` on MacOS does _not_ have a default starting point. 
GNU `find` defaults to using the current directory (`./`) as a starting point if one is not given so the end result should be the same.

**Examples** 
```bash
# Existing and new command on MacOS
$ find ./ -name '*.go' -not -name '_test.go' | wc -l
       815

$ find -name '*.go' -not -name '_test.go' | wc -l 
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
       0
```


```bash
# Existing and new command on Ubuntu
$ find ./ -name '*.go' -not -name '_test.go' | wc -l
815

find -name '*.go' -not -name '_test.go' | wc -l
815
```