### PR TITLE
test: Make ssh_is_opened timeout equal to provided value

### DIFF
--- a/backend/tests/integration/testutils/infra/device.py
+++ b/backend/tests/integration/testutils/infra/device.py
@@ -179,19 +179,15 @@ class MenderDevice:
         """
         waited = -1
         t0 = int(time.time())
-        raise_exception = None
-        for _ in redo.retrier(max_sleeptime=wait, attempts=wait, sleeptime=1):
-            try:
-                self.run("true", hide=True, wait=wait)
-                raise_exception = None
-                break
-            except Exception as e:
-                raise_exception = e
-            finally:
-                waited = int(time.time()) - t0
-        if raise_exception:
-            logger.error("Can't open ssh after %d s of waiting and trying" % waited)
-            raise (raise_exception)
+        try:
+            self.run("true", hide=True, wait=wait)
+        except Exception as e:
+            waited = int(time.time()) - t0
+            logger.error(
+                "Can't open ssh to %s after %d s of waiting and trying"
+                % (self.host_string, waited)
+            )
+            raise (e)
 
     def yocto_id_installed_on_machine(self):
         cmd = "mender-update show-artifact"


### PR DESCRIPTION
Fix ssh_is_opened so that the wait parameter is correctly used, by forwarding it to MenderDevice::run. Before the fix, the timeout was forwarded to MenderDevice::run, while the run itself was tried up to "wait" times on top of that. This resulted in 600*600 seconds (100 hours) of total timeout. If the client device did not become ready for any reason it caused the pipelines to seemingly hang.

Changelog: None
Ticket: QA-1147