### PR TITLE
refactor(useradm): Properly enforce required useradm CLI flags

### DIFF
--- a/backend/services/useradm/main.go
+++ b/backend/services/useradm/main.go
@@ -76,8 +76,9 @@ func doMain(args []string) error {
 			Usage: "Create user",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "username",
-					Usage: "Name of created user, must be an email address",
+					Name:     "username",
+					Usage:    "Name of created user, must be an email address",
+					Required: true,
 				},
 				cli.StringFlag{
 					Name:  "password",
@@ -99,8 +100,9 @@ func doMain(args []string) error {
 			Usage: "Set password",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "username",
-					Usage: "Name of created user, must be an email address",
+					Name:     "username",
+					Usage:    "Name of created user, must be an email address",
+					Required: true,
 				},
 				cli.StringFlag{
 					Name:  "password",


### PR DESCRIPTION
Previously, the useradm commands did not have required flags marked as such. If missing multiple flags, the user would only be notified of one. Now, all mising flags will be shown immediately to the user.

Changelog: useradm commands now properly inform the user of missing required flags.