### PR TITLE
ci: deploy branches on staging cluster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -649,9 +649,10 @@ publish:backend:docker:
     name: quay.io/skopeo/stable:${SKOPEO_VERSION}
     # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#override-the-entrypoint-of-an-image
     entrypoint: [""]
-  rules:
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
+  rules:  # This job will run for any branch or tag, but not for maintenance branches
+    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/'
+      when: never
+    - if: $CI_COMMIT_TAG || $CI_COMMIT_BRANCH
   before_script:
     - skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ variables:
     value: "302.Release-information/03.Open-source-licenses/01.Mender-Server/docs.md"
 
 include:
-  - component: "gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master"
+  # - component: "gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master"
   - project: "Northern.tech/Mender/mendertesting"
     file:
       - ".gitlab-ci-github-status-updates.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ include:
       - when: never
 
 stages:
-  - lint
+  # - lint
   - build
   - test
   - publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -658,13 +658,14 @@ publish:backend:docker:
       if [ "$CI_COMMIT_REF_PROTECTED" == "true" ]; then
         export MENDER_PUBLISH_REGISTRY="docker.io"
         echo "INFO: Protected branch. Publishing to public registry: ${MENDER_PUBLISH_REGISTRY}"
+        skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
+        skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io
       else
         export MENDER_PUBLISH_REGISTRY="${CI_REGISTRY}"
         export MENDER_PUBLISH_REPOSITORY="${MENDER_IMAGE_REPOSITORY}"
         echo "INFO: Unprotected branch. Publishing to internal registry: ${MENDER_PUBLISH_REGISTRY}/${MENDER_PUBLISH_REPOSITORY}"
+        skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
       fi
-    - skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io
     - dnf install -y make git-core
     - export MENDER_PUBLISH_TAG="${CI_COMMIT_REF_NAME}"
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,19 +94,17 @@ variables:
 
 include:
   - component: "gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master"
-    rules:
-      - when: never
   - project: "Northern.tech/Mender/mendertesting"
     file:
       - ".gitlab-ci-github-status-updates.yml"
       # QA-1046 Remove after hardening sign-off checks in the modern commit linter
       - ".gitlab-ci-check-commits-signoffs.yml"
-    rules:
-      - when: never
   - local: "/frontend/pipeline.yml"
-    rules:
-      - when: never
   - local: "/.gitlab/merge-enterprise.yml"
+    rules:
+      - if: '$CI_PROJECT_NAME == "mender-server"'
+        when: always
+      - when: never
 
 stages:
   - lint
@@ -360,11 +358,11 @@ build:backend:docker:
   extends: .template:build:docker
   rules:
     - changes:
-        paths: ["backend/**/*"]
+        paths: ["backend/**/*", ".gitlab-ci.yml"]
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
       when: always
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
+      when: always
   script:
     # FIXME: Only exporting deployments build stage to run unit tests
     #        We're assuming the images have consistent GOTOOLCHAIN.
@@ -601,18 +599,6 @@ test:staging-deployment:firefox:
   script:
     - npx playwright install firefox
     - npm run test -- --project=firefox
-  rules:
-    - when: never
-
-#
-# Run e2e tests on staging using Webkit
-#
-test:staging-deployment:webkit:
-  extends: .template:test:staging-deployment
-  allow_failure: true
-  script:
-    - npx playwright install webkit
-    - npm run test -- --project=webkit
   rules:
     - when: never
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,17 +94,19 @@ variables:
 
 include:
   - component: "gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master"
+    rules:
+      - when: never
   - project: "Northern.tech/Mender/mendertesting"
     file:
       - ".gitlab-ci-github-status-updates.yml"
       # QA-1046 Remove after hardening sign-off checks in the modern commit linter
       - ".gitlab-ci-check-commits-signoffs.yml"
-  - local: "/frontend/pipeline.yml"
-  - local: "/.gitlab/merge-enterprise.yml"
     rules:
-      - if: '$CI_PROJECT_NAME == "mender-server"'
-        when: always
       - when: never
+  - local: "/frontend/pipeline.yml"
+    rules:
+      - when: never
+  - local: "/.gitlab/merge-enterprise.yml"
 
 stages:
   - lint
@@ -122,6 +124,8 @@ default:
     when:
       - runner_system_failure
       - stuck_or_timeout_failure
+
+# TEMPLATES #
 
 .requires-docker: &requires-docker
   - DOCKER_RETRY_SLEEP_S=10 # wait longer for k8s workers
@@ -175,231 +179,6 @@ default:
       export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --builder=ci-builder";
       fi
 
