### PR TITLE
test: restored artifact downloads to use backend retrieved location instead of set href

### DIFF
--- a/frontend/tests/e2e_tests/integration/02-baseline/01-releases.spec.ts
+++ b/frontend/tests/e2e_tests/integration/02-baseline/01-releases.spec.ts
@@ -73,13 +73,14 @@ test.describe('Files', () => {
       await page.click('.expandButton');
       const downloadButton = page.getByText(/download artifact/i);
       await expect(downloadButton).toBeVisible();
-      const href = await downloadButton.getAttribute('href');
-      expect(href).toBeTruthy();
-      const suggestedFilename = (await downloadButton.getAttribute('download')) || fileName;
-      const response = await request.get(href);
-      expect(response.ok()).toBeTruthy();
-      const downloadTargetPath = `./${suggestedFilename}`;
-      fs.writeFileSync(downloadTargetPath, await response.body());
+      const downloadPromise = page.waitForEvent('download');
+      await downloadButton.click();
+      const download = await downloadPromise;
+      const downloadUrl = download.url();
+      const response = await request.get(downloadUrl);
+      const fileData = await response.body();
+      const downloadTargetPath = `./${download.suggestedFilename()}`;
+      fs.writeFileSync(downloadTargetPath, fileData);
       const stdout = execSync(`mender-artifact read --no-progress ${downloadTargetPath}`);
       const artifactInfo = parse(stdout.toString());
       // Parse artifact header to check that artifact name matches


### PR DESCRIPTION
https://gitlab.com/Northern.tech/Mender/mender-server/-/pipelines/2376770703 staging + os job success