### PR TITLE
fix(gui): removed error messages shown when subscribing or showing billing info as trial user

### DIFF
--- a/frontend/src/js/components/settings/organization/Billing.tsx
+++ b/frontend/src/js/components/settings/organization/Billing.tsx
@@ -195,9 +195,12 @@ export const Billing = () => {
   const planName = PLANS[currentPlan].name;
 
   useEffect(() => {
+    if (isTrial) {
+      return;
+    }
     dispatch(getCurrentCard());
     dispatch(getUserBilling());
-  }, [dispatch]);
+  }, [dispatch, isTrial]);
 
   const enabledAddOns = addons.filter(({ enabled }) => enabled).map(({ name }) => ADDONS[name].title);
 

--- a/frontend/src/js/components/subscription/SubscriptionPage.tsx
+++ b/frontend/src/js/components/subscription/SubscriptionPage.tsx
@@ -402,10 +402,10 @@ export const SubscriptionPage = () => {
 
   //Fetch Billing profile & subscription
   useEffect(() => {
-    dispatch(getUserBilling());
     if (isTrial) {
       return;
     }
+    dispatch(getUserBilling());
     dispatch(getCurrentCard());
     //We need to handle special enterprise-like agreements
     dispatch(getUserSubscription())


### PR DESCRIPTION
- NB: this lets the frontend rely on trial signups to always provide a new billing profile when signing up