### PR TITLE
fix: soften warning about sharing tenant token

### DIFF
--- a/frontend/src/js/components/settings/organization/Organization.tsx
+++ b/frontend/src/js/components/settings/organization/Organization.tsx
@@ -156,7 +156,8 @@ export const Organization = () => {
           notification={
             showTokenWarning && (
               <Alert severity="warning">
-                Do not share your organization token with others. Treat this token like a password, as it can be used to request authorization for new devices.
+                Do not share your organization token. If leaked, unauthorized devices can send authorization requests, making it difficult to identify and
+                manage your own devices.
               </Alert>
             )
           }


### PR DESCRIPTION
Update the warning message to accurately reflect the risk of unauthorized device authorization requests instead of comparing the token to a password.

Ticket: ME-620
Signed-off-by: Nick Anderson <nick@cmdln.org>