### PR TITLE
Fix list artifacts breaking change

### DIFF
--- a/backend/docs/api/deployments/internal_v1.yaml
+++ b/backend/docs/api/deployments/internal_v1.yaml
@@ -720,7 +720,7 @@ components:
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
                 metadata: {}
-                meta_data: {}
+                meta_data: []
               artifact_provides:
                 artifact_name: test
                 rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99

--- a/backend/docs/api/deployments/internal_v1.yaml
+++ b/backend/docs/api/deployments/internal_v1.yaml
@@ -719,6 +719,7 @@ components:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: {}
               artifact_provides:
                 artifact_name: test

--- a/backend/docs/api/deployments/management_v1.yaml
+++ b/backend/docs/api/deployments/management_v1.yaml
@@ -742,6 +742,8 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata:
+                      type: object
                     meta_data:
                       type: object
                   artifact_provides:
@@ -771,6 +773,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -801,6 +804,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -910,6 +914,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -938,6 +943,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -968,6 +974,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -1331,6 +1338,7 @@ paths:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                  metadata: {}
                   meta_data: []
                 artifact_provides:
                   artifact_name: test
@@ -1643,6 +1651,8 @@ components:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+                metadata:
+                  type: object
                 meta_data:
                   type: object
               artifact_provides:
@@ -1694,6 +1704,7 @@ components:
             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
             size: 123
             date: 2016-03-11T13:03:17.063+0000
+          metadata: {}
           meta_data: []
         artifact_provides:
           artifact_name: test
@@ -1827,6 +1838,7 @@ components:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
           artifact_provides:
             artifact_name: test
@@ -1855,6 +1867,7 @@ components:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
           artifact_provides:
             artifact_name: test
@@ -1906,6 +1919,7 @@ components:
         updates:
         - type_info:
             type: type
+          metadata: {}
           meta_data: []
           files:
           - date: 2000-01-23T04:56:07.000+00:00
@@ -1918,6 +1932,7 @@ components:
             checksum: checksum
         - type_info:
             type: type
+          metadata: {}
           meta_data: []
           files:
           - date: 2000-01-23T04:56:07.000+00:00

--- a/backend/docs/api/deployments/management_v1.yaml
+++ b/backend/docs/api/deployments/management_v1.yaml
@@ -742,10 +742,8 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
-                    metadata:
-                      type: object
-                    meta_data:
-                      type: object
+                    metadata: {}
+                    meta_data: []
                   artifact_provides:
                     artifact_name: test
                     rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -1651,10 +1649,8 @@ components:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
-                metadata:
-                  type: object
-                meta_data:
-                  type: object
+                metadata: {}
+                meta_data: []
               artifact_provides:
                 artifact_name: test
                 rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99

--- a/backend/docs/api/deployments/management_v2.yaml
+++ b/backend/docs/api/deployments/management_v2.yaml
@@ -222,6 +222,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -250,6 +251,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -280,6 +282,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                   artifact_provides:
                     artifact_name: test
@@ -588,6 +591,7 @@ components:
             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
             size: 123
             date: 2016-03-11T13:03:17.063+0000
+          metadata: {}
           meta_data: []
         artifact_provides:
           artifact_name: test
@@ -686,6 +690,7 @@ components:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
           artifact_provides:
             artifact_name: test
@@ -714,6 +719,7 @@ components:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
           artifact_provides:
             artifact_name: test

--- a/backend/docs/api/deployments/schemas.yaml
+++ b/backend/docs/api/deployments/schemas.yaml
@@ -166,8 +166,8 @@ components:
                 checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                 size: 123
                 date: 2016-03-11T13:03:17.063+0000
-              meta_data: {}
               metadata: {}
+              meta_data: []
             artifact_provides:
               artifact_name: test
               rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -226,11 +226,11 @@ components:
       deprecated: true
       description: |
         Deprecated: Please use `metadata` instead.
-        An object of unknown structure as this is dependent
+        A list of objects of unknown structure as this is dependent
         of update type (also custom defined by user)
-      additionalProperties:
-        type: string
-      type: object
+      items:
+        type: object
+      type: array
     Statistics:
       example:
         success: 3
