### PR TITLE
chore: removed warnings about implicit aria props spread on fragments by tooltip

### DIFF
--- a/frontend/src/js/components/releases/ReleaseDetails.tsx
+++ b/frontend/src/js/components/releases/ReleaseDetails.tsx
@@ -267,7 +267,7 @@ const ArtifactsList = ({ artifacts, selectedArtifact, setSelectedArtifact, setSh
           {columns.map(item => (
             <div className="columnHeader" key={item.name} onClick={() => sortColumn(item)}>
               <Tooltip title={item.title} placement="top-start">
-                <>{item.title}</>
+                {item.title}
               </Tooltip>
               {item.sortable ? <SortIcon className={`sortIcon ${sortCol === item.name ? 'selected' : ''} ${sortDown.toString()}`} /> : null}
               {item.tooltip}

--- a/frontend/src/js/components/releases/__snapshots__/ReleaseDetails.test.tsx.snap
+++ b/frontend/src/js/components/releases/__snapshots__/ReleaseDetails.test.tsx.snap
@@ -1829,7 +1829,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-21:focus::-ms-input-
       <div
         class="columnHeader"
       >
-        Device type compatibility
+        <span
+          aria-label="Device type compatibility"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          Device type compatibility
+        </span>
         <div
           class="margin-left-small"
           data-mui-internal-clone-element="true"
@@ -1857,12 +1863,24 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-21:focus::-ms-input-
       <div
         class="columnHeader"
       >
-        Type
+        <span
+          aria-label="Type"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          Type
+        </span>
       </div>
       <div
         class="columnHeader"
       >
-        Size
+        <span
+          aria-label="Size"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          Size
+        </span>
         <svg
           aria-hidden="true"
           class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium sortIcon true emotion-2"
@@ -1878,7 +1896,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-21:focus::-ms-input-
       <div
         class="columnHeader"
       >
-        Last modified
+        <span
+          aria-label="Last modified"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          Last modified
+        </span>
         <svg
           aria-hidden="true"
           class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium sortIcon selected true emotion-2"


### PR DESCRIPTION
after the merge package adoption merge there seems to have been a changed default in one of the MUI libraries, causing the text content of a component wrapped in a tooltip to be spread as aria-label prop, which in turn caused many related log messages [in CI](https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/11715063689#L1142) & in the browser console - in this case a wrapping fragment seems to be not (longer) used => removing 