### PR TITLE
(doc) Add documentation that `retries` is restricted to professional and enterprise plans

### DIFF
--- a/backend/docs/api/deviceconfig/management_v1.yaml
+++ b/backend/docs/api/deviceconfig/management_v1.yaml
@@ -119,6 +119,7 @@ components:
           type: integer
           description: The number of times a device can retry the deployment in case of failure, defaults to 0
           default: 0
+          x-mender-plan: ["professional", "enterprise"]
         update_control_map:
           x-mender-plan: ["enterprise"]
           type: object

--- a/backend/services/deployments/docs/management_api_v2.yml
+++ b/backend/services/deployments/docs/management_api_v2.yml
@@ -1193,6 +1193,7 @@ definitions:
         type: integer
         description: The number of times a device can retry the deployment in case of failure, defaults to 0
         default: 0
+        x-mender-plan: ["professional", "enterprise"]
       max_devices:
         type: integer
         description: |

--- a/backend/services/deviceconfig/docs/management_api.yml
+++ b/backend/services/deviceconfig/docs/management_api.yml
@@ -160,6 +160,7 @@ components:
           type: integer
           description: The number of times a device can retry the deployment in case of failure, defaults to 0
           default: 0
+          x-mender-plan: ["professional", "enterprise"]
         update_control_map:
           x-mender-plan: ["enterprise"]
           type: object


### PR DESCRIPTION
This change attempts to properly document that `retries` requires the professional or enterprise plan.