@@ -316,7 +316,7 @@ components:
         type_info:
           type: type
         metadata: {}
-        meta_data: {}
+        meta_data: []
         files:
         - date: 2000-01-23T04:56:07.000+00:00
           size: 6

--- a/backend/docs/api/deployments/schemas.yaml
+++ b/backend/docs/api/deployments/schemas.yaml
@@ -167,6 +167,7 @@ components:
                 size: 123
                 date: 2016-03-11T13:03:17.063+0000
               meta_data: {}
+              metadata: {}
             artifact_provides:
               artifact_name: test
               rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -216,7 +217,16 @@ components:
       type: object
     MetadataAny:
       description:
-        meta_data is an object of unknown structure as this is dependent
+        metadata is an object of unknown structure as this is dependent
+        of update type (also custom defined by user)
+      additionalProperties:
+        type: string
+      type: object
+    MetadataAnyDeprecated:
+      deprecated: true
+      description: |
+        Deprecated: Please use `metadata` instead.
+        An object of unknown structure as this is dependent
         of update type (also custom defined by user)
       additionalProperties:
         type: string
@@ -305,6 +315,7 @@ components:
       example:
         type_info:
           type: type
+        metadata: {}
         meta_data: {}
         files:
         - date: 2000-01-23T04:56:07.000+00:00
@@ -322,8 +333,10 @@ components:
           items:
             $ref: '#/components/schemas/UpdateFile'
           type: array
-        meta_data:
+        metadata:
           $ref: '#/components/schemas/MetadataAny'
+        meta_data:
+          $ref: '#/components/schemas/MetadataAnyDeprecated'
       type: object
     AttributeFilterPredicate:
       description: Attribute filter predicate

--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -7656,7 +7656,7 @@ components:
           type: string
       type: object
     MetadataAny:
-      description: meta_data is an object of unknown structure as this is dependent of update type (also custom defined by user)
+      description: an object of unknown structure as this is dependent of update type (also custom defined by user)
       additionalProperties:
         type: string
       type: object
@@ -7666,6 +7666,7 @@ components:
       example:
         type_info:
           type: type
+        metadata: {}
         meta_data: {}
         files:
           - date: '2000-01-23T04:56:07.000+00:00'
@@ -7683,6 +7684,8 @@ components:
           items:
             $ref: '#/components/schemas/UpdateFile'
           type: array
+        metadata:
+          $ref: '#/components/schemas/MetadataAny'
         meta_data:
           $ref: '#/components/schemas/MetadataAny'
       type: object

--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -1467,8 +1467,8 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
-                          meta_data:
-                            type: object
+                          metadata: {}
+                          meta_data: []
                       artifact_provides:
                         artifact_name: test
                         rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -1496,6 +1496,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -1526,6 +1527,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -1635,6 +1637,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -1663,6 +1666,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -1693,6 +1697,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -2052,6 +2057,7 @@ paths:
                         checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                         size: 123
                         date: 2016-03-11T13:03:17.063+0000
+                    metadata: {}
                     meta_data: []
                 artifact_provides:
                   artifact_name: test
@@ -2390,6 +2396,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -2418,6 +2425,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -2448,6 +2456,7 @@ paths:
                               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                               size: 123
                               date: 2016-03-11T13:03:17.063+0000
+                          metadata: {}
                           meta_data: []
                       artifact_provides:
                         artifact_name: test
@@ -7496,7 +7505,8 @@ components:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
-                  meta_data: {}
+                  metadata: {}
+                  meta_data: []
               artifact_provides:
                 artifact_name: test
                 rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -7656,10 +7666,19 @@ components:
           type: string
       type: object
     MetadataAny:
-      description: an object of unknown structure as this is dependent of update type (also custom defined by user)
+      description: metadata is an object of unknown structure as this is dependent of update type (also custom defined by user)
       additionalProperties:
         type: string
       type: object
+    MetadataAnyDeprecated:
+      deprecated: true
+      description: |
+        Deprecated: Please use `metadata` instead.
+        A list of objects of unknown structure as this is dependent
+        of update type (also custom defined by user)
+      items:
+        type: object
+      type: array
     Update:
       description: |
         Single updated to be applied.
