### PR TITLE
feat: update traefik version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -323,7 +323,7 @@ services:
       default:
         aliases: [mender-workflows]
   traefik:
-    image: traefik:3.5
+    image: traefik:3.6.2
     command:
       - --api=true
       - --api.insecure=true


### PR DESCRIPTION
Update of traefik version to support Docker 29.x with API >= 1.44.

Backport of https://github.com/mendersoftware/mender-server/pull/1099 on main branch.