### PR TITLE
chore: Remove mongo flag `--nojournal`

### DIFF
--- a/backend/pkg/mongo/dbtest/db.go
+++ b/backend/pkg/mongo/dbtest/db.go
@@ -116,7 +116,6 @@ func (dbs *DBServer) start() {
 		"--dbpath", dbs.dbpath,
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
-		"--nojournal",
 	}
 	dbs.tomb = tomb.Tomb{}
 	dbs.server = exec.Command("mongod", args...)

--- a/backend/pkg/mongo/v2/dbtest/db.go
+++ b/backend/pkg/mongo/v2/dbtest/db.go
@@ -115,7 +115,6 @@ func (dbs *DBServer) start() {
 		"--dbpath", dbs.dbpath,
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
-		"--nojournal",
 	}
 	dbs.tomb = tomb.Tomb{}
 	dbs.server = exec.Command("mongod", args...)

--- a/backend/services/deviceconfig/store/mongo/main_test.go
+++ b/backend/services/deviceconfig/store/mongo/main_test.go
@@ -124,7 +124,6 @@ func NewMongoTestInstance(path string) *MongoTestInstance {
 		"--dbpath", path,
 		"--bind_ip", "127.0.0.1",
 		"--port", strconv.Itoa(addr.Port),
-		"--nojournal",
 	}
 	var stdout, stderr bytes.Buffer
 	db.Process = exec.Command("mongod", args...)


### PR DESCRIPTION
The flag was removed in MongoDB 6.1 https://www.mongodb.com/docs/manual/release-notes/7.0-compatibility/