### PR TITLE
chore(gui): fixed input sizing in non-standard inputs to align w/ new theme

### DIFF
--- a/frontend/src/js/common-ui/forms/TimeframePicker.tsx
+++ b/frontend/src/js/common-ui/forms/TimeframePicker.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
+import { useTheme } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 import dayjs from 'dayjs';
@@ -32,6 +33,9 @@ export const TimeframePicker = ({ tonight: propsTonight }) => {
   const [tonight] = useState(dayjs(propsTonight));
   const [maxStartDate, setMaxStartDate] = useState(tonight);
   const [minEndDate, setMinEndDate] = useState(tonight);
+
+  const theme = useTheme();
+  const isNextTheme = !theme.palette.background.lightgrey;
 
   const { control, setValue, watch, getValues } = useFormContext();
 
@@ -71,6 +75,7 @@ export const TimeframePicker = ({ tonight: propsTonight }) => {
             disableFuture
             slotProps={{
               textField: props => ({
+                size: isNextTheme ? 'small' : 'medium',
                 inputProps: {
                   ...props.inputProps,
                   'aria-label': 'From'
@@ -94,6 +99,7 @@ export const TimeframePicker = ({ tonight: propsTonight }) => {
             disableFuture
             slotProps={{
               textField: props => ({
+                size: isNextTheme ? 'small' : 'medium',
                 inputProps: {
                   ...props.inputProps,
                   'aria-label': 'To'

--- a/frontend/src/js/components/releases/Releases.tsx
+++ b/frontend/src/js/components/releases/Releases.tsx
@@ -73,7 +73,11 @@ const useStyles = makeStyles()(theme => ({
   searchNote: { minHeight: '1.8rem' },
   tabContainer: { alignSelf: 'flex-start' },
   uploadButton: { minWidth: 164, marginRight: theme.spacing(2) },
-  nameSearch: { [`.${inputBaseClasses.root}.${outlinedInputClasses.root}`]: { paddingTop: theme.spacing(), paddingBottom: theme.spacing() } }
+  nameSearch: {
+    [`.${inputBaseClasses.root}.${outlinedInputClasses.root}`]: {
+      padding: theme.palette.background.lightgrey ? `${theme.spacing()} 0 ${theme.spacing()} 14px` : ''
+    }
+  }
 }));
 
 const Header = ({ canUpload, releasesListState, setReleasesListState, onUploadClick }) => {

--- a/frontend/src/js/components/releases/__snapshots__/Releases.test.tsx.snap
+++ b/frontend/src/js/components/releases/__snapshots__/Releases.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`Releases Component > renders correctly 1`] = `
               Release name
             </h5>
             <div
-              class="MuiFormControl-root MuiTextField-root css-1f2jaah-MuiFormControl-root-MuiTextField-root-nameSearch"
+              class="MuiFormControl-root MuiTextField-root css-1fcjm1w-MuiFormControl-root-MuiTextField-root-nameSearch"
             >
               <div
                 class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-uf2sy4-MuiInputBase-root-MuiOutlinedInput-root"


### PR DESCRIPTION
next theme before:
<img width="773" height="240" alt="Screenshot 2025-09-01 at 13 54 40" src="https://github.com/user-attachments/assets/4421a871-bbe7-4708-9b02-ac9048beccf3" />
next theme after:
<img width="815" height="281" alt="Screenshot 2025-09-01 at 13 56 34" src="https://github.com/user-attachments/assets/af639a84-4cc7-4f18-86d8-2489114b04da" />