@@ -7667,7 +7686,7 @@ components:
         type_info:
           type: type
         metadata: {}
-        meta_data: {}
+        meta_data: []
         files:
           - date: '2000-01-23T04:56:07.000+00:00'
             size: 6
@@ -7687,7 +7706,7 @@ components:
         metadata:
           $ref: '#/components/schemas/MetadataAny'
         meta_data:
-          $ref: '#/components/schemas/MetadataAny'
+          $ref: '#/components/schemas/MetadataAnyDeprecated'
       type: object
     DeviceWithImageImageMetaArtifact:
       properties:
@@ -7779,7 +7798,8 @@ components:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
-                meta_data: {}
+                meta_data: []
+                metadata: {}
             artifact_provides:
               artifact_name: test
               rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -8006,8 +8026,8 @@ components:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
-                  meta_data:
-                    type: object
+                  metadata: {}
+                  meta_data: []
               artifact_provides:
                 artifact_name: test
                 rootfs-image.checksum: 32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99
@@ -8057,6 +8077,7 @@ components:
                 checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                 size: 123
                 date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
         artifact_provides:
           artifact_name: test
@@ -8190,6 +8211,7 @@ components:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: []
             artifact_provides:
               artifact_name: test
@@ -8218,6 +8240,7 @@ components:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: []
             artifact_provides:
               artifact_name: test
@@ -8268,6 +8291,7 @@ components:
         updates:
           - type_info:
               type: type
+            metadata: {}
             meta_data: []
             files:
               - date: '2000-01-23T04:56:07.000+00:00'
@@ -8280,6 +8304,7 @@ components:
                 checksum: checksum
           - type_info:
               type: type
+            metadata: {}
             meta_data: []
             files:
               - date: '2000-01-23T04:56:07.000+00:00'
@@ -8562,6 +8587,7 @@ components:
                 checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                 size: 123
                 date: 2016-03-11T13:03:17.063+0000
+            metadata: {}
             meta_data: []
         artifact_provides:
           artifact_name: test
@@ -8660,6 +8686,7 @@ components:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: []
             artifact_provides:
               artifact_name: test
@@ -8688,6 +8715,7 @@ components:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: []
             artifact_provides:
               artifact_name: test

--- a/backend/services/deployments/docs/internal_api.yml
+++ b/backend/services/deployments/docs/internal_api.yml
@@ -793,7 +793,7 @@ definitions:
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
                 metadata: {}
-                meta_data: {}
+                meta_data: []
             artifact_provides:
               artifact_name: "test"
               rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -928,7 +928,7 @@ definitions:
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
               metadata: {}
-              meta_data: {}
+              meta_data: []
           artifact_provides:
             artifact_name: "test"
             rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -993,10 +993,14 @@ definitions:
           type: object
           description: an object of unknown structure as this is dependent of update type (also custom defined by user)
         meta_data:
-          type: object
+          type: array
+          items:
+            type: object
           description: |
             Deprecated: Please use `metadata` instead.
-            An object of unknown structure as this is dependent of update type (also custom defined by user)
+            A list of objects of unknown structure as this is dependent of update type (also custom defined by user)
+        items:
+          type: object
   ArtifactInfo:
       description: |
           Information about artifact format and version.

--- a/backend/services/deployments/docs/internal_api.yml
+++ b/backend/services/deployments/docs/internal_api.yml
@@ -792,6 +792,7 @@ definitions:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: {}
             artifact_provides:
               artifact_name: "test"
@@ -926,6 +927,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: {}
           artifact_provides:
             artifact_name: "test"
@@ -987,10 +989,14 @@ definitions:
           type: array
           items:
             $ref: "#/definitions/UpdateFile"
+        metadata:
+          type: object
+          description: an object of unknown structure as this is dependent of update type (also custom defined by user)
         meta_data:
           type: object
           description: |
