### PR TITLE
MEN-8935: Add request content length to access logs

### DIFF
--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -107,6 +107,9 @@ func (a AccessLogger) LogFunc(
 	logCtx["responsetime"] = latency.String()
 	logCtx["status"] = c.Writer.Status()
 	logCtx["byteswritten"] = c.Writer.Size()
+	if length := c.Request.ContentLength; length > -1 {
+		logCtx["contentlength"] = length
+	}
 
 	var logLevel logrus.Level = logrus.InfoLevel
 	if code >= 500 {


### PR DESCRIPTION
**Description**
This PR adds the value of the Content-Length header of each request to the access log. I think (hope) that this is actually all that's required to meet the acceptance criteria. However, please do see the ticket for further details and let me know if I'm wrong in that.

Example:
```
time="2025-11-21T10:30:56Z" level=info byteswritten=-1 caller="accesslog.AccessLogger.LogFunc@middleware_gin.go:134" method=POST path=/api/management/v1/deployments/artifacts path_params= qs= request_id=e6a47e52-fbe4-44f2-91b8-518d1e240cd7 responsetime=14.43ms contentlength=5581 status=201 ts="2025-11-21T10:30:56.882Z" type=HTTP/1.1 user_id=<> useragent="<>"
```