### PR TITLE
ci: consolidate coveralls jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -494,6 +494,7 @@ test:staging-deployment:firefox:
 
 publish:backend:coverage:
   stage: publish
+  extends: coveralls:done
   needs:
     - job: test:backend:unit
       artifacts: true
@@ -511,25 +512,11 @@ publish:backend:coverage:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: "golang:${GOLANG_VERSION}"
   allow_failure: true # QA-925 - Coveralls servers are unreliable.
-  variables:
-    COVERALLS_TOKEN: "$COVERALLS_REPO_TOKEN"
-  before_script:
-    - go install github.com/mattn/goveralls@latest
-    # Convert coverage directory (from acceptance/integration) to textfmt
-    - find ${GOCOVERDIR} -mindepth 1 -maxdepth 1 -type d
-      -exec go tool covdata textfmt -i {} -o {}.cover \;
   script:
-    - cd backend
-    # NOTE: All coverage files have the filename '<coveralls flag>.cover'
-    - |
-      for coverpath in $(find ${GOCOVERDIR} -type f -name '*.cover'); do
-        coverfile=$(basename "$coverpath")
-        goveralls -parallel \
-          -service=gitlab \
-          -flagname="${coverfile%.cover}" \
-          -coverprofile="${coverpath}"
+    - for coverpath in $(find ${GOCOVERDIR} -type f -name '*.cover'); do
+      coverfile=$(basename "$coverpath");
+      coveralls report -n --parallel --job-flag="${coverfile%.cover}" --format=golang "$coverpath";
       done
 
 publish:backend:docker:
@@ -657,6 +644,9 @@ coveralls:done:
     - mkdir -p $HOME/bin
     - tar -xzvf ./coveralls-linux-$(uname -m).tar.gz -C $HOME/bin
     - export PATH="$PATH:$HOME/bin"
+    - if test "${CI_COMMIT_BRANCH#pr_}" != "$CI_COMMIT_BRANCH"; then
+      export CI_MERGE_REQUEST_IID="${CI_COMMIT_BRANCH#pr_}";
+      fi
   script:
     - coveralls done -n
   tags:

--- a/backend/services/deployments/apk-requirements.txt
+++ b/backend/services/deployments/apk-requirements.txt
@@ -1,1 +1,0 @@
-xz-dev musl-dev gcc

--- a/backend/services/deployments/deb-requirements.txt
+++ b/backend/services/deployments/deb-requirements.txt
@@ -1,2 +1,0 @@
-liblzma-dev
-libssl-dev

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -232,38 +232,26 @@ test:frontend:acceptance:enterprise:qemu:
     - docker login -u "$REGISTRY_MENDER_IO_USERNAME" -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io
     - npm run script --prefix frontend/tests/e2e_tests -- --environment enterprise --variant qemu
 
-.template:publish:frontend:tests:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
-  stage: publish
-  before_script:
-    - export CI_BUILD_REF=${CI_COMMIT_SHA}
-    - export CI_BUILD_REF_NAME=${CI_COMMIT_REF_NAME}
-    - export CI_MERGE_REQUEST_IID=${CI_COMMIT_BRANCH#pr_}
-    - export COVERALLS_PARALLEL=true
-    - export COVERALLS_SERVICE_JOB_ID=${CI_JOB_ID}
-    - export COVERALLS_SERVICE_NUMBER=${CI_PIPELINE_ID}
-    - apk add --no-cache git
-    - npm i -g coveralls
-  allow_failure: true
-
 publish:frontend:tests:
-  extends: .template:publish:frontend:tests
+  extends: coveralls:done
+  stage: publish
   rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^(staging|saas-[a-zA-Z0-9.]+)$/
-      when: never
+    - if: $CI_COMMIT_REF_PROTECTED == "true"
+      when: on_success
     - changes:
         paths: ['frontend/**/*']
         compare_to: '${RULES_CHANGES_COMPARE_TO_REF}'
+  variables:
+    COVERALLS_FLAG_NAME: frontend-unit
   needs:
     - job: test:frontend:unit
       artifacts: true
   script:
-    - export COVERALLS_SERVICE_JOB_NUMBER=frontend-unit
-    - export COVERALLS_FLAG_NAME=frontend-unit
-    - coveralls < frontend/coverage/lcov.info
+    - coveralls report --format lcov --job-flag frontend-unit frontend/coverage/lcov.info
 
 publish:frontend:e2e-tests:
-  extends: .template:publish:frontend:tests
+  extends: coveralls:done
+  stage: publish
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
@@ -275,12 +263,13 @@ publish:frontend:e2e-tests:
     - job: test:frontend:acceptance
       artifacts: true
   allow_failure: true # QA-925 - Coveralls servers are unreliable.
-  variables:
-    COVERALLS_SERVICE_JOB_NUMBER: frontend-e2e
-    COVERALLS_FLAG_NAME: frontend-e2e
   script:
     - sed -i -re 's/(^[SF:]+[../]+)(.*)$/SF:\2/' frontend/coverage/lcov.info
-    - coveralls < frontend/coverage/lcov.info
+    - coveralls report -n
+      --parallel
+      --format lcov
+      --job-flag frontend-e2e
+      frontend/coverage/lcov.info
 
 publish:frontend:e2e-tests:enterprise:
   extends: publish:frontend:e2e-tests


### PR DESCRIPTION
This commit consolidates all coveralls jobs to use the coveralls CLI and letting the CLI discover the parameters from GitlabCI to make sure the parameters are used consistently.

~~NOTE: I'm not sure if this work for the parallel builds for the backend the job reports multiple coverage reports in a single job.~~
Edit: it works ✨