### PR TITLE
QA-1090: Update URL for `mender-artifact` download

### DIFF
--- a/backend/tests/Dockerfile.acceptance
+++ b/backend/tests/Dockerfile.acceptance
@@ -1,7 +1,7 @@
 FROM python:3.13-slim-bookworm
 COPY requirements-acceptance.txt requirements.txt
 RUN apt update && apt install -qy wget && \
-    wget "https://downloads.mender.io/repos/debian/pool/main/m/mender-artifact/mender-artifact_4.1.0-1%2b$(. /etc/os-release; echo $ID)%2b$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb" -O mender-artifact.deb && \
+    wget "https://downloads.mender.io/repos/workstation-tools/pool/main/m/mender-artifact/mender-artifact_4.1.0-1%2b$(. /etc/os-release; echo $ID)%2b$(. /etc/os-release; echo $VERSION_CODENAME)_amd64.deb" -O mender-artifact.deb && \
     dpkg -x mender-artifact.deb . && \
     pip install -r requirements.txt
 WORKDIR /testing


### PR DESCRIPTION
We have split now the packages between workstation tools and device components. Download the tool from the correct pool.