### PR TITLE
chore(pkg): initialized new package for type utils

### DIFF
--- a/backend/pkg/utils/types/pointer.go
+++ b/backend/pkg/utils/types/pointer.go
@@ -1,0 +1,7 @@
+// Copyright 2025 Northern.tech AS
+//
+//	All Rights Reserved
+
+package types
+
+func Pointer[T any](value T) *T { return &value }


### PR DESCRIPTION
Initialized the package with a simple Pointer generic for dereferencing variables and constants.
One pointer func to rule them all!

(Cherry-picked from enterprise).