### PR TITLE
Introduce docker compose healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: [server, --automigrate]
     depends_on:
       mongo:
-        condition: service_started
+        condition: service_healthy
       s3:
         condition: service_healthy
     environment:
@@ -66,7 +66,8 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       DEVICEAUTH_INVENTORY_ADDR: http://inventory:8080
       DEVICEAUTH_ORCHESTRATOR_ADDR: http://workflows:8080
@@ -102,7 +103,8 @@ services:
       DEVICECONFIG_WORKFLOWS_URL: http://workflows:8080
       DEVICECONFIG_MONGO_URL: "mongodb://mongo"
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     labels:
       traefik.enable: "true"
       traefik.http.services.deviceconfig.loadBalancer.server.port: "8080"
@@ -126,8 +128,10 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
-      - nats
+      mongo:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
     environment:
       DEVICECONNECT_INVENTORY_URI: http://inventory:8080
       DEVICECONNECT_WORKFLOWS_URL: http://workflows:8080
@@ -182,7 +186,8 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       INVENTORY_DEVICEMONITOR_ADDR: http://devicemonitor:8080
       INVENTORY_ORCHESTRATOR_ADDR: http://workflows:8080
@@ -222,7 +227,8 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       IOT_MANAGER_DEVICEAUTH_URL: "http://deviceauth:8080"
       IOT_MANAGER_WORKFLOWS_URL: "http://workflows:8080"
@@ -247,7 +253,8 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       USERADM_MONGO: "mongodb://mongo"
       USERADM_SERVER_PRIV_KEY_PATH: "/etc/useradm/private.pem"
@@ -301,8 +308,10 @@ services:
     restart: on-failure:3
     command: [server, --automigrate]
     depends_on:
-      - mongo
-      - nats
+      mongo:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
     environment:
       WORKFLOWS_MONGO_URL: "mongodb://mongo"
       WORKFLOWS_NATS_URI: "nats://nats"
@@ -314,6 +323,8 @@ services:
     command:
       - --api=true
       - --api.insecure=true
+      - --ping=true
+      - --ping.entrypoint=traefik
       - --accesslog=true
       - --entrypoints.web.address=:80
       - --entrypoints.web.http.redirections.entryPoint.scheme=https
@@ -327,6 +338,11 @@ services:
       - --providers.file.directory=/etc/traefik/config
       - --providers.docker=true
       - --providers.docker.exposedByDefault=false
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ping | grep -q 'OK'"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
     volumes:
       - ./compose/config/traefik:/etc/traefik/config:ro
       - ./compose/certs:/etc/traefik/certs:ro
@@ -345,6 +361,11 @@ services:
 
   mongo:
     image: mongo:7.0
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
+      interval: 10s
+      timeout: 3s
+      retries: 5
     ulimits:
       nofile:
         soft: 64000
@@ -356,8 +377,13 @@ services:
         aliases: [mender-mongo]
 
   nats:
-    image: nats:2.10
-    command: [-js]
+    image: nats:2.10-alpine
+    command: [-js, -m, '8222']
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz | grep -q 'ok'"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
     networks:
       default:
         aliases: [mender-nats]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./backend/services/create-artifact-worker/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/create-artifact-worker:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     depends_on:
       - workflows
     environment:
@@ -21,7 +21,7 @@ services:
       context: .
       dockerfile: ./backend/services/deployments/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/deployments:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -63,7 +63,7 @@ services:
       context: .
       dockerfile: ./backend/services/deviceauth/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/deviceauth:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -96,7 +96,7 @@ services:
       context: .
       dockerfile: ./backend/services/deviceconfig/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/deviceconfig:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     environment:
       DEVICECONFIG_INVENTORY_URI: http://inventory:8080
@@ -125,7 +125,7 @@ services:
       context: .
       dockerfile: ./backend/services/deviceconnect/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/deviceconnect:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -156,7 +156,7 @@ services:
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/gui:${MENDER_IMAGE_TAG:-latest}
     build:
       context: ./frontend
-    restart: on-failure:3
+    restart: on-failure:20
     labels:
       traefik.enable: "true"
       traefik.http.services.gui.loadBalancer.server.port: "8090"
@@ -183,7 +183,7 @@ services:
       context: .
       dockerfile: ./backend/services/inventory/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/inventory:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -224,7 +224,7 @@ services:
       context: .
       dockerfile: ./backend/services/iot-manager/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/iot-manager:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -250,7 +250,7 @@ services:
       context: .
       dockerfile: ./backend/services/useradm/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/useradm:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:
@@ -282,7 +282,7 @@ services:
       context: .
       dockerfile: ./backend/services/workflows/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/workflows:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: ["worker"]
     depends_on:
       - workflows
@@ -305,7 +305,7 @@ services:
       context: .
       dockerfile: ./backend/services/workflows/Dockerfile
     image: ${MENDER_IMAGE_REGISTRY:-docker.io}/${MENDER_IMAGE_REPOSITORY:-mendersoftware}/workflows:${MENDER_IMAGE_TAG:-latest}
-    restart: on-failure:3
+    restart: on-failure:20
     command: [server, --automigrate]
     depends_on:
       mongo:


### PR DESCRIPTION
The purpose of this Pull-Request is to introduce healthcheck mechanisms on mongo, nats and traefik containers.


The initial intention is to face some issues when running mender-server on a "slow" machine, with mongo regularly not being ready and multiple containers depending on mongo failing on startup.
I also increased the restart value because workflows container was failing. It depends on mongo, successfully connects but complains with "failed to apply migrations" error (version reported 0.0.0 while expecting 1.0.0).

This Pull-Request is a backport of https://github.com/mendersoftware/mender-server/pull/1081