### PR TITLE
feat(workflows): default value for input variables and gojsonq fix

### DIFF
--- a/backend/services/workflows/app/processor/job.go
+++ b/backend/services/workflows/app/processor/job.go
@@ -69,12 +69,21 @@ func (j JobProcessor) ProcessJSON(
 					// as an input parameter, then with `device.jsonInput.tier` you can refer
 					// to the Device.Tier field
 					if strings.HasPrefix(key, param.Name+jsonRefInputVariable) {
-						return gojsonq.New().FromString(param.Value).Find(
-							strings.TrimPrefix(
-								key,
-								param.Name+jsonRefInputVariable,
-							),
+						findString := strings.TrimPrefix(
+							key,
+							param.Name+jsonRefInputVariable+".",
 						)
+						if strings.Contains(findString, "|") {
+							findString = strings.Split(findString, "|")[0]
+						}
+						v := gojsonq.New().FromString(param.Value).Find(
+							findString,
+						)
+						values := strings.Split(key, "|")
+						if v == nil && len(values) > 1 {
+							return strings.TrimSuffix(values[1], "}")
+						}
+						return v
 					}
 					if param.Name == key && param.Raw != nil {
 						return j.ProcessJSON(param.Raw, ps)

--- a/backend/services/workflows/app/processor/string.go
+++ b/backend/services/workflows/app/processor/string.go
@@ -147,9 +147,12 @@ SubMatchLoop:
 					dataAny := gojsonq.New().FromString(param.Value).Find(
 						strings.TrimPrefix(
 							paramName,
-							param.Name+jsonRefInputVariable,
+							param.Name+jsonRefInputVariable+".",
 						),
 					)
+					if dataAny == nil && len(value) > 0 {
+						return value
+					}
 					switch d := dataAny.(type) {
 					case string:
 						return d


### PR DESCRIPTION
With this change you can use the following syntax
to set a default value for an empty input variable:

${workflow.input.device.jsonInput.tier|standard}

There is also a required in some environments
fix for proper querying of the fields via jsonInput.

see for usage: https://github.com/mendersoftware/mender-server-enterprise/pull/865

Changelog: Commit
Ticket: MEN-9096