### PR TITLE
List services in Makefile correctly on MacOS

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -6,7 +6,7 @@ MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSTIORY ?= mendersoftware
 MENDER_PUBLISH_TAG ?= $(MENDER_IMAGE_TAG)
 
-SERVICES = $(subst services,,$(subst /,,$(wildcard services/*/)))
+SERVICES = $(subst services,,$(subst /,,$(sort $(dir $(wildcard services/*/)))))
 BUILD_TARGETS := $(addsuffix -build, $(SERVICES))
 TEST_TARGETS := $(addsuffix -test, $(SERVICES))
 TEST_UNIT_TARGETS := $(addsuffix -test-unit, $(SERVICES))


### PR DESCRIPTION
TLDR; List services in Makefile correctly on MacOS

The Makefile function `wildcard` returns both files and directories in the /services/ directory (at least on Mac). This leads to test execution failing midway when it encounters Makefile.common (the only file in /services/). A simple enough solution is to keep only directories using the `dir` function.

In addition, I believe the ordering produced by `wildward` is non-deterministic, so I added a call to `sort` to ensure tests are executed in a consistent order (alphabetical).