### PR TITLE
ci: add qa-common retry and runner defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,6 +90,10 @@ variables:
     value: "302.Release-information/03.Open-source-licenses/01.Mender-Server/docs.md"
 
 include:
+  - project: Northern.tech/Mender/mendertesting
+    file:
+      - qa-common/runner.yml
+      - qa-common/retry.yml
   - component: "gitlab.com/Northern.tech/Mender/mendertesting/commit-lint@master"
   - project: "Northern.tech/Mender/mendertesting"
     file:
@@ -113,13 +117,8 @@ stages:
   - deploy-staging
 
 default:
-  tags:
-    - k8s-small
-  retry:
-    max: 2
-    when:
-      - runner_system_failure
-      - stuck_or_timeout_failure
+  tags: !reference [.qa-common-default-runner, tags]
+  retry: !reference [.qa-common-default-retry, retry]
 
 .requires-docker: &requires-docker
   - DOCKER_RETRY_SLEEP_S=10 # wait longer for k8s workers
@@ -646,6 +645,7 @@ publish:backend:licenses:
   variables:
     GOFLAGS: -tags=nopkcs11
   before_script:
+    - !reference [.qa-common-network-go-retry, before_script]
     - go install github.com/google/go-licenses@v1.6.0
   script:
     - cd backend
@@ -676,6 +676,7 @@ publish:licenses:docs-site:
     - job: publish:frontend:licenses
       artifacts: true
   before_script:
+    - !reference [.qa-common-network-git-clone-retry, before_script]
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
     - git config --global user.name "${GITHUB_USER_NAME}"
@@ -821,6 +822,7 @@ release:mender-docs-changelog:
     - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
       allow_failure: true
   before_script:
+    - !reference [.qa-common-network-git-clone-retry, before_script]
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
     - git config --global user.name "${GITHUB_USER_NAME}"
@@ -852,6 +854,7 @@ release:mender-docs-changelog:saas:
     - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
       when: never
   before_script:
+    - !reference [.qa-common-network-git-clone-retry, before_script]
     # Setting up git
     - git config --global user.email "${GITHUB_USER_EMAIL}"
     - git config --global user.name "${GITHUB_USER_NAME}"
@@ -882,6 +885,7 @@ release:mender-docs-changelog:saas:
   variables:
     HELM_PATCH_VERSION: ${CI_PIPELINE_ID}
   before_script:
+    - !reference [.qa-common-network-git-clone-retry, before_script]
     - git config --global user.email "${GITHUB_USER_EMAIL}"
     - git config --global user.name "${GITHUB_USER_NAME}"
     - export DIGESTS_FOLDER=$(pwd)/.digests

--- a/.gitlab/merge-enterprise.yml
+++ b/.gitlab/merge-enterprise.yml
@@ -16,6 +16,7 @@ merge-to-enterprise:
     GITHUB_REPOSITORY_ENTERPRISE: "mendersoftware/mender-server-enterprise"
     GITHUB_REPOSITORY_OPEN_SOURCE: "mendersoftware/mender-server"
   before_script:
+    - !reference [.qa-common-network-git-clone-retry, before_script]
     - GIT_REMOTE="https://mender-test-bot:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/$GITHUB_REPOSITORY_ENTERPRISE"
     - GITHUB_ORG="${GITHUB_REPOSITORY_ENTERPRISE%%/*}"
     - PR_BRANCH="${GITHUB_REPOSITORY_OPEN_SOURCE##*/}/$CI_COMMIT_BRANCH"

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -32,6 +32,7 @@ test:frontend:license-headers:
         compare_to: '${RULES_CHANGES_COMPARE_TO_REF}'
   needs: []
   before_script:
+    - !reference [.qa-common-network-apt-retry, before_script]
     - apt update && apt install git -yq
   script:
     - deno task --cwd frontend/scripts licenseCheck --rootDir $(pwd)
@@ -51,6 +52,7 @@ test:frontend:licenses:
     - job: build:frontend:docker
       artifacts: true
   before_script:
+    - !reference [.qa-common-network-apt-retry, before_script]
     - cd frontend
     - apt-get update && apt-get install -yq curl
     - curl -fsSL https://deb.nodesource.com/setup_24.x | bash


### PR DESCRIPTION
Include qa-common/runner.yml and qa-common/retry.yml from mendertesting to apply a consistent .qa-common-default-runner tag and .qa-common-default-retry policy to all jobs pipeline-wide.

Add network probes (apt/go/git-clone) to jobs that perform network operations, so transient failures trigger a retry instead of a hard fail.

Ticket: QA-1490