### PR TITLE
chore(gui): removed unintended counter underline to ensure widget tags stay as intended

### DIFF
--- a/frontend/src/js/components/dashboard/__snapshots__/Devices.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/__snapshots__/Devices.test.tsx.snap
@@ -100,6 +100,8 @@ exports[`Devices Component > renders correctly 1`] = `
 
 .emotion-8 {
   max-width: 6vh;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-8.red {

--- a/frontend/src/js/components/dashboard/widgets/ActionableDevices.tsx
+++ b/frontend/src/js/components/dashboard/widgets/ActionableDevices.tsx
@@ -65,6 +65,7 @@ const useStyles = makeStyles()(theme => ({
   },
   issueType: {
     maxWidth: '6vh',
+    textDecoration: 'none',
     ['&.red']: { color: theme.palette.secondary.main },
     ['&.green']: { color: theme.palette.primary.main }
   },


### PR DESCRIPTION
little annoyance I came across...
before:
<img width="776" height="560" alt="Screenshot 2026-01-28 at 15 13 27" src="https://github.com/user-attachments/assets/81f6111d-af87-43cb-abba-eedef42b4505" />
after:
<img width="769" height="551" alt="Screenshot 2026-01-28 at 15 13 13" src="https://github.com/user-attachments/assets/b8dc9bda-2eee-4247-ae04-502564e23e26" />
