### PR TITLE
feat(inventory): internal patch /tenants/:tenant_id/device/:device_id/attributes

### DIFF
--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -4667,6 +4667,59 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/internal/v1/inventory/tenants/{tenant_id}/device/{device_id}/attributes:
+    patch:
+      tags:
+        - Device_inventory_Internal API
+      summary: Update multiple inventory attributes for a device
+      description: |
+        An API end-point that allows to update the inventory attributes for a device.
+        It is operating in the same way as the /attribute/scope/{scope} endpoint, but
+        does not override the scope of the attributes that you provide.
+      operationId: Update Inventory for a Device Scope Wise
+      parameters:
+        - name: If-Unmodified-Since
+          in: header
+          description: Skips updating the device if modified after the given RFC1123 timestamp.
+          required: false
+          schema:
+            type: string
+        - name: tenant_id
+          in: path
+          description: ID of given tenant.
+          required: true
+          schema:
+            type: string
+        - name: device_id
+          in: path
+          description: ID of given device.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: List of inventory attributes to set.
+        content:
+          '*/*':
+            schema:
+              type: array
+              description: A list of attribute descriptors.
+              items:
+                $ref: '#/components/schemas/Attribute'
+        required: true
+      responses:
+        '200':
+          description: Device inventory successfully updated.
+          content: {}
+        '400':
+          $ref: '#/components/responses/InvalidRequestError'
+        '412':
+          description: 'Precondition failed: If-Unmodified-Since condition not met'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /api/internal/v1/inventory/tenants/{tenant_id}/devices/{device_id}/groups:
     get:
       tags:

--- a/backend/docs/api/inventory/internal_v1.yaml
+++ b/backend/docs/api/inventory/internal_v1.yaml
@@ -231,6 +231,59 @@ paths:
                 $ref: '../common/schemas.yaml#/components/schemas/Error'
         "500":
           $ref: '../common/responses.yaml#/components/responses/InternalServerError'
+  /api/internal/v1/inventory/tenants/{tenant_id}/device/{device_id}/attributes:
+    patch:
+      tags:
+      - Internal API
+      summary: Update multiple inventory attributes for a device
+      description: |
+        An API end-point that allows to update the inventory attributes for a device.
+        It is operating in the same way as the /attribute/scope/{scope} endpoint, but
+        does not override the scope of the attributes that you provide.
+      operationId: Update Inventory for a Device Scope Wise
+      parameters:
+      - name: If-Unmodified-Since
+        in: header
+        description: Skips updating the device if modified after the given RFC1123 timestamp.
+        required: false
+        schema:
+          type: string
+      - name: tenant_id
+        in: path
+        description: ID of given tenant.
+        required: true
+        schema:
+          type: string
+      - name: device_id
+        in: path
+        description: ID of given device.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: List of inventory attributes to set.
+        content:
+          '*/*':
+            schema:
+              type: array
+              description: A list of attribute descriptors.
+              items:
+                $ref: './schemas.yaml#/components/schemas/Attribute'
+        required: true
+      responses:
+        "200":
+          description: Device inventory successfully updated.
+          content: {}
+        "400":
+          $ref: '../common/responses.yaml#/components/responses/InvalidRequestError'
+        "412":
+          description: "Precondition failed: If-Unmodified-Since condition not met"
+          content:
+            application/json:
+              schema:
+                $ref: '../common/schemas.yaml#/components/schemas/Error'
+        "500":
+          $ref: '../common/responses.yaml#/components/responses/InternalServerError'
   /api/internal/v1/inventory/tenants/{tenant_id}/devices/{device_id}/groups:
     get:
       tags:

