### PR TITLE
Fix "cli processor" unit tests on MacOS

### DIFF
--- a/backend/services/workflows/app/processor/cli_test.go
+++ b/backend/services/workflows/app/processor/cli_test.go
@@ -17,6 +17,7 @@ package processor
 import (
 	"context"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,11 +29,23 @@ import (
 )
 
 var (
-	executorMock = executor.New([]string{
-		"/usr/bin/echo",
-		"/usr/bin/bash",
-	})
+	echo         string
+	bash         string
+	executorMock executor.BinaryExecutor
 )
+
+func init() {
+	switch os.Getenv("GOOS") {
+	case "darwin":
+		// The `echo` and `bash` binaries are located in `/bin` on MacOS
+		echo = "/bin/echo"
+		bash = "/bin/bash"
+	default:
+		echo = "/usr/bin/echo"
+		bash = "/usr/bin/bash"
+	}
+	executorMock = executor.New([]string{echo, bash})
+}
 
 func TestProcessJobCLI(t *testing.T) {
 	ctx := context.Background()
@@ -47,7 +60,7 @@ func TestProcessJobCLI(t *testing.T) {
 				Type: model.TaskTypeCLI,
 				CLI: &model.CLITask{
 					Command: []string{
-						"/usr/bin/echo",
+						echo,
 						"TEST",
 					},
 				},
@@ -123,7 +136,7 @@ func TestProcessJobCLIWrongExitCode(t *testing.T) {
 				Type: model.TaskTypeCLI,
 				CLI: &model.CLITask{
 					Command: []string{
-						"/usr/bin/bash",
+						bash,
 						"-c",
 						"exit 10",
 					},
@@ -214,7 +227,7 @@ func TestProcessJobCLTimeOut(t *testing.T) {
 				Type: model.TaskTypeCLI,
 				CLI: &model.CLITask{
 					Command: []string{
-						"/usr/bin/bash",
+						bash,
 						"-c",
 						"sleep 10",
 					},


### PR DESCRIPTION
**Description**
In https://github.com/mendersoftware/mender-server-enterprise/pull/942 these [tests were changed](https://github.com/mendersoftware/mender-server-enterprise/commit/3012e6a16b8dc7da50a16ce1c87b0da4191231ca#diff-1d94f41c0c7aa1313a5df9522178695d98a09357b5de8313d47d43d00b4926f1) to use absolute paths to binaries which are incompatible with MacOS. This makes it impossible for the unit tests to succeed on a Mac system. It's also impossible (or at least strongly discouraged) to work around this on the Mac system as `/usr/bin` is in an Apple SSV (signed system volume) and therefore cannot be modified.

I modified the tests instead to use different absolute path's on MacOS instead. However, I'm not sure I see the need for absolute binary paths in tests (or indeed why we're not mocking the cli executor entirely?). 

Ticket: None