### PR TITLE
QA-1434: Revert "ci: Pin QEMU image for e2e tests to the previous working version"

### DIFF
--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.rofs.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.rofs.yml
@@ -6,7 +6,7 @@ services:
       - CLIENT_IP
 
   client:
-    image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-master-pin-qa-1417
+    image: registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:mender-master
     environment:
       - SERVER_URL=https://docker.mender.io
       - TENANT_TOKEN


### PR DESCRIPTION
This reverts commit 90e3037a10e8b1889deea90d9a9437e3e9eee905.