### PR TITLE
QA-1472: Relax e2e match criteria for `mender-demo-artifact` version

### DIFF
--- a/frontend/tests/e2e_tests/fixtures/fixtures.ts
+++ b/frontend/tests/e2e_tests/fixtures/fixtures.ts
@@ -18,17 +18,11 @@ import { test as nonCoveredTest } from '@playwright/test';
 import { getPeristentLoginInfo } from '../utils/commands.ts';
 import { timeouts } from '../utils/constants.ts';
 
-type DemoArtifactVersionInfo = {
-  artifactVersion: string;
-  updateVersion: string;
-};
-
 export type TestEnvironment = 'enterprise' | 'staging' | 'os';
 
 type TestFixtures = {
   baseUrl: string;
   config: unknown;
-  demoArtifactVersion: DemoArtifactVersionInfo;
   demoDeviceName: string;
   environment: TestEnvironment;
   page: Page;
@@ -88,7 +82,6 @@ const test = (process.env.TEST_ENVIRONMENT === 'staging' ? nonCoveredTest : cove
     await use(baseUrl);
   },
   demoDeviceName: defaultConfig.demoDeviceName,
-  demoArtifactVersion: { artifactVersion: '3.8.3', updateVersion: '5.0.3' }
 });
 
 export { expect };

--- a/frontend/tests/e2e_tests/integration/02-baseline/01-releases.spec.ts
+++ b/frontend/tests/e2e_tests/integration/02-baseline/01-releases.spec.ts
@@ -68,7 +68,7 @@ test.describe('Files', () => {
 
   test.describe('downloads', () => {
     test.describe.configure({ retries: 2 });
-    test('allows artifact downloads', async ({ demoArtifactVersion, page, request }) => {
+    test('allows artifact downloads', async ({ page, request }) => {
       await page.getByText(/mender-demo-artifact/i).click();
       await page.click('.expandButton');
       const downloadButton = await page.getByText(/download artifact/i);
@@ -92,10 +92,8 @@ test.describe('Files', () => {
       // Parse artifact header to check that artifact name matches
       const artifactName = artifactInfo['Mender Artifact'].Name;
       expect(artifactName).toMatch(/^mender-demo-artifact/);
-      const versionInfo = artifactName.substring(artifactName.indexOf(expectedArtifactName) + expectedArtifactName.length + 1);
-      expect(versionInfo).toEqual(demoArtifactVersion.artifactVersion);
       const { 'data-partition.mender-demo-artifact.version': updateVersion } = artifactInfo.Updates[0].Provides;
-      expect(updateVersion).toEqual(demoArtifactVersion.updateVersion);
+      expect(updateVersion).toEqual(artifactName);
     });
   });
 


### PR DESCRIPTION
With upcoming changes from the demo artifact, we will not anymore have a predictable version but it is generated on each build and publish.

This commit just expects the artifact name to be `mender-demo-artifact-<something>` and verify that the same version is also provided as `data-partition.mender-demo-artifact.version`.

See:
* https://github.com/mendersoftware/mender-demo-artifact/pull/369