### PR TITLE
test(gui): fixed an issue that would make sp tenant config fallback seem to be failure reason

### DIFF
--- a/frontend/tests/e2e_tests/integration/session.setup.ts
+++ b/frontend/tests/e2e_tests/integration/session.setup.ts
@@ -16,10 +16,13 @@ import * as fs from 'fs';
 
 import test from '../fixtures/fixtures.ts';
 import { isEnterpriseOrStaging, isLoggedIn, login, prepareNewPage, startDockerClient, stopDockerClient, tenantTokenRetrieval } from '../utils/commands.ts';
-import { emptyStorageState, selectors, spStoragePath, storagePath, switchTenantStoragePath, timeouts } from '../utils/constants.ts';
+import { emptyStorageState, selectors, spStoragePath, storageFolder, storagePath, switchTenantStoragePath, timeouts } from '../utils/constants.ts';
 
 test.describe('Test setup', () => {
   test.beforeAll(async () => {
+    if (!fs.existsSync(storageFolder)) {
+      fs.mkdirSync(storageFolder, { recursive: true });
+    }
     try {
       fs.unlinkSync('loginInfo.json');
       await stopDockerClient();

--- a/frontend/tests/e2e_tests/utils/constants.ts
+++ b/frontend/tests/e2e_tests/utils/constants.ts
@@ -34,9 +34,10 @@ export const selectors = {
 
 export const releaseTag = 'sometag';
 
-export const storagePath = 'storage/storage.json';
-export const spStoragePath = 'storage/sp-tenant-storage.json';
-export const switchTenantStoragePath = 'storage/switch-tenant-storage.json';
+export const storageFolder = 'storage';
+export const storagePath = `${storageFolder}/storage.json`;
+export const spStoragePath = `${storageFolder}/sp-tenant-storage.json`;
+export const switchTenantStoragePath = `${storageFolder}/switch-tenant-storage.json`;
 
 const oneSecond = 1000;
 export const timeouts = {


### PR DESCRIPTION
for situations like here: https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/11314431109#L354 - usually the storage folder would be created when storing session state, but if signup fails, the folder creation isn't happening so writing to the target location doesn't succeed and the log output is confusing...