### PR TITLE
chore: made mockgen.sh work on Mac OS

### DIFF
--- a/backend/utils/mockgen.sh
+++ b/backend/utils/mockgen.sh
@@ -22,12 +22,12 @@ generate_mock() {
 	mkdir -p ./mocks
 
 	# Initialize mock file with copyright header
-	awk '$1 !~ /^[/][/].*/ {print ""; exit} ; {print $0}' $GOFILE >"mocks/${INTERFACE}.go"
+	awk '$1 !~ /^[\/][\/].*/ {print ""; exit} ; {print $0}' $GOFILE >"mocks/${INTERFACE}.go"
 
 	docker run --rm -v "${REPO_ROOT}:${REPO_ROOT}" \
 		-w ${PACKAGE_PATH} \
 		-u $(id -u):$(id -g) \
-		vektra/mockery:v2.45 --name "${INTERFACE}" \
+		vektra/mockery:v2.53 --name "${INTERFACE}" \
 		--output ./mocks --print >>"mocks/${INTERFACE}.go"
 }
 generate_mock


### PR DESCRIPTION
**Description**

Updated the `awk` command that copies the copyright header with escaped backslashes so it works with the version of `awk` shipped with Mac OS by default as well as `gawk` (which is the Linux default I believe). I tested on a standard ubuntu image and it seems to work just fine, but I'd appreciate if the reviewer could test it as well. 

Also updated the version of `vektra/mockery` to match enterprise and make mockgen work with more recent versions of Go.