-build:backend:docker:
-  extends: .template:build:docker
-  rules:
-    - changes:
-        paths: ["backend/**/*", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: always
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: always
-  script:
-    # FIXME: Only exporting deployments build stage to run unit tests
-    #        We're assuming the images have consistent GOTOOLCHAIN.
-    #        Will be fixed once we optimize to template based pipeline.
-    - |-
-      make -C backend/services/deployments docker \
-        DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
-        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
-    - make -C backend docker
-
-build:backend:docker-acceptance:
-  extends: build:backend:docker
-  before_script:
-    - *requires-docker
-    - apk add make bash git
-    - *dind-login
-    # We're only building acceptance test images for CI runner platform.
-    - unset DOCKER_PLATFORM
-  script:
-    # NOTE: Only build for test platform (default) for the acceptance test images
-    - make -C backend docker-acceptance
-
-test:backend:static:
-  stage: test
-  needs: []
-  rules:
-    - changes:
-        paths: ["backend/**/*.go", "backend/go.mod", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-  image: "golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
-  script:
-    - cd backend
-    - golangci-lint run -v
-
-test:backend:validate-open-api:
-  stage: test
-  needs: []
-  rules:
-    - changes:
-        paths: ["backend/**/docs/*.yml", "backend/docs/api/*.yaml", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: on_success
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine:${ALPINE_VERSION}
-  before_script:
-    - apk add --no-cache curl
-    - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
-    - sh install.sh
-  script:
-    - |
-      cat > .spectral.yaml << EOF
-      extends: [['spectral:oas', all]]
-      parserOptions:
-        incompatibleValues: 1
-      EOF
-    - spectral lint -v -D -f text backend/services/**/docs/*.yml backend/docs/api/*.yaml
-    - spectral lint -v -D -f junit -o spectral-report.xml backend/services/**/docs/*.yml backend/docs/api/*.yml
-  artifacts:
-    when: always
-    expire_in: 2 weeks
-    reports:
-      junit: $CI_PROJECT_DIR/spectral-report.xml
-
-test:backend:unit:
-  # FIXME: Using deployments build stage since we're running all tests
-  image: "${CI_REGISTRY_IMAGE}/deployments:${MENDER_IMAGE_TAG_BUILDER}"
-  stage: test
-  needs:
-    - job: build:backend:docker
-      artifacts: false
-  resource_group: test_backend_unit
-  rules:
-    - changes:
-        paths: ["backend/**/*.go", "backend/go.mod", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: on_success
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:${MONGO_VERSION}
-      alias: mongo
-  variables:
-    TEST_MONGO_URL: "mongodb://mongo"
-    WORKFLOWS_MONGO_URL: "mongodb://mongo"
-  before_script:
-    - mkdir -p $GOCOVERDIR
-  script:
-    - |
-      make -C backend test-unit \
-        TESTFLAGS="-cover -coverprofile=${GOCOVERDIR}/\$(COMPONENT)-unit.cover"
-  artifacts:
-    expire_in: 1w
-    when: on_success
-    paths:
-      - ${GOCOVERDIR}/*-unit.cover
-
-test:backend:acceptance:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
-  extends: .build:base
-  stage: test
-  rules:
-    - changes:
-        paths: ["backend/**/*", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: on_success
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
-      alias: docker
-  needs:
-    - job: build:backend:docker
-      artifacts: false
-    - job: build:backend:docker-acceptance
-      artifacts: false
-  before_script:
-    - *requires-docker
-    - apk add make bash git
-    - *dind-login
-    - make -C backend -j 4 docker-pull
-    - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_TEST}
-    - mkdir -p $GOCOVERDIR
-  script:
-    # NOTE: Setting GOCOVERDIR this way will group the coverage report per
-    #       service (using make variable: COMPONENT).
-    - make -C backend test-acceptance GOCOVERDIR="${GOCOVERDIR}/\$(COMPONENT)-acceptance"
-  artifacts:
-    expire_in: 1w
-    when: on_success
-    paths:
-      - ${GOCOVERDIR}/*-acceptance
-
-test:backend:integration:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
-  stage: test
-  extends: .build:base
-  rules:
-    - changes:
-        paths: ["backend/**/*", ".gitlab-ci.yml"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: on_success
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
-      alias: docker
-      variables:
-        HEALTHCHECK_TCP_PORT: "2376"
-  needs:
-    - job: build:backend:docker
-      artifacts: false
-    - job: build:backend:docker-acceptance
-      artifacts: false
-  before_script:
-    - *requires-docker
-    - apk add make bash git curl
-    - *dind-login
-    - mkdir -p ${GOCOVERDIR}/integration
-    - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
-  script:
-    - make -C backend test-integration
-      GOCOVERDIR=${GOCOVERDIR}/integration
-      MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
-  artifacts:
-    expire_in: 1w
-    when: always
-    paths:
-      - ${GOCOVERDIR}/integration
-      - backend/logs.*
-      - backend/results_integration_*.xml
-      - backend/report_integration_*.html
-    reports:
-      junit: backend/results_integration_*.xml
-
-test:integration:
-  stage: test
-  needs:
-    - job: build:backend:docker
-      artifacts: false
-    - job: build:frontend:docker
-      artifacts: false
-  rules:
-    - if: $CI_COMMIT_REF_PROTECTED == "true"
-      when: manual
-      allow_failure: true
-  variables:
-    # NOTE: Cannot use indirect values based off CI_* since these will be
-    #       expanded in the downstream project context.
-    MENDER_SERVER_REGISTRY: "${CI_REGISTRY}"
-    MENDER_SERVER_REPOSITORY: "northern.tech/mender/${CI_PROJECT_NAME}"
-    MENDER_SERVER_TAG: "build-${CI_COMMIT_SHA}"
-    PYTEST_ADDOPTS: "-k 'not Enterprise'"
-    RUN_TESTS_FULL_INTEGRATION: "true"
-  trigger:
-    project: "Northern.tech/Mender/integration"
-
-test:prep:
-  stage: test
-  extends: .build:base
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: on_success
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
-      alias: docker
-  script:
-    - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/extract mendersoftware/mender-stress-test-client:master -c "cp mender-stress-test-client /extract/"
-  artifacts:
-    paths:
-      - mender-stress-test-client
-    expire_in: 2w
-  tags:
-    - hetzner-amd-beefy
-
 .template:test:staging-deployment:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mendersoftware/mender-test-containers:gui-e2e-testing
   stage: .post
@@ -435,26 +214,411 @@ test:prep:
   tags:
     - hetzner-amd-beefy-privileged
 
+#
+# Helm version bump
+#
+.helm-version-bump:
+  needs:
+    - job: publish:backend:docker
+      artifacts: true
+    # - job: publish:frontend:docker
+    #   artifacts: true
+  rules: # This job will run for any branch or tag, but not for maintenance branches.
+    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/'
+      when: never
+    - if: $CI_COMMIT_TAG || $CI_COMMIT_BRANCH
+  allow_failure: true
+  tags:
+    - hetzner-amd-beefy
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master
+  variables:
+    HELM_PATCH_VERSION: ${CI_PIPELINE_ID}
+    SYNC_ENVIRONMENT: ${CI_COMMIT_REF_SLUG}
+  before_script:
+    - git config --global user.email "${GITHUB_USER_EMAIL}"
+    - git config --global user.name "${GITHUB_USER_NAME}"
+    - export DIGESTS_FOLDER=$(pwd)/.digests
+    - export PROJECT_FOLDER=$(pwd)
+  script:
+    - git clone https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_HELM_REPO} /tmp/helm
+    - cd /tmp/helm
+    - | # Set the target branch and target chart directory
+      if [[ "${SYNC_ENVIRONMENT}" == "staging" ]]; then
+        export TARGET_BRANCH="staging"
+        export TARGET_CHART_DIR="${CHART_DIR}" # For staging, we modify the main chart
+      else
+        export TARGET_BRANCH="dev/${SYNC_ENVIRONMENT}"
+        export TARGET_CHART_DIR="dev/${SYNC_ENVIRONMENT}"
+      fi
+      echo "INFO: Target branch in Helm repo will be '${TARGET_BRANCH}'"
+      echo "INFO: Target chart directory will be '${TARGET_CHART_DIR}'"
+    - git remote add github-${CI_JOB_ID} https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_HELM_REPO}
+    - |
+      if git ls-remote --exit-code --heads "https://ignored:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_HELM_REPO}" "$TARGET_BRANCH"; then
+        echo "INFO: Branch ${TARGET_BRANCH} exists in Helm repo. Checking it out."
+        git fetch github-${CI_JOB_ID} ${TARGET_BRANCH}:overlay-version-bump-${CI_JOB_ID}
+      else
+        echo "INFO: Branch ${TARGET_BRANCH} does not exist in Helm repo. Creating it from 'staging' branch."
+        git fetch github-${CI_JOB_ID} staging:overlay-version-bump-${CI_JOB_ID}
+      fi
+    - git checkout overlay-version-bump-${CI_JOB_ID}
+    - | # Create the target directory and copy the chart
+      if [ "${TARGET_CHART_DIR}" != "${CHART_DIR}" ]; then
+        mkdir -p "${TARGET_CHART_DIR}"
+        cp -r "${CHART_DIR}/." "${TARGET_CHART_DIR}/"
+      fi
+    - echo "INFO - checking values files"
+    - test -e ${TARGET_CHART_DIR}/values.yaml || ( echo "ERROR - ${TARGET_CHART_DIR}/values.yaml doesn't exist" ; exit 1 )
+    - test -e ${TARGET_CHART_DIR}/Chart.yaml || ( echo "ERROR - ${TARGET_CHART_DIR}/Chart.yaml doesn't exist" ; exit 1 )
+    - |
+      for SERVICE_MAPPING in $(echo ${SERVICES}); do
+        CONTAINER=$(echo "${SERVICE_MAPPING}" | cut -d':' -f1)
+        CONTAINER_KEY=$(echo "${SERVICE_MAPPING}" | cut -d':' -f2)
+        if [[ -n "${CI_COMMIT_TAG}" ]]; then
+          # For tag pipelines, use the Git tag as the image tag.
+          export THIS_TAG="${CI_COMMIT_TAG}"
+        else
+          # For branch pipelines, use the branch slug + image digest for uniqueness.
+          export THIS_TAG="${CI_COMMIT_REF_SLUG}@$(cat ${DIGESTS_FOLDER}/${CONTAINER})"
+        fi
+        echo "INFO - container ${CONTAINER} image identifier is: ${THIS_TAG}"
+        if [ -z "${THIS_TAG}" ]; then
+          echo "ERROR - can't find tag for container ${CONTAINER}"
+          exit 1
+        fi
+        echo "INFO - bumping version ${THIS_TAG} to ${CONTAINER} image tag"
+        THIS_KEY=".${CONTAINER_KEY}.image.tag" THIS_VALUE="${THIS_TAG}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${TARGET_CHART_DIR}/values.yaml
+        if [[ "${CONTAINER}" == "gui" ]]; then
+          THIS_KEY=".${CONTAINER_KEY}.image.registry" THIS_VALUE="${HELM_MENDER_PUBLISH_REGISTRY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${TARGET_CHART_DIR}/values.yaml
+          THIS_KEY=".${CONTAINER_KEY}.image.repository" THIS_VALUE="${HELM_MENDER_PUBLISH_REPOSITORY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${TARGET_CHART_DIR}/values.yaml
+        fi
+      done
+    - git add ${TARGET_CHART_DIR}/values.yaml
+    - echo "DEBUG - display values file content"
+    - cat ${TARGET_CHART_DIR}/values.yaml
+    - echo "INFO - bumping helm chart version"
+    - FULL_VERSION=$(yq ".version" ${TARGET_CHART_DIR}/Chart.yaml)
+    - MAJOR_VERSION=$(echo $FULL_VERSION | cut -f1 -d.)
+    - MINOR_VERSION=$(echo $FULL_VERSION | cut -f2 -d.)
+    - PATCH_VERSION=$(echo $FULL_VERSION | cut -f3 -d. | cut -f1 -d\-)
+    - THIS_VALUE="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}-${HELM_PATCH_VERSION}" yq -i '.version = strenv(THIS_VALUE)' ${TARGET_CHART_DIR}/Chart.yaml
+    - git add ${TARGET_CHART_DIR}/Chart.yaml
+    - cat ${TARGET_CHART_DIR}/Chart.yaml
+    - | # Generate and commit the HelmRelease manifest for the dev branch env
+      if [ "${TARGET_CHART_DIR}" != "${CHART_DIR}" ]; then
+        HELMRELEASE_DIR="releases/dev"
+        mkdir -p "${HELMRELEASE_DIR}"
+        HELMRELEASE_NAME="mender-$(echo ${TARGET_CHART_DIR} | sed 's|/|-|g')"
+        HELMRELEASE_FILE="${HELMRELEASE_DIR}/${HELMRELEASE_NAME}.yaml"
+
+        echo "INFO - Generating HelmRelease manifest at ${HELMRELEASE_FILE}"
+
+        cat << EOF > "${HELMRELEASE_FILE}"
+        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        kind: HelmRelease
+        metadata:
+          name: ${HELMRELEASE_NAME}
+          namespace: mender-dev # TODO: namespace per branch env?
+        spec:
+          interval: 5m
+          chart:
+            spec:
+              chart: ./${TARGET_CHART_DIR}
+              sourceRef:
+                kind: GitRepository
+                name: mender-helm # TODO: is this correct?
+                namespace: flux-system
+              version: "${THIS_VALUE}"
+          releaseName: ${HELMRELEASE_NAME}
+        EOF
+
+        git add "${HELMRELEASE_FILE}"
+      fi
+    - git commit --signoff --message "[CI/CD] bump helm chart"
+    - |
+      for retry in $(seq 5); do
+        if git push github-${CI_JOB_ID} overlay-version-bump-${CI_JOB_ID}:${TARGET_BRANCH}; then
+          exit 0
+        fi
+        git fetch github-${CI_JOB_ID} ${TARGET_BRANCH}
+        git rebase github-${CI_JOB_ID}/${TARGET_BRANCH}
+        sleep ${TIMEOUT_SECONDS:-5}
+      done
+      echo "ERROR - can't push to github"
+      exit 1
+  after_script:
+    - git remote remove github-${CI_JOB_ID}
+    - cd ${PROJECT_FOLDER}
+    - rm -rf /tmp/helm
+
+# JOBS #
+
+#
+# Build backend services docker images
+#
+build:backend:docker:
+  extends: .template:build:docker
+  rules:
+    - changes:
+        paths: ["backend/**/*"]
+        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
+      when: always
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+  script:
+    # FIXME: Only exporting deployments build stage to run unit tests
+    #        We're assuming the images have consistent GOTOOLCHAIN.
+    #        Will be fixed once we optimize to template based pipeline.
+    - |-
+      make -C backend/services/deployments docker \
+        DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
+        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
+    - make -C backend docker
+
+#
+# Build backend services docker images for acceptance tests
+#
+build:backend:docker-acceptance:
+  extends: build:backend:docker
+  rules:
+    - when: never
+  before_script:
+    - *requires-docker
+    - apk add make bash git
+    - *dind-login
+    # We're only building acceptance test images for CI runner platform.
+    - unset DOCKER_PLATFORM
+  script:
+    # NOTE: Only build for test platform (default) for the acceptance test images
+    - make -C backend docker-acceptance
+
+#
+# Run backend static analysis
+#
+test:backend:static:
+  stage: test
+  needs: []
+  rules:
+    - when: never
+  image: "golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
+  script:
+    - cd backend
+    - golangci-lint run -v
+
+#
+# Validate backend OpenAPI specifications
+#
+test:backend:validate-open-api:
+  stage: test
+  needs: []
+  rules:
+    - when: never
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine:${ALPINE_VERSION}
+  before_script:
+    - apk add --no-cache curl
+    - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
+    - sh install.sh
+  script:
+    - |
+      cat > .spectral.yaml << EOF
+      extends: [['spectral:oas', all]]
+      parserOptions:
+        incompatibleValues: 1
+      EOF
+    - spectral lint -v -D -f text backend/services/**/docs/*.yml backend/docs/api/*.yaml
+    - spectral lint -v -D -f junit -o spectral-report.xml backend/services/**/docs/*.yml backend/docs/api/*.yml
+  artifacts:
+    when: always
+    expire_in: 2 weeks
+    reports:
+      junit: $CI_PROJECT_DIR/spectral-report.xml
+
+#
+# Run backend unit tests
+#
+test:backend:unit:
+  # FIXME: Using deployments build stage since we're running all tests
+  image: "${CI_REGISTRY_IMAGE}/deployments:${MENDER_IMAGE_TAG_BUILDER}"
+  stage: test
+  needs:
+    - job: build:backend:docker
+      artifacts: false
+  resource_group: test_backend_unit
+  rules:
+    - when: never
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:${MONGO_VERSION}
+      alias: mongo
+  variables:
+    TEST_MONGO_URL: "mongodb://mongo"
+    WORKFLOWS_MONGO_URL: "mongodb://mongo"
+  before_script:
+    - mkdir -p $GOCOVERDIR
+  script:
+    - |
+      make -C backend test-unit \
+        TESTFLAGS="-cover -coverprofile=${GOCOVERDIR}/\$(COMPONENT)-unit.cover"
+  artifacts:
+    expire_in: 1w
+    when: on_success
+    paths:
+      - ${GOCOVERDIR}/*-unit.cover
+
+#
+# Run backend acceptance tests
+#
+test:backend:acceptance:
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  extends: .build:base
+  stage: test
+  rules:
+    - when: never
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+      alias: docker
+  needs:
+    - job: build:backend:docker
+      artifacts: false
+    - job: build:backend:docker-acceptance
+      artifacts: false
+  before_script:
+    - *requires-docker
+    - apk add make bash git
+    - *dind-login
+    - make -C backend -j 4 docker-pull
+    - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_TEST}
+    - mkdir -p $GOCOVERDIR
+  script:
+    # NOTE: Setting GOCOVERDIR this way will group the coverage report per
+    #       service (using make variable: COMPONENT).
+    - make -C backend test-acceptance GOCOVERDIR="${GOCOVERDIR}/\$(COMPONENT)-acceptance"
+  artifacts:
+    expire_in: 1w
+    when: on_success
+    paths:
+      - ${GOCOVERDIR}/*-acceptance
+
+#
+# Run backend integration tests
+#
+test:backend:integration:
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  stage: test
+  extends: .build:base
+  rules:
+    - when: never
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+      alias: docker
+      variables:
+        HEALTHCHECK_TCP_PORT: "2376"
+  needs:
+    - job: build:backend:docker
+      artifacts: false
+    - job: build:backend:docker-acceptance
+      artifacts: false
+  before_script:
+    - *requires-docker
+    - apk add make bash git curl
+    - *dind-login
+    - mkdir -p ${GOCOVERDIR}/integration
+    - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
+  script:
+    - make -C backend test-integration
+      GOCOVERDIR=${GOCOVERDIR}/integration
+      MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
+  artifacts:
+    expire_in: 1w
+    when: always
+    paths:
+      - ${GOCOVERDIR}/integration
+      - backend/logs.*
+      - backend/results_integration_*.xml
+      - backend/report_integration_*.html
+    reports:
+      junit: backend/results_integration_*.xml
+
+#
+# Trigger full integration test pipeline
+#
+test:integration:
+  stage: test
+  needs:
+    - job: build:backend:docker
+      artifacts: false
+    - job: build:frontend:docker
+      artifacts: false
+  rules:
+    - when: never
+  variables:
+    # NOTE: Cannot use indirect values based off CI_* since these will be
+    #       expanded in the downstream project context.
+    MENDER_SERVER_REGISTRY: "${CI_REGISTRY}"
+    MENDER_SERVER_REPOSITORY: "northern.tech/mender/${CI_PROJECT_NAME}"
+    MENDER_SERVER_TAG: "build-${CI_COMMIT_SHA}"
+    PYTEST_ADDOPTS: "-k 'not Enterprise'"
+    RUN_TESTS_FULL_INTEGRATION: "true"
+  trigger:
+    project: "Northern.tech/Mender/integration"
+
+#
+# Prepare artifacts for staging deployment tests
+#
+test:prep:
+  stage: test
+  extends: .build:base
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker
+  rules:
+    - when: never
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+      alias: docker
+  script:
+    - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/extract mendersoftware/mender-stress-test-client:master -c "cp mender-stress-test-client /extract/"
+  artifacts:
+    paths:
+      - mender-stress-test-client
+    expire_in: 2w
+  tags:
+    - hetzner-amd-beefy
+
+#
+# Run e2e tests on staging using Chrome
+#
 test:staging-deployment:chrome:
   extends: .template:test:staging-deployment
   script:
     - npx playwright install chromium
     - npm run test -- --project=chromium
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: delayed
-      start_in: 3 minutes
+    - when: never
 
+#
+# Run e2e tests on staging using Firefox
+#
 test:staging-deployment:firefox:
   extends: .template:test:staging-deployment
   script:
     - npx playwright install firefox
     - npm run test -- --project=firefox
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: delayed
-      start_in: 10 minutes
+    - when: never
 
+#
+# Run e2e tests on staging using Webkit
+#
+test:staging-deployment:webkit:
+  extends: .template:test:staging-deployment
+  allow_failure: true
+  script:
+    - npx playwright install webkit
+    - npm run test -- --project=webkit
+  rules:
+    - when: never
+
+#
+# Publish backend code coverage to Coveralls
+#
 publish:backend:coverage:
   stage: publish
   needs:
@@ -468,12 +632,7 @@ publish:backend:coverage:
       artifacts: true
       optional: true
   rules:
-    - changes:
-        paths: ["backend/**/*"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: on_success
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
+    - when: never
   image: "golang:${GOLANG_VERSION}"
   allow_failure: true # QA-925 - Coveralls servers are unreliable.
   variables:
@@ -495,6 +654,9 @@ publish:backend:coverage:
           -coverprofile="${coverpath}"
       done
 
+#
+# Publish backend docker images
+#
 publish:backend:docker:
   stage: publish
   image:
@@ -547,14 +709,13 @@ publish:backend:docker:
     paths:
       - .digests
 
+#
+# Check and report backend licenses
+#
 publish:backend:licenses:
   stage: publish
   rules:
-    - changes:
-        paths: ["backend/**/*"]
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: on_success
+    - when: never
   image: golang:${GOLANG_VERSION}
   variables:
     GOFLAGS: -tags=nopkcs11
@@ -576,12 +737,13 @@ publish:backend:licenses:
     paths:
       - backend/licenses.md
 
+#
+# Publish open-source licenses to the documentation website
+#
 publish:licenses:docs-site:
   stage: .post
   rules:
-    # Only make available for stable branches
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
-      allow_failure: true
+    - when: never
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
   needs:
     - job: publish:backend:licenses
@@ -609,15 +771,23 @@ publish:licenses:docs-site:
   after_script:
     - git remote remove licenses-${CI_JOB_ID}
 
+#
+# Notify Coveralls that all parallel jobs are finished
+#
 coveralls:done:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/curlimages/curl
   stage: .post
+  rules:
+    - when: never
   allow_failure: true # QA-925 - Coveralls servers are unreliable.
   script:
     - curl "https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN&carryforward=frontend-unit,frontend-e2e,frontend-e2e-enterprise,create-artifact-worker-unit,deployments-unit,deployments-acceptance,deviceauth-unit,deviceauth-acceptance,deviceconfig-unit,deviceconfig-acceptance,deviceconnect-unit,deviceconnect-acceptance,inventory-unit,inventory-acceptance,iot-manager-unit,iot-manager-acceptance,useradm-unit,useradm-acceptance,workflows-unit,workflows-acceptance,integration" -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"
   tags:
     - hetzner-amd-beefy
 
