### PR TITLE
ci: enabled wider tracing in e2e tests

### DIFF
--- a/frontend/tests/e2e_tests/playwright.config.ts
+++ b/frontend/tests/e2e_tests/playwright.config.ts
@@ -86,7 +86,7 @@ const options: PlaywrightTestConfig = {
     ...contextArgs,
     contextOptions: contextArgs,
     screenshot: 'only-on-failure',
-    trace: 'retain-on-failure',
+    trace: 'on',
     video: 'retain-on-failure',
     // headless: false,
     launchOptions


### PR DESCRIPTION
- to help debug the: 2fa gets disabled but stays enabled issue


this will keep trace files for all the test runs, to give us access to the backend responses in successful tests as well (considering the disabling of the 2fa ends successful, but is enabled in future tests) - https://playwright.dev/docs/api/class-testoptions#test-options-trace