### PR TITLE
test: relaxed deployment success checking further to address flash deployments

### DIFF
--- a/frontend/tests/e2e_tests/integration/03-advanced/04-deployments.spec.ts
+++ b/frontend/tests/e2e_tests/integration/03-advanced/04-deployments.spec.ts
@@ -126,7 +126,6 @@ test.describe('Deployments', () => {
     await deviceGroupSelect.fill('test');
     await page.click(`#deployment-device-group-selection-listbox li:has-text('testgroup')`);
     await triggerDeploymentCreation(page, expect(page.getByText(/Select a Release to deploy/i)).toHaveCount(0, { timeout: timeouts.tenSeconds }));
-    await page.waitForSelector(selectors.deploymentListItem, { timeout: timeouts.tenSeconds });
     await page.getByRole('tab', { name: /finished/i }).click();
     await page.waitForSelector(selectors.deploymentListItemContent, { timeout: timeouts.sixtySeconds });
   });


### PR DESCRIPTION
this occurred despite the fix: https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/12994761327 - I think the relaxation is ok considering the long wait for the finished deployment