### PR TITLE
QA-1417: Pin QEMU image for e2e tests to the previous working version

### DIFF
--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.rofs.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.rofs.yml
@@ -6,7 +6,7 @@ services:
       - CLIENT_IP
 
   client:
-    image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-master
+    image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-master-pin-qa-1417
     environment:
       - SERVER_URL=https://docker.mender.io
       - TENANT_TOKEN


### PR DESCRIPTION
This alias is for yesterday's image, which contains the demo certificates in `/etc/ssl/certs`.

It is a temporary workaround while we figure out the actual problem with the yocto build.