### PR TITLE
fix(useradm): Absolute path for created user

### DIFF
--- a/backend/services/useradm/api/http/api_useradm.go
+++ b/backend/services/useradm/api/http/api_useradm.go
@@ -307,7 +307,7 @@ func (u *UserAdmApiHandlers) AddUserHandler(c *gin.Context) {
 		return
 	}
 
-	c.Writer.Header().Add("Location", "users/"+string(user.ID))
+	c.Writer.Header().Add("Location", c.Request.URL.JoinPath(user.ID).EscapedPath())
 	c.Status(http.StatusCreated)
 
 }


### PR DESCRIPTION
The relative location resolves to a non-existing API path.