### PR TITLE
test: Use `redo.retrier` to wait for async operations

### DIFF
--- a/backend/tests/integration/tests/test_access.py
+++ b/backend/tests/integration/tests/test_access.py
@@ -17,6 +17,7 @@ import pytest
 import uuid
 import os
 import time
+import redo
 
 from testutils.common import Tenant, User, update_tenant, create_user, create_org
 from testutils.infra.cli import CliTenantadm
@@ -444,19 +445,16 @@ def _make_trial_tenant():
 
     propagate_wait_s = 2
     max_tries = 150
-    tries_left = max_tries
-    while tries_left > 0:
+    for i in redo.retrier(attempts=max_tries, sleeptime=propagate_wait_s):
         r = ApiClient(useradm.URL_MGMT).call(
             "POST", useradm.URL_LOGIN, auth=(email, password)
         )
         if r.status_code == 200:
             logger.info(
                 "_make_trial_tenant: it took %d tries to login"
-                % (max_tries - tries_left + 1)
+                % (i)
             )
             break
-        time.sleep(propagate_wait_s)
-        tries_left = tries_left - 1
 
     assert r.status_code == 200
 

--- a/backend/tests/integration/tests/test_auditlogs.py
+++ b/backend/tests/integration/tests/test_auditlogs.py
@@ -230,8 +230,6 @@ class TestAuditLogsEnterprise:
                 ]
                 if len(found) == 1:
                     return found[0]["time"]
-
-                time.sleep(0.5)
             else:
                 assert False, "max GET /logs retries hit"
 

--- a/backend/tests/integration/tests/test_create_artifact.py
+++ b/backend/tests/integration/tests/test_create_artifact.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import time
 import uuid
-
+import redo
 from json import dumps
 
 from testutils.api.client import ApiClient
@@ -80,8 +80,7 @@ class TestCreateArtifactBase:
         )
 
         artifact = None
-        for i in range(15):
-            time.sleep(1)
+        for _ in redo.retrier(attempts=15, sleeptime=1):
             r = api_client.call("GET", artifact_url,)
             if r.status_code == 200:
                 artifact = r.json()

--- a/backend/tests/integration/tests/test_password_reset.py
+++ b/backend/tests/integration/tests/test_password_reset.py
@@ -16,6 +16,7 @@ import pytest
 import re
 import time
 import uuid
+import redo
 
 from testutils.api import useradm
 from testutils.api.client import ApiClient
@@ -44,12 +45,11 @@ class TestPasswordResetEnterprise:
         assert r.status_code == 202
         # wait for the password reset email
         message = None
-        for i in range(15):
+        for _ in redo.retrier(attempts=15, sleeptime=1):
             messages = smtp_server.filtered_messages(email)
             if len(messages) > 0:
                 message = messages[0]
                 break
-            time.sleep(1)
         # be sure we received the email
         assert message is not None
         assert message.data != ""

--- a/backend/tests/integration/tests/test_tenantadm.py
+++ b/backend/tests/integration/tests/test_tenantadm.py
@@ -60,13 +60,12 @@ class TestCreateOrganizationCLIEnterprise:
         self.logger.debug("Tenant id: %s" % tenant_id)
 
         # Retry login every second for 3 min
-        for i in range(60 * 3):
+        for _ in retrier(attempts=60*3, sleeptime=1):
             rsp = self.api_mgmt_useradm.call(
                 "POST", api.useradm.URL_LOGIN, auth=(username, password)
             )
             if rsp.status_code == 200:
                 break
-            time.sleep(1)
 
         assert rsp.status_code == 200
 
@@ -93,14 +92,13 @@ class TestCreateOrganizationCLIEnterprise:
         self.logger.debug("Tenant id: %s" % tenant_id)
 
         # Retry login every second for 2 min
-        for i in range(60 * 2):
+        for _ in retrier(attempts=60*2, sleeptime=1):
             rsp = self.api_mgmt_useradm.call(
                 "POST", api.useradm.URL_LOGIN, auth=(username, password)
             )
             if rsp.status_code == 200:
                 self.logger.debug("Successfully logged into account")
                 break
-            time.sleep(1)
         assert rsp.status_code == 200
 
         try:

--- a/backend/tests/integration/tests/test_tenantadm_support.py
+++ b/backend/tests/integration/tests/test_tenantadm_support.py
@@ -16,6 +16,7 @@ import pytest
 import re
 import time
 import uuid
+import redo
 
 import testutils.api.tenantadm_v2 as tenantadm_v2
 from testutils.api import useradm
@@ -70,12 +71,11 @@ class TestContactSupportEnterprise:
         assert r.status_code == 202
         # wait for the email
         message = None
-        for i in range(15):
+        for _ in redo.retrier(attempts=15, sleeptime=1):
             messages = smtp_server.filtered_messages("support@mender.io")
             if len(messages) > 0:
                 message = messages[0]
                 break
-            time.sleep(1)
 
         # be sure we received the email
         assert message is not None

--- a/backend/tests/integration/tests/test_verify_email.py
+++ b/backend/tests/integration/tests/test_verify_email.py
@@ -16,6 +16,7 @@ import pytest
 import re
 import time
 import uuid
+import redo
 
 from testutils.api import useradm
 from testutils.api.client import ApiClient
@@ -54,12 +55,11 @@ class TestVerifyEmailEnterprise:
         assert r.status_code == 202
         # wait for the verification email
         message = None
-        for i in range(15):
+        for _ in redo.retrier(attempts=15, sleeptime=1):
             messages = smtp_server.filtered_messages(email)
             if len(messages) > 0:
                 message = messages[0]
                 break
-            time.sleep(1)
         # be sure we received the email
         assert message is not None
         assert message.data != ""

--- a/backend/tests/integration/testutils/infra/container_manager/docker_compose_base_manager.py
+++ b/backend/tests/integration/testutils/infra/container_manager/docker_compose_base_manager.py
@@ -188,17 +188,11 @@ class DockerComposeBaseNamespace(DockerNamespace):
             retry_attempts = 8
 
             # Take down all docker instances in this namespace.
-            while retry_attempts > 0:
-                logger.info(
-                    "(attempts left: %d) trying to stop all containers in %s"
-                    % (retry_attempts, self.name)
-                )
+            for _ in redo.retrier(attempts=retry_attempts, sleeptime=stop_sleep_seconds):
                 try:
                     self._docker_compose_cmd(
                         "down -v --remove-orphans", fail_early=False
                     )
                     break
                 except Exception as e:
-                    time.sleep(stop_sleep_seconds)
                     logger.error(e)
-                    retry_attempts = retry_attempts - 1


### PR DESCRIPTION
Ticket: QA-1214