### PR TITLE
fix(deviceauth): Use mongo's error code to check for record duplication in AddDevice

### DIFF
--- a/backend/services/deviceauth/store/mongo/datastore_mongo.go
+++ b/backend/services/deviceauth/store/mongo/datastore_mongo.go
@@ -325,7 +325,7 @@ func (db *DataStoreMongo) AddDevice(ctx context.Context, d model.Device) error {
 	c := db.client.Database(DbName).Collection(DbDevicesColl)
 
 	if _, err := c.InsertOne(ctx, d); err != nil {
-		if strings.Contains(err.Error(), "duplicate key error") {
+		if mongo.IsDuplicateKeyError(err) {
 			return store.ErrObjectExists
 		}
 		return errors.Wrap(err, "failed to store device")


### PR DESCRIPTION
As outlined in #1095, the error handling in deviceauth datastore_mongo uses a string comparison to check if a record is already present or not. This creates problems if the underlying database does not respond _exactly_ with the expected error _message_.

This PR updates the code to use an existing, more robust function instead, which checks on the error code returned by the mongo server.

__Note:__ The same string comparison happens in the useradm module too, but I was not sure if (and how) it should be included in the change, since there no duplicate handling seems to be required/implemented yet:

``` go
var (
	// user not found
	ErrUserNotFound = errors.New("user not found")
	// token not found
	ErrTokenNotFound = errors.New("token not found")
	// duplicated email address
	ErrDuplicateEmail = errors.New("user with a given email already exists")
	// duplicated Personal Access Token name
	ErrDuplicateTokenName = errors.New("Personal Access Token with a given name already exists")
	// etag doesn't match
	ErrETagMismatch = errors.New("ETag doesn't match")
)
```