### PR TITLE
feat: create docker-compose file for mender-client-qemu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -388,13 +388,5 @@ services:
       default:
         aliases: [mender-nats]
 
-  client:
-    image: mendersoftware/mender-client-qemu:mender-master
-    scale: 0
-    privileged: true
-    environment:
-      SERVER_URL: "${SERVER_URL:-https://docker.mender.io}"
-      TENANT_TOKEN: "${TENANT_TOKEN:-}"
-
 volumes:
   mongo: {}

--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.client.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.client.yml
@@ -1,0 +1,8 @@
+services:
+  client:
+    image: mendersoftware/mender-client-qemu:mender-master
+    scale: 0
+    privileged: true
+    environment:
+      SERVER_URL: "${SERVER_URL:-https://docker.mender.io}"
+      TENANT_TOKEN: "${TENANT_TOKEN:-}"

--- a/frontend/tests/e2e_tests/run
+++ b/frontend/tests/e2e_tests/run
@@ -3,7 +3,7 @@ set -e
 
 export SERVER_ROOT=${SERVIER_ROOT:-$(git rev-parse --show-toplevel)}
 export GUI_REPOSITORY=${GUI_REPOSITORY:-${SERVER_ROOT}/frontend}
-export COMPOSE_FILE="${SERVER_ROOT}/docker-compose.yml:${GUI_REPOSITORY}/tests/e2e_tests/docker-compose.e2e-tests.yml"
+export COMPOSE_FILE="${SERVER_ROOT}/docker-compose.yml:${GUI_REPOSITORY}/tests/e2e_tests/docker-compose.e2e-tests.client.yml:${GUI_REPOSITORY}/tests/e2e_tests/docker-compose.e2e-tests.yml"
 LOCAL=""
 VISUAL=""
 


### PR DESCRIPTION
Separating the client allow to not download the mender-client-qemu image by default when mender-server is starting.

The mender-client-qemu image is about 1.3GB so it's significant.

If this proposal makes sense for you then I can create a pull request for the main branch too.