### PR TITLE
docs: required fix for the OpenAPI3 specs

### DIFF
--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -5691,7 +5691,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewDevice'
+              $ref: '#/components/schemas/NewDeviceInternalProvision'
         required: true
       responses:
         '202':
@@ -9737,7 +9737,7 @@ components:
           type: number
         system:
           type: number
-    NewDevice:
+    NewDeviceInternalProvision:
       type: object
       properties:
         id:

--- a/backend/docs/api/iot-manager/internal_v1.yaml
+++ b/backend/docs/api/iot-manager/internal_v1.yaml
@@ -47,7 +47,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewDevice'
+              $ref: '#/components/schemas/NewDeviceInternalProvision'
         required: true
       responses:
         202:
@@ -157,7 +157,7 @@ paths:
           $ref: '../common/responses.yaml#/components/responses/InternalServerError'
 components:
   schemas:
-    NewDevice:
+    NewDeviceInternalProvision:
       type: object
       properties:
         id:


### PR DESCRIPTION
Contains a required fix for the go client generated based on specs.
(We cant use NewDevice since it collides with the default constructor generated)

Changelog: None
Ticket: QA-1097