### PR TITLE
chore(gui): aligned customized accordions w/ updated theme

### DIFF
--- a/frontend/src/js/components/deployments/CreateDeployment.tsx
+++ b/frontend/src/js/components/deployments/CreateDeployment.tsx
@@ -62,7 +62,7 @@ import { Devices, ReleasesWarning, Software } from './deployment-wizard/Software
 
 const useStyles = makeStyles()(theme => ({
   accordion: {
-    backgroundColor: theme.palette.grey[400],
+    backgroundColor: theme.palette.background.lightgrey ? theme.palette.grey[400] : theme.palette.info.light,
     marginTop: theme.spacing(4),
     '&:before': {
       display: 'none'

--- a/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
+++ b/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
@@ -834,9 +834,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-26:focus::-ms-input-
 
 .emotion-38 {
   background-color: #f7f7f7;
-  border-color: #e9e9e9;
-  border-style: solid;
-  border-width: 1px;
   margin-bottom: 16px;
   min-width: 700px;
   padding: 16px;

--- a/frontend/src/js/components/devices/device-details/__snapshots__/AuthStatus.test.tsx.snap
+++ b/frontend/src/js/components/devices/device-details/__snapshots__/AuthStatus.test.tsx.snap
@@ -149,9 +149,6 @@ exports[`AuthStatus Component > renders correctly 1`] = `
 
 .emotion-3 {
   background-color: #f7f7f7;
-  border-color: #e9e9e9;
-  border-style: solid;
-  border-width: 1px;
   margin-bottom: 16px;
   min-width: 700px;
   padding: 16px;

--- a/frontend/src/js/components/devices/device-details/authsets/AuthSetList.tsx
+++ b/frontend/src/js/components/devices/device-details/authsets/AuthSetList.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()(theme => ({
     }
   },
   accordion: {
-    backgroundColor: theme.palette.grey[50],
+    backgroundColor: theme.palette.background.lightgrey ? theme.palette.grey[50] : theme.palette.info.light,
     '&:before': { display: 'none' },
     '&$expanded': { margin: 'auto' },
     [`.columns-4 .${accordionSummaryClasses.content}`]: {

--- a/frontend/src/js/components/devices/device-details/authsets/AuthSets.tsx
+++ b/frontend/src/js/components/devices/device-details/authsets/AuthSets.tsx
@@ -32,10 +32,7 @@ import Authsetlist from './AuthSetList';
 const useStyles = makeStyles()(theme => ({
   decommission: { justifyContent: 'flex-end', marginTop: theme.spacing(2) },
   wrapper: {
-    backgroundColor: theme.palette.grey[400],
-    borderColor: theme.palette.grey[500],
-    borderStyle: 'solid',
-    borderWidth: 1,
+    backgroundColor: theme.palette.background.lightgrey ? theme.palette.grey[400] : theme.palette.info.light,
     marginBottom: theme.spacing(2),
     minWidth: 700,
     padding: theme.spacing(2)


### PR DESCRIPTION
current theme:
<img width="902" height="195" alt="Screenshot 2025-09-01 at 14 03 51" src="https://github.com/user-attachments/assets/46847628-4b17-4881-89d1-0072a4e9b343" />
<img width="1096" height="336" alt="Screenshot 2025-09-01 at 14 04 12" src="https://github.com/user-attachments/assets/bbcad081-3da9-4e1a-b355-0e8154d8c42b" />

new theme before:
<img width="978" height="116" alt="Screenshot 2025-09-01 at 14 05 48" src="https://github.com/user-attachments/assets/6ec65fbe-f641-46e4-8b2b-73c687a04ee3" />
<img width="1092" height="329" alt="Screenshot 2025-09-01 at 14 05 41" src="https://github.com/user-attachments/assets/efde3b1f-cd54-40f6-8fed-9e0e1521bc10" />

new theme after:
<img width="1077" height="291" alt="Screenshot 2025-09-01 at 14 04 01" src="https://github.com/user-attachments/assets/62f59293-4583-40cd-b9bf-ec7f3d7d363a" />
<img width="1155" height="388" alt="Screenshot 2025-09-01 at 14 04 07" src="https://github.com/user-attachments/assets/e779f6a7-467b-49c2-8fe0-ca26157e0ea3" />


