### PR TITLE
chore: add `traefik` as a valid routing hostname

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,7 +182,11 @@ build:backend:docker:
   extends: .template:build:docker
   rules:
     - changes:
-        paths: ["backend/**/*", ".gitlab-ci.yml"]
+        paths:
+          - "backend/**/*"
+          - ".gitlab-ci.yml"
+          - "docker-compose.yml"
+          - "compose/docker-compose.enterprise.yml"
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
       when: always
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -356,7 +360,11 @@ test:backend:integration:
   extends: .build:base
   rules:
     - changes:
-        paths: ["backend/**/*", ".gitlab-ci.yml"]
+        paths:
+          - "backend/**/*"
+          - ".gitlab-ci.yml"
+          - "docker-compose.yml"
+          - "compose/docker-compose.enterprise.yml"
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'

--- a/compose/docker-compose.enterprise.yml
+++ b/compose/docker-compose.enterprise.yml
@@ -18,7 +18,7 @@ services:
       traefik.http.services.auditlogs.loadBalancer.server.port: "8080"
       traefik.http.routers.auditlogs.middlewares: "mgmtStack@file"
       traefik.http.routers.auditlogs.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/auditlogs`)
       traefik.http.routers.auditlogs.service: auditlogs
     networks:
@@ -76,12 +76,12 @@ services:
       traefik.http.services.devicemonitor.loadBalancer.server.port: "8080"
       traefik.http.routers.devicemonitorDev.middlewares: "devStack@file"
       traefik.http.routers.devicemonitorDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/devicemonitor`)
       traefik.http.routers.devicemonitorDev.service: devicemonitor
       traefik.http.routers.devicemonitorMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.devicemonitorMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/devicemonitor`)
       traefik.http.routers.devicemonitorMgmt.service: devicemonitor
     networks:
@@ -149,13 +149,13 @@ services:
       traefik.http.services.tenantadm.loadBalancer.server.port: "8080"
       traefik.http.routers.tenantadm.middlewares: "mgmtStack@file"
       traefik.http.routers.tenantadm.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]/tenantadm`)
       traefik.http.routers.tenantadm.service: tenantadm
       traefik.http.routers.signup.middlewares: >-
         compression@file,sec-headers@file
       traefik.http.routers.signup.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         ((Method(`OPTIONS`) || Method(`POST`)) && PathRegexp(`/api/management/v[0-9a-z]+/tenantadm/tenants/signup`) ||
         (Method(`OPTIONS`) || Method(`POST`)) && PathRegexp(`/api/management/v[0-9a-z]+/tenantadm/tenants/trial`))
       traefik.http.routers.signup.service: tenantadm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,17 +44,17 @@ services:
       traefik.http.services.deployments.loadBalancer.server.port: "8080"
       traefik.http.routers.deploymentsDL.middlewares: "sec-headers@file"
       traefik.http.routers.deploymentsDL.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/deployments/download`)
       traefik.http.routers.deploymentsDL.service: deployments
       traefik.http.routers.deploymentsDev.middlewares: "devStack@file"
       traefik.http.routers.deploymentsDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/deployments`)
       traefik.http.routers.deploymentsDev.service: deployments
       traefik.http.routers.deploymentsMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.deploymentsMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/deployments`)
       traefik.http.routers.deploymentsMgmt.service: deployments
     networks:
@@ -86,12 +86,12 @@ services:
       traefik.http.services.deviceauth.loadBalancer.server.port: "8080"
       traefik.http.routers.deviceauthDev.middlewares: "compression@file"
       traefik.http.routers.deviceauthDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/authentication`)
       traefik.http.routers.deviceauthDev.service: deviceauth
       traefik.http.routers.deviceauthMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.deviceauthMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/devauth`)
       traefik.http.routers.deviceauthMgmt.service: deviceauth
     networks:
@@ -117,12 +117,12 @@ services:
       traefik.http.services.deviceconfig.loadBalancer.server.port: "8080"
       traefik.http.routers.deviceconfigDev.middlewares: "devStack@file"
       traefik.http.routers.deviceconfigDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/deviceconfig`)
       traefik.http.routers.deviceconfigDev.service: deviceconfig
       traefik.http.routers.deviceconfigMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.deviceconfigMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/deviceconfig`)
       traefik.http.routers.deviceconfigMgmt.service: deviceconfig
     networks:
@@ -151,12 +151,12 @@ services:
       traefik.http.services.deviceconnect.loadBalancer.server.port: "8080"
       traefik.http.routers.deviceconnectDev.middlewares: "devStack@file"
       traefik.http.routers.deviceconnectDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[0-9a-z]+/deviceconnect`)
       traefik.http.routers.deviceconnectDev.service: deviceconnect
       traefik.http.routers.deviceconnectMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.deviceconnectMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/deviceconnect`)
       traefik.http.routers.deviceconnectMgmt.service: deviceconnect
     networks:
@@ -176,7 +176,7 @@ services:
         compression@file,sec-headers@file
       traefik.http.routers.gui.priority: 1
       traefik.http.routers.gui.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathPrefix(`/`)
       traefik.http.routers.gui.service: gui
     environment:
@@ -212,23 +212,23 @@ services:
       traefik.http.routers.inventoryDevV1.middlewares: >-
         devStack@file,inventoryV1-replacepathregex@file
       traefik.http.routers.inventoryDevV1.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v1/inventory`)
       traefik.http.routers.inventoryDevV1.service: inventory
       traefik.http.routers.inventoryMgmtV1.middlewares: >-
         mgmtStack@file,inventoryMgmtV1-replacepathregex@file
       traefik.http.routers.inventoryMgmtV1.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v1/inventory`)
       traefik.http.routers.inventoryMgmtV1.service: inventory
       traefik.http.routers.inventoryDev.middlewares: "devStack@file"
       traefik.http.routers.inventoryDev.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/devices/v[2-9]/inventory`)
       traefik.http.routers.inventoryDev.service: inventory
       traefik.http.routers.inventoryMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.inventoryMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[2-9]/inventory`)
       traefik.http.routers.inventoryMgmt.service: inventory
 
@@ -256,7 +256,7 @@ services:
       traefik.http.services.iot-manager.loadBalancer.server.port: "8080"
       traefik.http.routers.iot-managerMgmt.middlewares: "mgmtStack@file"
       traefik.http.routers.iot-managerMgmt.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/iot-manager`)
       traefik.http.routers.iot-managerMgmt.service: iot-manager
     networks:
@@ -281,13 +281,13 @@ services:
       traefik.http.services.useradm.loadBalancer.server.port: "8080"
       traefik.http.routers.useradm.middlewares: "mgmtStack@file"
       traefik.http.routers.useradm.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         PathRegexp(`/api/management/v[0-9a-z]+/useradm`)
       traefik.http.routers.useradm.service: useradm
       traefik.http.routers.userauth.middlewares: >-
         compression@file,sec-headers@file
       traefik.http.routers.userauth.rule: >-
-        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`)) &&
+        (Host(`${MENDER_HOSTNAME:-docker.mender.io}`) || Host(`localhost`) || Host(`traefik`)) &&
         (!PathRegexp(`/api/management/v[0-9a-z]+/useradm/auth/logout`) &&
         PathRegexp(`/api/management/v[0-9a-z]+/useradm/(auth|oauth2|oidc)`))
       traefik.http.routers.userauth.service: useradm


### PR DESCRIPTION
Required by integration tests.