### PR TITLE
MEN-8686: Handle error conditions during trial signup gracefully in gui

### DIFF
--- a/frontend/src/js/components/login/Signup.tsx
+++ b/frontend/src/js/components/login/Signup.tsx
@@ -132,11 +132,13 @@ export const Signup = () => {
       plan: 'enterprise',
       ts: captchaTimestamp
     };
-    return dispatch(createOrganizationTrial(signup)).catch(() => {
-      setFormValues({ ...formValues, ...formData, captcha: '' });
-      setIsStarting(true);
-      setLoading(false);
-    });
+    return dispatch(createOrganizationTrial(signup))
+      .unwrap()
+      .catch(() => {
+        setFormValues({ ...formValues, ...formData, captcha: '' });
+        setIsStarting(true);
+        setLoading(false);
+      });
   };
 
   const onUserDataSubmit = (formData: UserData) => {

--- a/frontend/src/js/store/organizationSlice/thunks.ts
+++ b/frontend/src/js/store/organizationSlice/thunks.ts
@@ -77,10 +77,13 @@ export const createOrganizationTrial = createAsyncThunk(`${sliceName}/createOrga
   const target = `${targetLocation}${tenantadmApiUrlv2}/tenants/trial`;
   return Api.postUnauthorized(target, data)
     .catch(err => {
-      if (err.response.status >= 400 && err.response.status < 500) {
+      if (err.response?.status >= 400 && err.response?.status < 500) {
         dispatch(setSnackbar({ message: err.response.data.error, autoHideDuration: TIMEOUTS.fiveSeconds }));
-        return Promise.reject(err);
+      } else {
+        // This handles "timeouts", "general connectivity" and "500 - Internal Server Error" errors
+        dispatch(setSnackbar({ message: 'There was an error creating your account', autoHideDuration: TIMEOUTS.fiveSeconds }));
       }
+      return Promise.reject(err);
     })
     .then(({ headers }) => {
       cookies.remove('oauth');


### PR DESCRIPTION
**Description**

While investigating what could/would cause the backend to hang occasionally (the root cause of MEN-8686) I found that the `gui` is not handling `500 - Internal Server Error`, `timeouts` and other `"connectivity errors"` from the `/tenants/trial` backend endpoint. This is what causes the UI to "hang forever" on the loading page when the `backend` is struggling (with what is yet to be determined).

Although not the root cause of [MEN-8686](https://northerntech.atlassian.net/browse/MEN-8686), this is imo worth fixing as it improves the experience of the user if/when they experience this issue in the wild.

[MEN-8686]: https://northerntech.atlassian.net/browse/MEN-8686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