### PR TITLE
ci: update spectral install script github hostname

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -231,7 +231,7 @@ test:backend:validate-open-api:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine:${ALPINE_VERSION}
   before_script:
     - apk add --no-cache curl
-    - curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
+    - curl -L https://raw.githubusercontent.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
     - sh install.sh
   script:
     - |


### PR DESCRIPTION
The hostname raw.github.com is deprecated and no longer supported. The endpoint now returns `503 hostname doesn't match against certificate` and this fails the CI.

The new and supported hostname is raw.githubusercontent.com. More information:
    https://github.com/orgs/community/discussions/173902


```bash
$ curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh

<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html>
  <head>
    <title>503 hostname doesn't match against certificate</title>
  </head>
  <body>
    <h1>Error 503 hostname doesn't match against certificate</h1>
    <p>hostname doesn't match against certificate</p>
    <h3>Error 54113</h3>
    <p>Details: cache-osl6535-OSL 1758271956 1933615451</p>
    <hr>
    <p>Varnish cache server</p>
  </body>
</html>
```

```bash
$ curl -L https://raw.githubusercontent.com/stoplightio/spectral/master/scripts/install.sh

#!/bin/sh


VERSION=${1:-latest};

install () {

set -eu

KERNEL=$(uname -s)
ARCH=$(uname -m)
if [ "$KERNEL" != "Linux" ] && [ "$KERNEL" != "Darwin" ] ; then
  echo "Sorry, KERNEL/Architecture not supported: ${KERNEL}/${ARCH}. Download binary from https://github.com/stoplightio/spectral/releases"
  exit 1
fi
... removed for brevity ...
```