### PR TITLE
chore(gui): publication job double /gui fixed

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -303,12 +303,12 @@ publish:frontend:docker:
         docker://${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG} # covers vX.Y.Z + -fragment/ -build tags
     - |
       if echo -n "${MENDER_PUBLISH_TAG}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-2)
-        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-1)
+        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-2)
+        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-1)
 
         if .gitlab/check_publish_latest.sh; then
-            echo "Updating 'latest' reference: ${MENDER_PUBLISH_IMAGE}/gui:latest"
-            skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:latest
+            echo "Updating 'latest' reference: ${MENDER_PUBLISH_IMAGE}:latest"
+            skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:latest
         fi
       fi
   artifacts:


### PR DESCRIPTION
FRONTEND_REPOSITORY is mendersoftware/gui, so
MENDER_PUBLISH_IMAGE="${MENDER_PUBLISH_REGISTRY}/${FRONTEND_REPOSITORY}" makes double gui/gui see:
https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/12689201864

time="2026-01-12T22:08:22Z" level=fatal msg="copying image 1/2 from manifest list: writing blob: initiating layer upload to /v2/mender-server-enterprise/gui/gui/blobs/uploads/ in [MASKED]: name unknown: The repository with name 'mender-server-enterprise/gui/gui' does not exist in the registry with id '175683096866'"

Ticket: None