+#
+# Generate changelog and create a release PR
+#
 changelog:
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
   stage: changelog
@@ -630,14 +800,7 @@ changelog:
   tags:
     - hetzner-amd-beefy
   rules:
-    # Only run for protected branches (main and maintenance branches)
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
-      when: never
-      # QA-1073: Trigger main release candidates manually for open source
-    - if: $CI_PROJECT_NAME == "mender-server" && $CI_COMMIT_BRANCH == "main"
-      when: manual
-      allow_failure: true
-    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
+    - when: never
   before_script:
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
@@ -688,18 +851,16 @@ changelog:
   after_script:
     - git remote remove github-${CI_JOB_ID}
 
+#
+# Create a GitHub release
+#
 release:github:
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
   stage: .post
   tags:
     - hetzner-amd-beefy
   rules:
-    # Only make available for protected branches (main and maintenance branches)
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
-      when: never
-    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_BRANCH != ""
-      when: manual
-      allow_failure: true
+    - when: never
   needs:
     - job: changelog
   script:
@@ -708,15 +869,16 @@ release:github:
       --repo-url=${GITHUB_REPO_URL}
       --target-branch=${CI_COMMIT_REF_NAME}
 
+#
+# Update the changelog on the Mender documentation website
+#
 release:mender-docs-changelog:
   image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:release-please-v1-master"
   stage: .post
   tags:
     - hetzner-amd-beefy
   rules:
-    # Only make available for stable branches
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
-      allow_failure: true
+    - when: never
   before_script:
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
@@ -747,16 +909,15 @@ release:mender-docs-changelog:
     - git push origin changelog-${CI_JOB_ID}
     - gh pr create --title "Update CHANGELOG${CHANGELOG_SUFFIX}.md for $CI_PROJECT_NAME" --body "Automated change to the CHANGELOG${CHANGELOG_SUFFIX}.md file" --base master --head changelog-${CI_JOB_ID}
 
+#
+# Update the changelog on the Mender documentation website for SaaS releases
+#
 release:mender-docs-changelog:saas:
   extends: release:mender-docs-changelog
   variables:
     CHANGELOG_REMOTE_FILE: "12.Hosted-Mender/docs.md"
   rules:
-    - if: '$CI_PROJECT_NAME == "mender-server"'
-      when: never
-    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+(?:-saas\.*\d*)?$/'
-    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
-      when: never
+    - when: never
   before_script:
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
@@ -768,113 +929,7 @@ release:mender-docs-changelog:saas:
     - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
 
 #
-# Helm version bump
-#
-.helm-version-bump:
-  needs:
-    - job: publish:backend:docker
-      artifacts: true
-    - job: publish:frontend:docker
-      artifacts: true
-  rules:
-    - if: $CI_COMMIT_REF_PROTECTED == "true" && $CI_COMMIT_REF_NAME == "main"
-      when: on_success
-    - if: $CI_COMMIT_TAG =~ "/^v\d+\.\d+\.\d+(?:-rc(?:[\.\d]*))*$/"
-      when: on_success
-    - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
-      when: never
-  allow_failure: true
-  tags:
-    - hetzner-amd-beefy
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master
-  variables:
-    HELM_PATCH_VERSION: ${CI_PIPELINE_ID}
-  before_script:
-    - git config --global user.email "${GITHUB_USER_EMAIL}"
-    - git config --global user.name "${GITHUB_USER_NAME}"
-    - export DIGESTS_FOLDER=$(pwd)/.digests
-    - export PROJECT_FOLDER=$(pwd)
-  script:
-    - git clone https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_HELM_REPO} /tmp/helm
-    - cd /tmp/helm
-    - git remote add github-${CI_JOB_ID} https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_HELM_REPO}
-    - git fetch github-${CI_JOB_ID} ${SYNC_ENVIRONMENT:-staging}:overlay-version-bump-${CI_JOB_ID}
-    - git checkout overlay-version-bump-${CI_JOB_ID}
-    - echo "INFO - checking values files"
-    - test -e ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml || ( echo "ERROR - ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml doesn't exists" ; exit 1 )
-    - test -e ${CHART_DIR}/Chart.yaml || ( echo "ERROR - ${CHART_DIR}/Chart.yaml doesn't exists" ; exit 1 )
-    - |
-      for CONTAINER in $(echo ${SERVICES}); do
-        if [[ "${CI_COMMIT_REF_NAME}" == "main" ]]; then
-          export THIS_TAG="main@$(cat ${DIGESTS_FOLDER}/${CONTAINER})"
-          echo "INFO - container ${CONTAINER} SHA is: ${THIS_TAG}"
-        else
-          export THIS_TAG="${CI_COMMIT_TAG}"
-        fi
-        if [ -z "${THIS_TAG}" ]; then
-          echo "ERROR - can't find tag for container ${CONTAINER}"
-          exit 1
-        fi
-        echo "INFO - bumping version ${THIS_TAG} to ${CONTAINER} image tag"
-        CONTAINER_KEY=${CONTAINER}
-        if [[ "${CHART_DIR}" == "mender" ]]; then
-          case ${CONTAINER} in
-            deviceauth)
-              CONTAINER_KEY="device_auth"
-              ;;
-            create-artifact-worker)
-              CONTAINER_KEY="create_artifact_worker"
-              ;;
-            generate-delta-worker)
-              CONTAINER_KEY="generate_delta_worker"
-              ;;
-            iot-manager)
-              CONTAINER_KEY="iot_manager"
-              ;;
-          esac
-        elif [[ "${CHART_DIR}" == "alvaldi" ]]; then
-          case ${CONTAINER} in
-            iot-manager)
-              CONTAINER_KEY="iotManager"
-              ;;
-          esac
-        fi
-        THIS_KEY=".${CONTAINER_KEY}.image.tag" THIS_VALUE="${THIS_TAG}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-        if [[ "${CONTAINER}" == "gui" ]]; then
-          THIS_KEY=".${CONTAINER_KEY}.image.registry" THIS_VALUE="${HELM_MENDER_PUBLISH_REGISTRY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-          THIS_KEY=".${CONTAINER_KEY}.image.repository" THIS_VALUE="${HELM_MENDER_PUBLISH_REPOSITORY}" yq -i 'eval(strenv(THIS_KEY)) = strenv(THIS_VALUE)' ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-        fi
-      done
-    - git add ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-    - echo "DEBUG - display values file content"
-    - cat ${CHART_DIR}/values-${SYNC_ENVIRONMENT}.yaml
-    - echo "INFO - bumping helm chart version"
-    - FULL_VERSION=$(yq ".version" ${CHART_DIR}/Chart.yaml)
-    - MAJOR_VERSION=$(echo $FULL_VERSION | cut -f1 -d.)
-    - MINOR_VERSION=$(echo $FULL_VERSION | cut -f2 -d.)
-    - PATCH_VERSION=$(echo $FULL_VERSION | cut -f3 -d. | cut -f1 -d\-)
-    - THIS_VALUE="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}-${HELM_PATCH_VERSION}" yq -i '.version = strenv(THIS_VALUE)' ${CHART_DIR}/Chart.yaml
-    - git add ${CHART_DIR}/Chart.yaml
-    - cat ${CHART_DIR}/Chart.yaml
-    - git commit --signoff --message "[CI/CD] bump helm chart"
-    - |
-      for retry in $(seq 5); do
-        if git push github-${CI_JOB_ID} overlay-version-bump-${CI_JOB_ID}:${SYNC_ENVIRONMENT:-staging}; then
-          exit 0
-        fi
-        git fetch github-${CI_JOB_ID} ${SYNC_ENVIRONMENT:-staging}
-        git rebase github-${CI_JOB_ID}/${SYNC_ENVIRONMENT:-staging}
-        sleep ${TIMEOUT_SECONDS:-5}
-      done
-      echo "ERROR - can't push to github"
-      exit 1
-  after_script:
-    - git remote remove github-${CI_JOB_ID}
-    - cd ${PROJECT_FOLDER}
-    - rm -rf /tmp/helm
-
-#
-# Mender Helm Rolling release
+# Mender Helm Rolling release for staging
 #
 mender-helm-version-bump:staging:
   extends: .helm-version-bump
