### PR TITLE
docs(deployments): document 'sort' option in the internal endpoint for getting deployments

### DIFF
--- a/backend/docs/api/deployments/internal_v1.yaml
+++ b/backend/docs/api/deployments/internal_v1.yaml
@@ -236,6 +236,15 @@ paths:
         name: created_after
         schema:
           type: integer
+      - description: |
+          Supports sorting the deployments list by creation date.
+        in: query
+        name: sort
+        schema:
+          enum:
+          - asc
+          - desc
+          type: string
       responses:
         '200':
           content:

--- a/backend/services/deployments/docs/internal_api.yml
+++ b/backend/services/deployments/docs/internal_api.yml
@@ -260,6 +260,15 @@ paths:
           required: false
           type: number
           format: integer
+        - name: sort
+          in: query
+          description: |
+            Supports sorting the deployments list by creation date.
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
       produces:
         - application/json
       responses:


### PR DESCRIPTION
So in the end the functionality was already there - the internal endpoint and management ones are reusing same logic quite a lot and support for sorting is present everywhere - internal, management v1 & v2. It was just not documented.
I tested locally and it works just fine.

Ticket: MEN-8914
