### PR TITLE
MEN-8927: Fix deviceauth maintenance sync-devices compatibility issues 

### DIFF
--- a/backend/services/deviceauth/cmd/maintenance.go
+++ b/backend/services/deviceauth/cmd/maintenance.go
@@ -38,7 +38,13 @@ func MaintenanceSyncDeviceInventory(
 				return err
 			}
 		}
-		dev.IdDataStruct["status"] = dev.Status
+		if dev.IdDataStruct == nil {
+			dev.IdDataStruct = map[string]any{
+				"status": dev.Status,
+			}
+		} else {
+			dev.IdDataStruct["status"] = dev.Status
+		}
 		err := inv.SetDeviceIdentityIfUnmodifiedSince(
 			ctx, dev.TenantID,
 			dev.Id, dev.IdDataStruct,


### PR DESCRIPTION
This PR handles certain edge cases when syncing deviceauth identity data to inventory service when using the `propagate-inventory` maintenance command.