### PR TITLE
ci: fix repository references in publish:frontend:docker

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -295,7 +295,7 @@ publish:frontend:docker:
     MENDER_PUBLISH_REGISTRY: docker.io
   script:
     - export MENDER_PUBLISH_IMAGE="${MENDER_PUBLISH_REGISTRY}/${FRONTEND_REPOSITORY}"
-    - echo "About to publish ${DOCKER_TAG} to ${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG}"
+    - echo "About to publish ${MENDER_IMAGE_GUI} to ${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG}"
     - |
       skopeo copy --multi-arch all \
         --digestfile .digests/gui \
@@ -303,12 +303,12 @@ publish:frontend:docker:
         docker://${MENDER_PUBLISH_IMAGE}:${MENDER_PUBLISH_TAG} # covers vX.Y.Z + -fragment/ -build tags
     - |
       if echo -n "${MENDER_PUBLISH_TAG}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-2)
-        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-1)
+        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-2)
+        skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:$(echo -n $MENDER_PUBLISH_TAG | cut -d . -f-1)
 
         if .gitlab/check_publish_latest.sh; then
-            echo "Updating 'latest' reference: ${MENDER_PUBLISH_IMAGE}/gui:latest"
-            skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}/gui:latest
+            echo "Updating 'latest' reference: ${MENDER_PUBLISH_IMAGE}:latest"
+            skopeo copy --multi-arch all docker://${MENDER_IMAGE_GUI} docker://${MENDER_PUBLISH_IMAGE}:latest
         fi
       fi
   artifacts:


### PR DESCRIPTION
Fixes the container registry URL for publishing the tags:
 - `latest`
 - `vX.Y`
 - `vX`

Ticket: QA-1450