### PR TITLE
chore: increase golangci-lint run timeot from 5 to 10 minutes

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 
   build-tags:
     - nopkcs11 # Disables (unused) openssl dependency


### PR DESCRIPTION
The golangci-lint run on the generated go client on some runners takes a bit longer, this one increases the timeout from 5 minutes to 10 minutes

Ticket: QA-1097