### PR TITLE
ci: simplify mender-docs-changelog generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -775,22 +775,13 @@ release:mender-docs-changelog:
       else
       export CHANGELOG_SUFFIX="";
       fi;
-    - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
   script:
-    # Generate the change for this release only
-    - git cliff --use-branch-tags --current --output this_mender_docs_changelog.md
     - git clone https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_CHANGELOG_REPO_URL}
     - cd ${GITHUB_CHANGELOG_REPO_URL#*/}
     - git checkout -b changelog-${CI_JOB_ID}
-    # Backup the Changelog file and remove the header
-    - tail -n +9 ${CHANGELOG_REMOTE_FILE} > ${CHANGELOG_REMOTE_FILE}.${CI_JOB_ID}
-    - sed -i -E "s/^---$//" ${CHANGELOG_REMOTE_FILE}.${CI_JOB_ID}
-    - cat ../.docs_header.md > ${CHANGELOG_REMOTE_FILE}
-    - cat ../this_mender_docs_changelog.md | grep -v -E '^---' >> ${CHANGELOG_REMOTE_FILE}
-    - cat ${CHANGELOG_REMOTE_FILE}.${CI_JOB_ID} >> ${CHANGELOG_REMOTE_FILE}
+    - cat ../.docs_header.md "../CHANGELOG${CHANGELOG_SUFFIX}.md" > "${CHANGELOG_REMOTE_FILE}"
     - git add ${CHANGELOG_REMOTE_FILE}
-    - |
-      git commit -s -m "chore: add $CI_PROJECT_NAME changelog"
+    - 'git commit -s -m "chore: add $CI_PROJECT_NAME changelog"'
     - git push origin changelog-${CI_JOB_ID}
     - gh pr create --title "Update CHANGELOG${CHANGELOG_SUFFIX}.md for $CI_PROJECT_NAME" --body "Automated change to the CHANGELOG${CHANGELOG_SUFFIX}.md file" --base master --head changelog-${CI_JOB_ID}
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,12 @@ variables:
   CHANGELOG_REMOTE_FILE:
     description: "The changelog file in the remote changelog repo"
     value: "10.Mender-Server/docs.md"
+  GIT_CLIFF__CHANGELOG__HEADER:
+    description: "Override the default git cliff header for this project"
+    value: ""
+  GIT_CLIFF__CHANGELOG__FOOTER:
+    description: "Override the default git cliff footer for this project"
+    value: ""
 
   # Helm version bump
   HELM_MENDER_PUBLISH_REGISTRY:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
----
 ## 4.0.0 - 2025-02-10
 
 
@@ -24708,8 +24707,6 @@ artifact description
 * Fix bug that caused the update not to be retried after failing during
 previous attempt (#193)
 
----
 ## Mender v1.0.0
 _Released 02.20.2017_
 
----


### PR DESCRIPTION
Avoid git cliff recreation, simply reuse the previously generated CHANGELOG file

Ticket: None

Credits to: @alfrunes https://github.com/mendersoftware/mender-server-enterprise/pull/840 and @danielskinstad : https://github.com/mendersoftware/mender-gateway/commit/7fee6707c4554cb926cf316e01dcead1cefd4d67