### PR TITLE
MEN-9377: deviceauth `propagate-inventory` process batches of 1000 devices

### DIFF
--- a/backend/services/deviceauth/cmd/maintenance.go
+++ b/backend/services/deviceauth/cmd/maintenance.go
@@ -66,45 +66,58 @@ func MaintenanceSyncDeviceInventory(
 	rateLimit *rate.Limiter,
 ) error {
 	var totalCount int64
-	startTS := time.Now().Add(-time.Second)
 	logger := log.FromContext(ctx)
-	for dev, err := range db.ListAllDevices(ctx,
-		"tenant_id",
-		model.DevKeyId,
-		model.DevKeyIdDataStruct,
-		model.DevKeyStatus,
-	) {
-		if err != nil {
-			return fmt.Errorf("error listing all devices: %w", err)
-		}
-		if rateLimit != nil {
-			err = rateLimit.Wait(ctx)
+	var (
+		dev     *model.Device
+		err     error
+		startID *string
+	)
+	for {
+		dev = nil
+		startTS := time.Now().Add(-time.Second)
+		for dev, err = range db.ListAllDevices(ctx,
+			startID,
+			1000,
+			"tenant_id",
+			model.DevKeyId,
+			model.DevKeyIdDataStruct,
+			model.DevKeyStatus,
+		) {
 			if err != nil {
-				return err
+				return fmt.Errorf("error listing all devices: %w", err)
+			}
+			if rateLimit != nil {
+				err = rateLimit.Wait(ctx)
+				if err != nil {
+					return err
+				}
+			}
+			if dev.IdDataStruct == nil {
+				dev.IdDataStruct = map[string]any{
+					"status": dev.Status,
+				}
+			} else {
+				dev.IdDataStruct["status"] = dev.Status
+			}
+			fixupIDData2InventoryData(dev.IdDataStruct)
+			err := inv.SetDeviceIdentityIfUnmodifiedSince(
+				ctx, dev.TenantID,
+				dev.Id, dev.IdDataStruct,
+				startTS,
+			)
+			if errors.Is(err, inventory.ErrPreconditionsFailed) {
+				err = nil
+			}
+			if err != nil {
+				return fmt.Errorf("error updating inventory data: %w", err)
+			}
+			totalCount++
+			if totalCount%1000 == 0 {
+				logger.Infof("processed %d devices", totalCount)
 			}
 		}
-		if dev.IdDataStruct == nil {
-			dev.IdDataStruct = map[string]any{
-				"status": dev.Status,
-			}
-		} else {
-			dev.IdDataStruct["status"] = dev.Status
-		}
-		fixupIDData2InventoryData(dev.IdDataStruct)
-		err := inv.SetDeviceIdentityIfUnmodifiedSince(
-			ctx, dev.TenantID,
-			dev.Id, dev.IdDataStruct,
-			startTS,
-		)
-		if errors.Is(err, inventory.ErrPreconditionsFailed) {
-			err = nil
-		}
-		if err != nil {
-			return fmt.Errorf("error updating inventory data: %w", err)
-		}
-		totalCount++
-		if totalCount%1000 == 0 {
-			logger.Infof("processed %d devices", totalCount)
+		if dev == nil {
+			break
 		}
 	}
 	logger.Infof("finished processing %d devices", totalCount)

--- a/backend/services/deviceauth/cmd/maintenance.go
+++ b/backend/services/deviceauth/cmd/maintenance.go
@@ -65,50 +65,67 @@ func MaintenanceSyncDeviceInventory(
 	inv client.DeviceInventoryInternalAPIAPI,
 	rateLimit *rate.Limiter,
 ) error {
-	var totalCount int64
-	startTS := time.Now().Add(-time.Second)
-	logger := log.FromContext(ctx)
-	for dev, err := range db.ListAllDevices(ctx,
-		"tenant_id",
-		model.DevKeyId,
-		model.DevKeyIdDataStruct,
-		model.DevKeyStatus,
-	) {
-		if err != nil {
-			return fmt.Errorf("error listing all devices: %w", err)
-		}
-		if rateLimit != nil {
-			err = rateLimit.Wait(ctx)
+	var (
+		lastDeviceID *string
+		totalCount   int64
+
+		logger = log.FromContext(ctx)
+	)
+	for {
+		deviceCount := 0
+		batchStartTS := time.Now().
+			Add(-time.Second) // One second of jitter
+		for dev, err := range db.ListAllDevices(ctx,
+			lastDeviceID,
+			1000,
+			"tenant_id",
+			model.DevKeyId,
+			model.DevKeyIdDataStruct,
+			model.DevKeyStatus,
+		) {
+			deviceCount++
+			if err != nil {
+				return fmt.Errorf("error listing all devices: %w", err)
+			}
+			if rateLimit != nil {
+				err = rateLimit.Wait(ctx)
+				if err != nil {
+					return err
+				}
+			}
+			if dev.IdDataStruct == nil {
+				dev.IdDataStruct = map[string]any{
+					"status": dev.Status,
+				}
+			} else {
+				dev.IdDataStruct["status"] = dev.Status
+			}
+			fixupIDData2InventoryData(dev.IdDataStruct)
+			attributes, err := GetInventoryAttributes(dev.IdDataStruct)
 			if err != nil {
 				return err
 			}
-		}
-		if dev.IdDataStruct == nil {
-			dev.IdDataStruct = map[string]any{
-				"status": dev.Status,
+			//nolint:bodyclose
+			rsp, err := inv.UpdateInventoryForADeviceScopeWise(ctx, dev.TenantID, dev.Id).
+				AttributeRequest(attributes).
+				IfUnmodifiedSince(batchStartTS.In(
+					time.FixedZone("GMT", 0),
+				).Format(time.RFC1123)).
+				Execute()
+			if rsp != nil && rsp.StatusCode == http.StatusPreconditionFailed {
+				err = nil
 			}
-		} else {
-			dev.IdDataStruct["status"] = dev.Status
+			if err != nil {
+				return fmt.Errorf("error updating inventory data: %w", err)
+			}
+			totalCount++
+			if totalCount%1000 == 0 {
+				logger.Infof("processed %d devices", totalCount)
+			}
+			lastDeviceID = &dev.Id
 		}
-		fixupIDData2InventoryData(dev.IdDataStruct)
-		attributes, err := GetInventoryAttributes(dev.IdDataStruct)
-		if err != nil {
-			return err
-		}
-		//nolint:bodyclose
-		rsp, err := inv.UpdateInventoryForADeviceScopeWise(ctx, dev.TenantID, dev.Id).
-			AttributeRequest(attributes).
-			IfUnmodifiedSince(startTS.In(time.FixedZone("GMT", 0)).Format(time.RFC1123)).
-			Execute()
-		if rsp != nil && rsp.StatusCode == http.StatusPreconditionFailed {
-			err = nil
-		}
-		if err != nil {
-			return fmt.Errorf("error updating inventory data: %w", err)
-		}
-		totalCount++
-		if totalCount%1000 == 0 {
-			logger.Infof("processed %d devices", totalCount)
+		if deviceCount == 0 {
+			break
 		}
 	}
 	logger.Infof("finished processing %d devices", totalCount)

--- a/backend/services/deviceauth/store/mongo/datastore_mongo.go
+++ b/backend/services/deviceauth/store/mongo/datastore_mongo.go
@@ -1082,6 +1082,8 @@ func (db *DataStoreMongo) ListTenantsIds(
 
 func (db *DataStoreMongo) ListAllDevices(
 	ctx context.Context,
+	startAfterID *string,
+	limit int64,
 	fields ...string,
 ) iter.Seq2[*model.Device, error] {
 	collDevs := db.client.
@@ -1090,7 +1092,9 @@ func (db *DataStoreMongo) ListAllDevices(
 			mopts.Collection().
 				SetReadPreference(readpref.SecondaryPreferred()))
 
-	findOpts := mopts.Find()
+	findOpts := mopts.Find().
+		SetSort(bson.M{"_id": 1}).
+		SetLimit(limit)
 	if len(fields) > 0 {
 		projection := make(bson.D, 0, len(fields))
 		for _, key := range fields {
@@ -1098,8 +1102,14 @@ func (db *DataStoreMongo) ListAllDevices(
 		}
 		findOpts.SetProjection(projection)
 	}
+	q := bson.D{}
+	if startAfterID != nil {
+		q = append(q, bson.E{Key: "_id", Value: bson.D{
+			{Key: "$gt", Value: *startAfterID}},
+		})
+	}
 
-	cur, err := collDevs.Find(ctx, bson.D{}, findOpts)
+	cur, err := collDevs.Find(ctx, q, findOpts)
 	if err != nil {
 		return func(yield func(*model.Device, error) bool) {
 			yield(nil, err)

--- a/backend/services/deviceauth/store/mongo/datastore_mongo.go
+++ b/backend/services/deviceauth/store/mongo/datastore_mongo.go
@@ -1089,6 +1089,8 @@ func (db *DataStoreMongo) ListTenantsIds(
 
 func (db *DataStoreMongo) ListAllDevices(
 	ctx context.Context,
+	afterDeviceID *string,
+	limit int64,
 	fields ...string,
 ) iter.Seq2[*model.Device, error] {
 	collDevs := db.client.
@@ -1097,7 +1099,17 @@ func (db *DataStoreMongo) ListAllDevices(
 			mopts.Collection().
 				SetReadPreference(readpref.SecondaryPreferred()))
 
-	findOpts := mopts.Find()
+	findOpts := mopts.Find().
+		SetSort(bson.M{"_id": 1})
+	if limit >= 0 {
+		findOpts.SetLimit(limit)
+	}
+	filter := bson.D{}
+	if afterDeviceID != nil {
+		filter = append(filter, bson.E{Key: "_id", Value: bson.D{
+			{Key: "$gt", Value: *afterDeviceID},
+		}})
+	}
 	if len(fields) > 0 {
 		projection := make(bson.D, 0, len(fields))
 		for _, key := range fields {
@@ -1106,7 +1118,7 @@ func (db *DataStoreMongo) ListAllDevices(
 		findOpts.SetProjection(projection)
 	}
 
-	cur, err := collDevs.Find(ctx, bson.D{}, findOpts)
+	cur, err := collDevs.Find(ctx, filter, findOpts)
 	if err != nil {
 		return func(yield func(*model.Device, error) bool) {
 			yield(nil, err)

--- a/backend/services/deviceauth/store/mongo/datastore_mongo_test.go
+++ b/backend/services/deviceauth/store/mongo/datastore_mongo_test.go
@@ -2977,7 +2977,7 @@ func TestListAllDevices(t *testing.T) {
 	t.Run("ok/all attributes", func(t *testing.T) {
 		t.Parallel()
 		countByTenantID := map[string]int{}
-		for dev, err := range ds.ListAllDevices(ctx) {
+		for dev, err := range ds.ListAllDevices(ctx, nil, 100) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, dev.Id)
 			assert.NotEmpty(t, dev.IdData)
@@ -2997,7 +2997,7 @@ func TestListAllDevices(t *testing.T) {
 	t.Run("ok/selected attributes", func(t *testing.T) {
 		t.Parallel()
 		count := 0
-		for dev, err := range ds.ListAllDevices(ctx, dbFieldID, dbFieldStatus) {
+		for dev, err := range ds.ListAllDevices(ctx, nil, 100, dbFieldID, dbFieldStatus) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, dev.Id)
 			assert.NotEmpty(t, dev.Status)
@@ -3013,7 +3013,7 @@ func TestListAllDevices(t *testing.T) {
 		t.Parallel()
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		for _, err := range ds.ListAllDevices(cancelledCtx) {
+		for _, err := range ds.ListAllDevices(cancelledCtx, nil, 10) {
 			if assert.ErrorIs(t, err, context.Canceled) {
 				break
 			}

--- a/backend/services/deviceauth/store/mongo/datastore_mongo_test.go
+++ b/backend/services/deviceauth/store/mongo/datastore_mongo_test.go
@@ -2987,7 +2987,7 @@ func TestListAllDevices(t *testing.T) {
 	t.Run("ok/all attributes", func(t *testing.T) {
 		t.Parallel()
 		countByTenantID := map[string]int{}
-		for dev, err := range ds.ListAllDevices(ctx) {
+		for dev, err := range ds.ListAllDevices(ctx, nil, -1) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, dev.Id)
 			assert.NotEmpty(t, dev.IdData)
@@ -3007,7 +3007,7 @@ func TestListAllDevices(t *testing.T) {
 	t.Run("ok/selected attributes", func(t *testing.T) {
 		t.Parallel()
 		count := 0
-		for dev, err := range ds.ListAllDevices(ctx, dbFieldID, dbFieldStatus) {
+		for dev, err := range ds.ListAllDevices(ctx, nil, -1, dbFieldID, dbFieldStatus) {
 			assert.NoError(t, err)
 			assert.NotEmpty(t, dev.Id)
 			assert.NotEmpty(t, dev.Status)
@@ -3023,7 +3023,7 @@ func TestListAllDevices(t *testing.T) {
 		t.Parallel()
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		for _, err := range ds.ListAllDevices(cancelledCtx) {
+		for _, err := range ds.ListAllDevices(cancelledCtx, nil, -1) {
 			if assert.ErrorIs(t, err, context.Canceled) {
 				break
 			}


### PR DESCRIPTION
As the command runs over time, less and less devices are being processed as devices are polling while the sync is in progress. This fix resets the clock for every 1000 devices processed.

Ticket: MEN-9377