-              meta_data is an object of unknown structure as this is dependent of update type (also custom defined by user)
+            Deprecated: Please use `metadata` instead.
+            An object of unknown structure as this is dependent of update type (also custom defined by user)
   ArtifactInfo:
       description: |
           Information about artifact format and version.

--- a/backend/services/deployments/docs/management_api.yml
+++ b/backend/services/deployments/docs/management_api.yml
@@ -803,6 +803,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -831,6 +832,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -861,6 +863,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -974,6 +977,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -1002,6 +1006,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -1032,6 +1037,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: {}
                     artifact_provides:
                       artifact_name: "test"
@@ -1418,6 +1424,7 @@ paths:
                       checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
+                  metadata: {}
                   meta_data: {}
               artifact_provides:
                 artifact_name: "test"
@@ -1969,6 +1976,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: {}
           artifact_provides:
             artifact_name: "test"
@@ -2032,6 +2040,7 @@ definitions:
                     checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
+                metadata: {}
                 meta_data: {}
             artifact_provides:
               artifact_name: "test"
@@ -2085,10 +2094,14 @@ definitions:
           type: array
           items:
             $ref: "#/definitions/UpdateFile"
+        metadata:
+          type: object
+          description: an object of unknown structure as this is dependent of update type (also custom defined by user)
         meta_data:
           type: object
           description: |
-              meta_data is an object of unknown structure as this is dependent of update type (also custom defined by user)
+              Deprecated: Please use `metadata` instead.
+              An object of unknown structure as this is dependent of update type (also custom defined by user)
   ArtifactInfo:
       description: |
           Information about artifact format and version.
@@ -2178,6 +2191,7 @@ definitions:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+          metadata: {}
           meta_data: {}
       artifact_provides:
         artifact_name: "test"
@@ -2317,6 +2331,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: {}
           artifact_provides:
             artifact_name: "test"
@@ -2345,6 +2360,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: {}
           artifact_provides:
             artifact_name: "test"

--- a/backend/services/deployments/docs/management_api.yml
+++ b/backend/services/deployments/docs/management_api.yml
@@ -804,7 +804,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -833,7 +833,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -864,7 +864,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -978,7 +978,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -1007,7 +1007,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -1038,7 +1038,7 @@ paths:
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
                         metadata: {}
-                        meta_data: {}
+                        meta_data: []
                     artifact_provides:
                       artifact_name: "test"
                       rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -1425,7 +1425,7 @@ paths:
                       size: 123
                       date: 2016-03-11T13:03:17.063+0000
                   metadata: {}
-                  meta_data: {}
+                  meta_data: []
               artifact_provides:
                 artifact_name: "test"
                 rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -1977,7 +1977,7 @@ definitions:
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
               metadata: {}
-              meta_data: {}
+              meta_data: []
           artifact_provides:
             artifact_name: "test"
             rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -2041,7 +2041,7 @@ definitions:
                     size: 123
                     date: 2016-03-11T13:03:17.063+0000
                 metadata: {}
-                meta_data: {}
+                meta_data: []
             artifact_provides:
               artifact_name: "test"
               rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -2098,10 +2098,12 @@ definitions:
           type: object
           description: an object of unknown structure as this is dependent of update type (also custom defined by user)
         meta_data:
-          type: object
+          type: array
           description: |
-              Deprecated: Please use `metadata` instead.
-              An object of unknown structure as this is dependent of update type (also custom defined by user)
+            Deprecated: Please use `metadata` instead.
+            A list of objects of unknown structure as this is dependent of update type (also custom defined by user)
+          items:
+            type: object
   ArtifactInfo:
       description: |
           Information about artifact format and version.
@@ -2192,7 +2194,7 @@ definitions:
               size: 123
               date: 2016-03-11T13:03:17.063+0000
           metadata: {}
-          meta_data: {}
+          meta_data: []
       artifact_provides:
         artifact_name: "test"
         rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -2332,7 +2334,7 @@ definitions:
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
               metadata: {}
-              meta_data: {}
+              meta_data: []
           artifact_provides:
             artifact_name: "test"
             rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"
@@ -2361,7 +2363,7 @@ definitions:
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
               metadata: {}
