### PR TITLE
ci: fix jq expression for evaluating existing enterprise pull request

### DIFF
--- a/.gitlab/merge-enterprise.yml
+++ b/.gitlab/merge-enterprise.yml
@@ -36,7 +36,7 @@ merge-to-enterprise:
         --header "Authorization: Bearer $GITHUB_BOT_TOKEN_REPO_FULL" \
         --header "Accept: application/vnd.github+json" \
         --header "X-GitHub-Api-Version: 2022-11-28" \
-        -O- | jq -r 'first? // {}' > pull.json
+        -O- | jq -r 'first? // ""' > pull.json
 
     - |
       cat > pr_body.txt << EOF


### PR DESCRIPTION
Currently the if expression evaluates `null` as a non-empty pull request number. Changed the expression to produce an empty string if none found.