### PR TITLE
chore(gui): removed log summary explanation text

### DIFF
--- a/frontend/src/js/components/deployments/deployment-report/AiLogAnalysis.tsx
+++ b/frontend/src/js/components/deployments/deployment-report/AiLogAnalysis.tsx
@@ -63,15 +63,10 @@ interface AiLogAnalysisProps {
 }
 
 const Header = () => (
-  <>
-    <div className="flexbox center-aligned">
-      <AutoAwesomeIcon color="secondary" className="margin-right-small" />
-      <Typography variant="h6">AI summary (experimental)</Typography>
-    </div>
-    <Typography variant="body2" color="text.primary" className="margin-top-small margin-bottom-small">
-      Analyze the deployment log with AI. The log data will be anonymized and processed to provide insights into any issues that occurred during the update.
-    </Typography>
-  </>
+  <div className="flexbox center-aligned margin-bottom-small">
+    <AutoAwesomeIcon color="secondary" className="margin-right-small" />
+    <Typography variant="h6">AI summary (experimental)</Typography>
+  </div>
 );
 
 const FeedbackSection = () => {


### PR DESCRIPTION
before:
<img width="1006" height="151" alt="Screenshot 2025-09-02 at 16 45 12" src="https://github.com/user-attachments/assets/d14fe187-1926-4dbe-8b02-43d9ad8c9547" />

after:
<img width="517" height="117" alt="Screenshot 2025-09-02 at 16 44 12" src="https://github.com/user-attachments/assets/c41b48d9-6425-46e4-b5e6-bf75ee343d7a" />
