### PR TITLE
4.0.x: ci: switch runners to k8s and coveralls allowed to fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,12 @@ variables:
   DOCKER_BUILDKITARGS:
     value: '--driver-opt "image=moby/buildkit:v0.17.3"' # QA-823
     description: "Optional buildkit args for docker build"
+  DOCKER_HOST:
+    value: 'tcp://docker:2375'
+    description: "Required to run dind inside k8s runners"
+  DOCKER_TLS_CERTDIR:
+    value: ''
+    description: "Required to run dind inside k8s runners"
   SKOPEO_VERSION:
     value: "v1.16.1"
     description: "Version of skopeo to use for publishing images"
@@ -97,10 +103,15 @@ stages:
 
 default:
   tags:
-    - hetzner-amd-beefy
+    - k8s
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
 
 .requires-docker: &requires-docker
-  - DOCKER_RETRY_SLEEP_S=2
+  - DOCKER_RETRY_SLEEP_S=10 # wait longer for k8s workers
   - DOCKER_RUNNING=false
   - for try in 4 3 2 1; do
   -  docker ps && DOCKER_RUNNING=true
@@ -132,8 +143,6 @@ default:
   stage: build
   extends: .build:base
   needs: []
-  tags:
-    - hetzner-amd-beefy
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
@@ -150,7 +159,6 @@ default:
       docker context create ci;
       docker builder create ${DOCKER_BUILDKITARGS} --name ci-builder ci;
       export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --builder=ci-builder";
-      unset DOCKER_HOST;
       fi
 
 build:backend:docker:
@@ -187,8 +195,6 @@ build:backend:docker-acceptance:
 test:backend:static:
   stage: test
   needs: []
-  tags:
-    - hetzner-amd-beefy
   rules:
     - changes:
         paths: ["backend/**/*.go"]
@@ -235,8 +241,6 @@ test:backend:unit:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  tags:
-    - hetzner-amd-beefy
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:6.0
       alias: mongo
@@ -266,8 +270,6 @@ test:backend:acceptance:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  tags:
-    - hetzner-amd-ax42
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
@@ -296,6 +298,7 @@ test:backend:acceptance:
 test:backend:integration:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
   stage: test
+  extends: .build:base
   rules:
     - changes:
         paths: ["backend/**/*"]
@@ -303,8 +306,6 @@ test:backend:integration:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  tags:
-    - hetzner-amd-beefy
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
@@ -471,8 +472,6 @@ publish:backend:coverage:
 
 publish:backend:docker:
   stage: publish
-  tags:
-    - hetzner-amd-beefy
   image:
     name: quay.io/skopeo/stable:${SKOPEO_VERSION}
     # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#override-the-entrypoint-of-an-image
@@ -506,8 +505,6 @@ publish:backend:docker:
 
 publish:backend:licenses:
   stage: publish
-  tags:
-    - hetzner-amd-beefy
   rules:
     - changes:
         paths: ["backend/**/*"]
@@ -538,8 +535,6 @@ publish:backend:licenses:
 
 publish:licenses:docs-site:
   stage: .post
-  tags:
-    - hetzner-amd-beefy
   rules:
     # Only make available for stable branches
     - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -451,6 +451,7 @@ publish:backend:coverage:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   image: "golang:${GOLANG_VERSION}"
+  allow_failure: true # QA-925 - Coveralls servers are unreliable.
   variables:
     COVERALLS_TOKEN: "$COVERALLS_REPO_TOKEN"
   before_script:
@@ -569,6 +570,7 @@ publish:licenses:docs-site:
 coveralls:done:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/curlimages/curl
   stage: .post
+  allow_failure: true # QA-925 - Coveralls servers are unreliable.
   script:
     - curl "https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN&carryforward=frontend-unit,frontend-e2e,frontend-e2e-enterprise,create-artifact-worker-unit,deployments-unit,deployments-acceptance,deviceauth-unit,deviceauth-acceptance,deviceconfig-unit,deviceconfig-acceptance,deviceconnect-unit,deviceconnect-acceptance,inventory-unit,inventory-acceptance,iot-manager-unit,iot-manager-acceptance,useradm-unit,useradm-acceptance,workflows-unit,workflows-acceptance,integration" -d "payload[build_num]=$CI_PIPELINE_ID&payload[status]=done"
   tags:

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -21,7 +21,7 @@ test:frontend:lint:
     - cd tests/e2e_tests && npm ci && cd ../..
     - npm run lint
   tags:
-    - hetzner-amd-beefy
+    - k8s
 
 test:frontend:license-headers:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/denoland/deno:debian-2.0.2
@@ -61,7 +61,7 @@ test:frontend:licenses:
   script:
     - deno run --allow-env --allow-read --allow-sys tests/licenses/licenseCheck.ts --rootDir $(pwd)
   tags:
-    - hetzner-amd-beefy
+    - k8s
 
 test:frontend:unit:
   stage: test
@@ -117,7 +117,7 @@ test:frontend:docs-links:
         exit 1
       fi
   tags:
-    - hetzner-amd-beefy
+    - k8s
 
 test:frontend:docs-links:hosted:
   extends: test:frontend:docs-links
@@ -306,7 +306,7 @@ publish:frontend:docker:
 publish:frontend:licenses:
   stage: publish
   tags:
-    - hetzner-amd-beefy
+    - k8s
   rules:
     - changes:
         paths: ['frontend/**/*']

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -261,6 +261,7 @@ publish:frontend:e2e-tests:
   needs:
     - job: test:frontend:acceptance
       artifacts: true
+  allow_failure: true # QA-925 - Coveralls servers are unreliable.
   variables:
     COVERALLS_SERVICE_JOB_NUMBER: frontend-e2e
     COVERALLS_FLAG_NAME: frontend-e2e

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -235,6 +235,7 @@ test:frontend:acceptance:enterprise:
     - npm i -g coveralls
   tags:
     - hetzner-amd-beefy
+  allow_failure: true
 
 publish:frontend:tests:
   extends: .template:publish:frontend:tests


### PR DESCRIPTION
Move most of the gitlab runners to k8s to avoid collision issues with multiple pipelines running at the same time

Cherry-picks `3515091a218b39d5d608ed2eb7b95730ef701e62` from main (with conflicts)

Ticket: QA-1111

In addition, cherry-picked cbc914bbaf5affc52cf182553aeb2973eda48efe and 6dc77f5865e26e521defe1e4c69f2410f6cbf19f because of coveralls failures