### PR TITLE
conf(tests): run compose tests as `linux/amd64` always

### DIFF
--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -3,6 +3,7 @@ include:
 
 services:
   acceptance-tester:
+    platform: linux/amd64
     scale: 0
     image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_ACCEPTANCE_IMAGE_TAG:-acceptance}"
     build:
@@ -21,6 +22,7 @@ services:
       - workflows-worker
 
   integration-tester:
+    platform: linux/amd64
     scale: 0
     image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_INTEGRATION_IMAGE_TAG:-integration_v2}"
     build:


### PR DESCRIPTION
**Description**

The integration and acceptance tests use a `mender-artifact` binary built for `x86-64` in many tests, and these tests always fail if the `acceptance-tester` and `integration-tester` are built for `arm64` (which is the case on MacOS unless a platform is defined).

I believe this should make no difference for non MacOS users (CI included) as this should be how the "testers" are already being built on those platforms.