### PR TITLE
MEN-8935: add `bytesprocessed` to accesslog entries

### DIFF
--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -107,9 +107,6 @@ func (a AccessLogger) LogFunc(
 	logCtx["responsetime"] = latency.String()
 	logCtx["status"] = c.Writer.Status()
 	logCtx["byteswritten"] = c.Writer.Size()
-	if length := c.Request.ContentLength; length > -1 {
-		logCtx["contentlength"] = length
-	}
 
 	var logLevel logrus.Level = logrus.InfoLevel
 	if code >= 500 {


### PR DESCRIPTION
This should cover the actual number of bytes consumed from the client which should also covered chunked transfer encoding.