### PR TITLE
test: Fix two imports in backend/tests/testutils/api/ modules

### DIFF
--- a/backend/tests/testutils/api/client.py
+++ b/backend/tests/testutils/api/client.py
@@ -23,7 +23,7 @@ import time
 
 from urllib3.exceptions import InsecureRequestWarning
 
-from testutils.infra.container_manager.kubernetes_manager import isK8S
+from ..infra.container_manager.kubernetes_manager import isK8S
 
 GATEWAY_HOSTNAME = os.environ.get("GATEWAY_HOSTNAME") or "traefik"
 

--- a/backend/tests/testutils/api/deviceauth.py
+++ b/backend/tests/testutils/api/deviceauth.py
@@ -14,7 +14,7 @@
 import json
 from typing import Dict, Tuple
 
-import testutils.util.crypto
+from ..util import crypto
 
 HOST = "mender-deviceauth:8080"
 
@@ -53,5 +53,5 @@ def auth_req(id_data, pubkey, privkey, tenant_token="") -> Tuple[Dict, Dict]:
         "tenant_token": tenant_token,
         "pubkey": pubkey,
     }
-    signature = testutils.util.crypto.auth_req_sign(json.dumps(payload), privkey)
+    signature = crypto.auth_req_sign(json.dumps(payload), privkey)
     return payload, {"X-MEN-Signature": signature}


### PR DESCRIPTION
`testutils` is not a Python package/module in PYTHONPATH unless
running in a specific working directory. To make imports from it
work in projects using the testutils modules from a different
place, a relative import needs to be used.

Ticket: none
Signed-off-by: Vratislav Podzimek <vratislav.podzimek+auto-signed@northern.tech>