### PR TITLE
fix(deviceconnect): device ping/pong handler causes timeouts

### DIFF
--- a/backend/services/deviceconnect/api/http/device.go
+++ b/backend/services/deviceconnect/api/http/device.go
@@ -241,15 +241,10 @@ func (h DeviceController) connectWSWriter(
 	defer ticker.Stop()
 	conn.SetPongHandler(func(string) error {
 		ticker.Reset(pingPeriod)
-		return conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
 	})
 
 	conn.SetPingHandler(func(msg string) error {
-		err := conn.SetReadDeadline(time.Now().Add(pongWait))
-		if err != nil {
-			return err
-		}
-
 		ticker.Reset(pingPeriod)
 		return conn.WriteControl(
 			websocket.PongMessage,


### PR DESCRIPTION
When there's traffic on the websocket connection, the ping/pong handler is never called and therefore SetReadDeadline is never called which in turn causes the connection to terminate.
This PR removes the calls to Conn.SetReadDeadline to rely on TCP keep-alive instead.