-              meta_data: {}
+              meta_data: []
           artifact_provides:
             artifact_name: "test"
             rootfs-image.checksum: "32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99"

--- a/backend/services/deployments/docs/management_api_v2.yml
+++ b/backend/services/deployments/docs/management_api_v2.yml
@@ -243,6 +243,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: []
                     artifact_provides:
                       artifact_name: "test"
@@ -271,6 +272,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: []
                     artifact_provides:
                       artifact_name: "test"
@@ -301,6 +303,7 @@ paths:
                             checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                             size: 123
                             date: 2016-03-11T13:03:17.063+0000
+                        metadata: {}
                         meta_data: []
                     artifact_provides:
                       artifact_name: "test"
@@ -675,6 +678,7 @@ definitions:
               checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
               size: 123
               date: 2016-03-11T13:03:17.063+0000
+          metadata: {}
           meta_data: []
       artifact_provides:
         artifact_name: "test"
@@ -762,6 +766,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: []
           artifact_provides:
             artifact_name: "test"
@@ -790,6 +795,7 @@ definitions:
                   checksum: cc436f982bc60a8255fe1926a450db5f195a19ad
                   size: 123
                   date: 2016-03-11T13:03:17.063+0000
+              metadata: {}
               meta_data: []
           artifact_provides:
             artifact_name: "test"
@@ -834,11 +840,14 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/UpdateFile"
+      metadata:
+        type: object
+        description: an object of unknown structure as this is dependent of update type (also custom defined by user
       meta_data:
         type: array
         description: |
-          meta_data is an array of objects of unknown structure as this
-          is dependent of update type (also custom defined by user)
+          Deprecated: Please use `metadata` instead.
+          An object of unknown structure as this is dependent of update type (also custom defined by user)
         items:
           type: object
 


### PR DESCRIPTION
**Description**
Reverts the breaking API change introduced in https://github.com/mendersoftware/mender-server/pull/1042/commits/33fae571932e14ca5b16afd26bc8e410b5c2a92b by adding a new `metadata` property on the Release type that is of the correct type while maintaining the old (and incorrectly formatted) `meta_data` property as-is.

I have also gone through the API documentation and updated examples and type references while also adding a note to the `meta_data` type indicating that it is deprecated and clients should rather use `metadata`. 

Thanks to Alf's contribution the documented type of the old and deprecated `meta_data` property in the API spec(s) has been updated to be in line with what the server actually produces (e.g reflect the bug in the API spec). This should hopefully result in consistent type generation for mgmt v1+v2, internal and device APIs. 

I suppose technically this is a breaking change to the API spec of (at least) mgmt v2. I would argue that this is worth doing because a) the server never responded with data that respected this spec to begin with and b) if anyone generated types from these they would either have to manually change them (in which case they should be some version of "ok" with this) or the de-serialization of the data simply wouldn't work.

Example response from any endpoint returning an artifact:
```bash
{
  "id": "b9d00e99-fad0-456c-904a-0c6f70f17073",
  "name": "test-1.15",
  "device_types_compatible": [
    "qemux86-64"
  ],
  "info": {
    "format": "mender",
    "version": 3
  },
  "signed": false,
  "updates": [
    {
      "type_info": {
        "type": "container-setup"
      },
      "files": null,
      # This is the new and correctly formatted `metadata` property
      "metadata": {
        "containers": [
          "debian@sha256:066051f6674f6a3293bbd5a190081b1ae7fcae655a3884db59ebb3a2831da623",
          "hello-world@sha256:2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535"
        ]
      },
      # This is the old and incorrectly formatted `meta_data` property
      "meta_data": [
        {
          "Key": "containers",
          "Value": [
            "debian@sha256:066051f6674f6a3293bbd5a190081b1ae7fcae655a3884db59ebb3a2831da623",
            "hello-world@sha256:2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535"
          ]
        }
      ]
    }
  ],
  "artifact_provides": {
    "artifact_name": "test-1.15"
  },
  "artifact_depends": {
    "device_type": [
      "qemux86-64"
    ]
  },
  "size": 5120,
  "modified": "2025-10-29T13:20:19.157Z"
}