@@ -882,7 +937,25 @@ mender-helm-version-bump:staging:
   stage: deploy-staging
   variables:
     GITHUB_HELM_REPO: "mendersoftware/mender-helm"
-    SERVICES: gui
+    # A space-separated list of 'service_name:helm_key'
+    SERVICES: "create-artifact-worker:create_artifact_worker deployments:deployments deviceauth:device_auth deviceconfig:deviceconfig deviceconnect:deviceconnect gui:gui inventory:inventory iot-manager:iot_manager useradm:useradm workflows:workflows"
     CHART_DIR: "mender"
     SYNC_ENVIRONMENT: staging
     HELM_PATCH_VERSION: ${CI_PIPELINE_ID}-staging # pre-release version for trigger staging only deploy
+  rules:
+    - if: $CI_COMMIT_REF_NAME == 'main'
+
+#
+# Mender Helm Rolling release for branches
+#
+mender-helm-version-bump:branch:
+  extends: .helm-version-bump
+  resource_group: mender-helm-${CI_COMMIT_REF_SLUG}
+  stage: deploy-staging
+  variables:
+    GITHUB_HELM_REPO: "mendersoftware/mender-helm"
+    # A space-separated list of 'service_name:helm_key'
+    SERVICES: "create-artifact-worker:create_artifact_worker deployments:deployments deviceauth:device_auth deviceconfig:deviceconfig deviceconnect:deviceconnect gui:gui inventory:inventory iot-manager:iot_manager useradm:useradm workflows:workflows"
+    CHART_DIR: "mender"
+  rules:
+    - if: $CI_COMMIT_BRANCH && $CI_COMMIT_REF_NAME != 'main'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -922,10 +922,10 @@ mender-helm-version-bump:staging:
   resource_group: mender-helm
   stage: deploy-staging
   variables:
-    GITHUB_HELM_REPO: "mendersoftware/mender-helm"
+    GITHUB_HELM_REPO: "NorthernTechHQ/nt-boilerplate-pipeline"
     # A space-separated list of 'service_name:helm_key'
     SERVICES: "create-artifact-worker:create_artifact_worker deployments:deployments deviceauth:device_auth deviceconfig:deviceconfig deviceconnect:deviceconnect gui:gui inventory:inventory iot-manager:iot_manager useradm:useradm workflows:workflows"
-    CHART_DIR: "mender"
+    CHART_DIR: "helm/mender"
     SYNC_ENVIRONMENT: staging
     HELM_PATCH_VERSION: ${CI_PIPELINE_ID}-staging # pre-release version for trigger staging only deploy
   rules:
@@ -939,9 +939,9 @@ mender-helm-version-bump:branch:
   resource_group: mender-helm-${CI_COMMIT_REF_SLUG}
   stage: deploy-staging
   variables:
-    GITHUB_HELM_REPO: "mendersoftware/mender-helm"
+    GITHUB_HELM_REPO: "NorthernTechHQ/nt-boilerplate-pipeline"
     # A space-separated list of 'service_name:helm_key'
     SERVICES: "create-artifact-worker:create_artifact_worker deployments:deployments deviceauth:device_auth deviceconfig:deviceconfig deviceconnect:deviceconnect gui:gui inventory:inventory iot-manager:iot_manager useradm:useradm workflows:workflows"
