### PR TITLE
MEN-8688: Add length validation for multipart generate image fields

### DIFF
--- a/backend/services/deployments/api/http/images_test.go
+++ b/backend/services/deployments/api/http/images_test.go
@@ -15,10 +15,12 @@
 package http
 
 import (
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -422,7 +424,11 @@ func TestPostArtifactsInternal(t *testing.T) {
 
 func TestPostArtifactsGenerate(t *testing.T) {
 	imageBody := []byte("123456790")
-
+	randomStringOfLength := func(length int) string {
+		b := make([]byte, (length/2 + 1))
+		rand.Read(b)
+		return fmt.Sprintf("%x", b)[:length]
+	}
 	testCases := []struct {
 		requestBodyObject        []h.Part
 		requestContentType       string
@@ -780,6 +786,162 @@ func TestPostArtifactsGenerate(t *testing.T) {
 			requestContentType:       "multipart/form-data",
 			responseCode:             http.StatusBadRequest,
 			responseBody:             "failed to read form value 'size'",
+			appGenerateImage:         false,
+			appGenerateImageResponse: "",
+			appGenerateImageError:    nil,
+		},
+		{
+			requestBodyObject: []h.Part{
+				{
+					FieldName:  "name",
+					FieldValue: randomStringOfLength(257),
+				},
+				{
+					FieldName:  "description",
+					FieldValue: "description",
+				},
+				{
+					FieldName:  "size",
+					FieldValue: "1024",
+				},
+				{
+					FieldName:  "device_types_compatible",
+					FieldValue: "Beagle Bone",
+				},
+				{
+					FieldName:  "type",
+					FieldValue: "single_file",
+				},
+				{
+					FieldName:  "args",
+					FieldValue: "args",
+				},
+				{
+					FieldName:   "file",
+					ContentType: "application/octet-stream",
+					ImageData:   imageBody,
+				},
+			},
+			requestContentType:       "multipart/form-data",
+			responseCode:             http.StatusBadRequest,
+			responseBody:             "invalid form parameters: name: the length must be between 1 and 256",
+			appGenerateImage:         false,
+			appGenerateImageResponse: "",
+			appGenerateImageError:    nil,
+		},
+		{
+			requestBodyObject: []h.Part{
+				{
+					FieldName:  "name",
+					FieldValue: "name",
+				},
+				{
+					FieldName:  "description",
+					FieldValue: "description",
+				},
+				{
+					FieldName:  "size",
+					FieldValue: "1024",
+				},
+				{
+					FieldName:  "device_types_compatible",
+					FieldValue: randomStringOfLength(257),
+				},
+				{
+					FieldName:  "type",
+					FieldValue: "single_file",
+				},
+				{
+					FieldName:  "args",
+					FieldValue: "args",
+				},
+				{
+					FieldName:   "file",
+					ContentType: "application/octet-stream",
+					ImageData:   imageBody,
+				},
+			},
+			requestContentType:       "multipart/form-data",
+			responseCode:             http.StatusBadRequest,
+			responseBody:             "invalid form parameters: device_types_compatible: (0: the length must be between 1 and 256.)",
+			appGenerateImage:         false,
+			appGenerateImageResponse: "",
+			appGenerateImageError:    nil,
+		},
+		{
+			requestBodyObject: []h.Part{
+				{
+					FieldName:  "name",
+					FieldValue: "name",
+				},
+				{
+					FieldName:  "description",
+					FieldValue: "description",
+				},
+				{
+					FieldName:  "size",
+					FieldValue: "1024",
+				},
+				{
+					FieldName:  "device_types_compatible",
+					FieldValue: strings.Join(strings.Split(randomStringOfLength(257), ""), ","),
+				},
+				{
+					FieldName:  "type",
+					FieldValue: "single_file",
+				},
+				{
+					FieldName:  "args",
+					FieldValue: "args",
+				},
+				{
+					FieldName:   "file",
+					ContentType: "application/octet-stream",
+					ImageData:   imageBody,
+				},
+			},
+			requestContentType:       "multipart/form-data",
+			responseCode:             http.StatusBadRequest,
+			responseBody:             "invalid form parameters: device_types_compatible: the length must be between 1 and 256.",
+			appGenerateImage:         false,
+			appGenerateImageResponse: "",
+			appGenerateImageError:    nil,
+		},
+		{
+			requestBodyObject: []h.Part{
+				{
+					FieldName:  "name",
+					FieldValue: "name",
+				},
+				{
+					FieldName:  "description",
+					FieldValue: "description",
+				},
+				{
+					FieldName:  "size",
+					FieldValue: "1024",
+				},
+				{
+					FieldName:  "device_types_compatible",
+					FieldValue: "Beagle Bone",
+				},
+				{
+					FieldName:  "type",
+					FieldValue: randomStringOfLength(257),
+				},
+				{
+					FieldName:  "args",
+					FieldValue: "args",
+				},
+				{
+					FieldName:   "file",
+					ContentType: "application/octet-stream",
+					ImageData:   imageBody,
+				},
+			},
+			requestContentType:       "multipart/form-data",
+			responseCode:             http.StatusBadRequest,
+			responseBody:             "invalid form parameters: type: the length must be between 1 and 256",
 			appGenerateImage:         false,
 			appGenerateImageResponse: "",
 			appGenerateImageError:    nil,

--- a/backend/services/deployments/model/image.go
+++ b/backend/services/deployments/model/image.go
@@ -269,9 +269,14 @@ type MultipartGenerateImageMsg struct {
 
 func (msg MultipartGenerateImageMsg) Validate() error {
 	if err := validation.ValidateStruct(&msg,
-		validation.Field(&msg.Name, validation.Required),
-		validation.Field(&msg.DeviceTypesCompatible, validation.Required),
-		validation.Field(&msg.Type, validation.Required),
+		validation.Field(&msg.Name, validation.Required, lengthIn1To256),
+		validation.Field(
+			&msg.DeviceTypesCompatible,
+			validation.Required,
+			validation.Each(lengthIn1To256),
+			lengthIn1To256,
+		),
+		validation.Field(&msg.Type, validation.Required, lengthIn1To256),
 	); err != nil {
 		return err
 	}

--- a/backend/services/deployments/model/validation.go
+++ b/backend/services/deployments/model/validation.go
@@ -22,6 +22,7 @@ var (
 	// Initialize validation rules once.
 	lengthIn0To200  = validation.Length(0, 200)
 	lengthIn1To4096 = validation.Length(1, 4096)
+	lengthIn1To256  = validation.Length(1, 256)
 
 	lengthLessThan4096 = validation.Length(0, 4096)
 )


### PR DESCRIPTION
**Description**

This PR adds input validation to the `name` (aka `Release name`), `type` and `device types compatible` when doing "Single file uploads for artifact generation", limiting them to 256 characters in length. While researching [MEN-8688](https://northerntech.atlassian.net/browse/MEN-8688) I discovered that if you make these fields longer than 256 characters the artifact generation fails silently in the background (see logs below). This seems to be caused by a recent change in [mender-artifact](https://github.com/mendersoftware/mender-artifact/commit/ddd821f8a5150fb8a3186b337525f17b2757599c) limiting strings to 256 characters in length. I suggest that we add input validation to match so customers get an explicit error in this (arguably edge) case instead of a silent failure.

**Related logs**

```bash
# Too long `name`
deployments-1             | time="2025-08-25T09:00:34Z" level=warning byteswritten=202 caller="accesslog.AccessLogger.LogFunc@middleware_gin.go:133" error="reading artifact error: readHeaderV3: handleHeaderReads: readHeader: invalid artifact provides: invalid artifact name: too many characters" method=POST path="/api/internal/v1/deployments/tenants/:tenant/artifacts" path_params="tenant=default" qs= request_id=456af12a-26d0-4173-a951-b0e7bf3073bd responsetime=3.069ms status=400 ts="2025-08-25T09:00:34.747Z" type=HTTP/1.1 useragent=Go-http-client/1.1

# Too long `device types compatible`
deployments-1             | time="2025-08-25T09:02:26Z" level=warning byteswritten=217 caller="accesslog.AccessLogger.LogFunc@middleware_gin.go:133"      error="reading artifact error: readHeaderV3: handleHeaderReads: readHeader: invalid artifact depends: compatible devices at index 0 invalid: too many characters"     method=POST path="/api/internal/v1/deployments/tenants/:tenant/artifacts" path_params="tenant=default" qs= request_id=cf34acfb-7286-4d43-8059-a231eaea845a     responsetime=3.637ms status=400 ts="2025-08-25T09:02:26.449Z" type=HTTP/1.1 useragent=Go-http-client/1.1
```

[MEN-8688]: https://northerntech.atlassian.net/browse/MEN-8688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