### PR TITLE
test(gui): made rapid pagination test disregard button actionability

### DIFF
--- a/frontend/tests/e2e_tests/integration/04-deployments.spec.ts
+++ b/frontend/tests/e2e_tests/integration/04-deployments.spec.ts
@@ -150,8 +150,12 @@ test.describe('Deployments', () => {
     // 10 clicks as anything leading outside of the 50 + something releases present (considering the 10 item page size)
     for (let clickAttempt = 0; clickAttempt < 10; clickAttempt++) {
       const paginationButton = page.getByRole('button', { name: 'next' });
+      if (await paginationButton.isDisabled()) {
+        continue;
+      }
       await paginationButton.click({ noWaitAfter: true, force: true });
     }
+    await expect(page.getByText(/-([5|6]\d) of \1/)).toBeVisible(); // depending on the deployment speed of other tests there might be slightly more than 50
     await expect(page.getByText(/queued to start/i).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
+ now rely more on final page info instead
- forcing the click turned out to still check for an actionable button