--- a/backend/services/inventory/api/http/api_inventory.go
+++ b/backend/services/inventory/api/http/api_inventory.go
@@ -50,19 +50,20 @@ const (
 	uriAttributes       = "/attributes"
 	uriDeviceAttributes = "/device/attributes"
 
-	apiUrlInternalV1         = "/api/internal/v1/inventory"
-	uriInternalAlive         = "/alive"
-	uriInternalHealth        = "/health"
-	uriInternalTenants       = "/tenants"
-	uriInternalDevices       = "/tenants/:tenant_id/devices"
-	urlInternalDevicesStatus = "/tenants/:tenant_id/devices/status/:status"
-	uriInternalDeviceDetails = "/tenants/:tenant_id/devices/:device_id"
-	uriInternalDeviceGroups  = "/tenants/:tenant_id/devices/:device_id/groups"
-	urlInternalAttributes    = "/tenants/:tenant_id/device/:device_id/attribute/scope/:scope"
-	urlInternalReindex       = "/tenants/:tenant_id/devices/:device_id/reindex"
-	apiUrlManagementV2       = "/api/management/v2/inventory"
-	urlFiltersAttributes     = "/filters/attributes"
-	urlFiltersSearch         = "/filters/search"
+	apiUrlInternalV1             = "/api/internal/v1/inventory"
+	uriInternalAlive             = "/alive"
+	uriInternalHealth            = "/health"
+	uriInternalTenants           = "/tenants"
+	uriInternalDevices           = "/tenants/:tenant_id/devices"
+	urlInternalDevicesStatus     = "/tenants/:tenant_id/devices/status/:status"
+	uriInternalDeviceDetails     = "/tenants/:tenant_id/devices/:device_id"
+	uriInternalDeviceGroups      = "/tenants/:tenant_id/devices/:device_id/groups"
+	urlInternalAttributes        = "/tenants/:tenant_id/device/:device_id/attribute/scope/:scope"
+	urlInternalAttributesNoScope = "/tenants/:tenant_id/device/:device_id/attributes"
+	urlInternalReindex           = "/tenants/:tenant_id/devices/:device_id/reindex"
+	apiUrlManagementV2           = "/api/management/v2/inventory"
+	urlFiltersAttributes         = "/filters/attributes"
+	urlFiltersSearch             = "/filters/search"
 
 	apiUrlInternalV2         = "/api/internal/v2/inventory"
 	urlInternalFiltersSearch = "/tenants/:tenant_id/filters/search"
@@ -529,8 +530,11 @@ func (i *InternalAPI) PatchDeviceAttributesInternalHandler(
 		}
 		notModifiedAfter = &parsed
 	}
+	scopeFromUrl := c.FullPath() == (apiUrlInternalV1 + urlInternalAttributes)
 	for i := range attrs {
-		attrs[i].Scope = c.Param("scope")
+		if scopeFromUrl {
+			attrs[i].Scope = c.Param("scope")
+		}
 		if attrs[i].Name == checkInTimeParamName && attrs[i].Scope == checkInTimeParamScope {
 			t, err := time.Parse(time.RFC3339, fmt.Sprintf("%v", attrs[i].Value))
 			if err != nil {

--- a/backend/services/inventory/api/http/routing.go
+++ b/backend/services/inventory/api/http/routing.go
@@ -175,6 +175,10 @@ func NewRouter(app inv.InventoryApp, options ...Option) http.Handler {
 	intrnlAPIV1.GET(uriInternalHealth, intrnlHandler.HealthCheckHandler)
 	intrnlAPIV1.GET(uriInternalAlive, intrnlHandler.LivelinessHandler)
 	intrnlAPIV1.PATCH(urlInternalAttributes, intrnlHandler.PatchDeviceAttributesInternalHandler)
+	intrnlAPIV1.PATCH(
+		urlInternalAttributesNoScope,
+		intrnlHandler.PatchDeviceAttributesInternalHandler,
+	)
 	intrnlAPIV1.POST(urlInternalReindex, intrnlHandler.ReindexDeviceDataHandler)
 	intrnlAPIV1.POST(uriInternalTenants, intrnlHandler.CreateTenantHandler)
 


### PR DESCRIPTION
feat(inventory): internal patch /tenants/:tenant_id/device/:device_id/attribute
    
The new endpoint PATCH /tenants/:tenant_id/device/:device_id/attribute
works exactly like /tenants/:tenant_id/device/:device_id/attribute/scope/:scope
with the exception that it does not override the given attributes scope.
In other words: what you give in the body will maintain the scope.
    
Changelog: Commit
Ticket: MEN-9096
Signed-off-by: Peter Grzybowski <peter@northern.tech>