### PR TITLE
Update traefik version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -319,7 +319,7 @@ services:
       default:
         aliases: [mender-workflows]
   traefik:
-    image: traefik:v3.1
+    image: traefik:3.6.2
     command:
       - --api=true
       - --api.insecure=true


### PR DESCRIPTION
The purpose of this Pull Request is to update traefik version to the latest.

I just faced Docker API version errors reported by traefik community here: https://github.com/traefik/traefik/issues/12253 and fixed in version 3.6.1 here: https://github.com/traefik/traefik/pull/12256.

Moving to the latest (3.6.2) so that it's still working with docker version 29.x.