### PR TITLE
ci: fix pipeline execution

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,19 +180,7 @@ default:
 
 build:backend:docker:
   extends: .template:build:docker
-  rules:
-    - changes:
-        paths:
-          - "backend/**/*"
-          - ".gitlab-ci.yml"
-          - "docker-compose.yml"
-          - "compose/docker-compose.enterprise.yml"
-        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-      when: always
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: always
-    - if: '$CI_COMMIT_REF_PROTECTED != "true" && $CI_PIPELINE_SOURCE == "push"'
-      when: always
+  # no rules as the job have to build every time for the review jobs
   script:
     # FIXME: Only exporting deployments build stage to run unit tests
     #        We're assuming the images have consistent GOTOOLCHAIN.

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -142,15 +142,7 @@ test:frontend:docs-links:hosted:
 
 build:frontend:docker:
   extends: .template:build:docker
-  rules:
-    - changes:
-        paths: ['frontend/**/*', 'compose/**/*', 'docker-compose.yml']
-        compare_to: '${RULES_CHANGES_COMPARE_TO_REF}'
-      when: always
-    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
-      when: always
-    - if: '$CI_COMMIT_REF_PROTECTED != "true" && $CI_PIPELINE_SOURCE == "push"'
-      when: always
+  # no rules as the job have to build every time for the review jobs
   script:
     - cd frontend
     - if test -z "${DOCKER_PLATFORM}"; then


### PR DESCRIPTION
When no changes are present to trigger the build:frontend and build:backend, the pipeline cannot be executed because they builds are needed for the review:deploy job