-    CHART_DIR: "mender"
+    CHART_DIR: "helm/mender"
   rules:
     - if: $CI_COMMIT_BRANCH && $CI_COMMIT_REF_NAME != 'main'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -654,6 +654,15 @@ publish:backend:docker:
       when: never
     - if: $CI_COMMIT_TAG || $CI_COMMIT_BRANCH
   before_script:
+    - |
+      if [ "$CI_COMMIT_REF_PROTECTED" == "true" ]; then
+        export MENDER_PUBLISH_REGISTRY="docker.io"
+        echo "INFO: Protected branch. Publishing to public registry: ${MENDER_PUBLISH_REGISTRY}"
+      else
+        export MENDER_PUBLISH_REGISTRY="${CI_REGISTRY}"
+        export MENDER_PUBLISH_REPOSITORY="${MENDER_IMAGE_REPOSITORY}"
+        echo "INFO: Unprotected branch. Publishing to internal registry: ${MENDER_PUBLISH_REGISTRY}/${MENDER_PUBLISH_REPOSITORY}"
+      fi
     - skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io
     - dnf install -y make git-core

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -652,7 +652,6 @@ publish:backend:docker:
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-    - when: never
   before_script:
     - skopeo login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - skopeo login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD docker.io

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -297,8 +297,6 @@ publish:frontend:e2e-tests:enterprise:
 
 publish:frontend:docker:
   extends: publish:backend:docker
-  variables:
-    MENDER_PUBLISH_REGISTRY: docker.io
   script:
     - export MENDER_PUBLISH_IMAGE="${MENDER_PUBLISH_REGISTRY}/${FRONTEND_REPOSITORY}"
     - echo "About to publish ${DOCKER_TAG} to ${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG}"


### PR DESCRIPTION
This introduces GitOps flow for deploying development branches to our staging cluster.  

The CI code has been updated to automate the process of deploying branches through committing HelmRelease, Charts, and values.yaml files to the `mender-helm` repository, so that FluxCD can notice these and create a per-branch environment on the cluster.

**Key changes:**
* added a new `mender-helm-version-bump:branch` job that uses (now very very) changed `.helm-version-bump:` template
  * for dev branches, this will commit Charts and values to a new sub-directory `<branch-name>` in `mender-helm` repo under a new `dev/` parent directory
  * also adds a `HelmRelease` manifest to Flux, so that Flux starts watching the new stuff in the `dev/<branch-name>` sub-directory
* existing staging deployments from `main` I tried not to touch too much

**Example flow:**

1. developer creates a new branch, for example `feature/new-api`, commits changes, and pushes to remote
2. the push to the `feature/new-api` branch triggers a new CI pipeline
3. job `build:backend:docker` builds and publishes container images, saves their `.digest`
4. `mender-helm-version-bump:branch` job runs:
    (triggered for any non-main branch)
    Clones the `mendersoftware/mender-helm` repository
    Creates a new branch named `dev/feature-new-api` if one does not already exist
    Copies the production Helm chart to a new sub-directory named `dev/feature-new-api`
    Updates the `values.yaml` file in the new directory with the image tags of the container images that were just built
    Updates the `Chart.yaml` file with a new pre-release version, for example `4.0.0-12345` where `12345` is the pipeline ID
    Creates a new `HelmRelease` manifest file for the new environment
    Commits and pushes all these changes to the `dev/feature-new-api` branch in the `mender-helm` repo
5. FluxCD reconciles the changes and attempts to deploy the new version in a dedicated namespace on the staging cluster

**TODO:**
* Cleanup - There should be an automated way for a dev branch environment to be cleaned up after it's branch in mender-server is deleted, maybe some combination of Gitlab's Environments and .post jobs that delete the branch in `mender-helm` so that FluxCD removes the environment automatically when it notices the dev branch is missing
  * I threw something together for this here https://gist.github.com/dhaustein/6504b94b542926ec87005f7ae2ecb448
* Everything else - I commented out most of the other steps like linting, tests, frontend etc. because I want to focus on the deployment first, but we need those to work with the dev environments too ofc

Ticket: QA-1109
Changelog: none