### PR TITLE
Collect compose logs in test span and dump database on debug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -404,13 +404,10 @@ test:backend:integration:
     expire_in: 1w
     when: always
     paths:
-      - ${GOCOVERDIR}/integration
-      - backend/logs.*
-      - backend/tests/integration/tests/logs.*
-      - backend/tests/integration/tests/results_integration_*.xml
-      - backend/tests/integration/tests/report_integration_*.html
+      - ${GOCOVERDIR}/integration/*
+      - backend/tests/logs/*
     reports:
-      junit: backend/tests/integration/tests/results_integration_*.xml
+      junit: backend/tests/logs/results_integration_*.xml
 
 test:backend:integration:ng:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     working_dir: /testing
+    environment:
+        PYTEST_ADDOPTS: "${PYTEST_ADDOPTS:-}"
     entrypoint:
       - pytest
       - --tb=long

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -25,6 +25,20 @@ from testutils.api.client import get_free_tcp_port, wait_for_port
 
 original_deserialize = ApiClient.deserialize
 
+def pytest_exception_interact(node, call, report):
+    if report.failed:
+        start = datetime.fromtimestamp(call.start, tz=timezone.utc)
+        stop = datetime.fromtimestamp(call.stop, tz=timezone.utc)
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "logs",
+                f"--since={start.isoformat()}",
+                f"--until={stop.isoformat()}",
+            ],
+            env={"COMPOSE_PROJECT_NAME": "backend-tests"},
+        )
 
 def new_deserialize(self, response_text, response_type, content_type):
     # the generated client does not support the application/jwt content type

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -11,8 +11,10 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+import logging
 import subprocess
 
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 import pytest
@@ -24,6 +26,25 @@ from testutils.infra.container_manager.kubernetes_manager import isK8S
 from testutils.api.client import get_free_tcp_port, wait_for_port
 
 original_deserialize = ApiClient.deserialize
+
+def _mongodump(node):
+    with open(f"/tests/logs/{node.name}.bson.gz", "wb") as f:
+        subprocess.run(
+            args=[
+                "docker",
+                "compose",
+                "exec",
+                "mongo",
+                "mongodump",
+                "--gzip",
+                "--archive",
+            ],
+            env={"COMPOSE_PROJECT_NAME": "backend-tests"},
+            stdout=f,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
 
 def pytest_exception_interact(node, call, report):
     if report.failed:
@@ -39,6 +60,9 @@ def pytest_exception_interact(node, call, report):
             ],
             env={"COMPOSE_PROJECT_NAME": "backend-tests"},
         )
+        if logging.getLogger().level <= logging.DEBUG:
+            _mongodump(node)
+
 
 def new_deserialize(self, response_text, response_type, content_type):
     # the generated client does not support the application/jwt content type

--- a/backend/tests/logs/.gitignore
+++ b/backend/tests/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/backend/tests/run-integration.bash
+++ b/backend/tests/run-integration.bash
@@ -42,8 +42,6 @@ PYTEST_REPORT_ENTERPRISE="--self-contained-html \
         --html=/tests/logs/report_integration_enterprise.html"
 PYTEST_REPORT=""
 
-PYTEST_ADDOPTS=""
-
 DOCS="$MENDER_SERVER_PATH/backend/tests/docs"
 
 usage() {
@@ -156,7 +154,7 @@ prepare_pytest_args() {
     done
 
     echo "-- using PYTEST_FILTER=$PYTEST_FILTER"
-    PYTEST_ADDOPTS="$PYTEST_ADDOPTS -k '$PYTEST_FILTER' $PYTEST_REPORT"
+    PYTEST_ADDOPTS="-k '$PYTEST_FILTER' $PYTEST_REPORT $PYTEST_ADDOPTS"
 
     export PYTEST_ADDOPTS
 }


### PR DESCRIPTION
A few improvements to integration environment:
 * Added collector for collecting compose logs filtering the time span of the failing test unit
 * Added collector for dumping a mongodb snapshot on failures if log level is "debug" or less.
 * Consolidated integration test artifacts
 * Exposed  PYTEST_ADDOPTS to be overridden by host environment