### PR TITLE
QA-1046: Remove redundant commits signoff check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,8 +97,6 @@ include:
   - project: "Northern.tech/Mender/mendertesting"
     file:
       - ".gitlab-ci-github-status-updates.yml"
-      # QA-1046 Remove after hardening sign-off checks in the modern commit linter
-      - ".gitlab-ci-check-commits-signoffs.yml"
   - local: "/frontend/pipeline.yml"
   - local: "/.gitlab/merge-enterprise.yml"
     rules:


### PR DESCRIPTION
We have modified the CI/CD component to add the extra job, so that we have a single point to remove once we do QA-1046. See:
* https://github.com/mendersoftware/mendertesting/pull/423