### PR TITLE
MEN-9456: Added `artifact_too_big` to deployment report states

### DIFF
--- a/frontend/src/js/components/deployments/deployment-report/DeviceList.tsx
+++ b/frontend/src/js/components/deployments/deployment-report/DeviceList.tsx
@@ -73,6 +73,7 @@ const stateInfoMap: Record<string, StateInfoEntry> = {
   aborted: { title: 'Paused before committing', progress: 100, color: statusColorMap.aborted, icon: CancelIcon },
   failure: { title: 'Fail', progress: 100, color: statusColorMap.error, icon: ErrorIcon },
   noartifact: { title: 'No compatible artifact found', progress: 0, icon: CancelIcon },
+  artifact_too_big: { title: 'Skipped', progress: 0, icon: CancelIcon },
   success: { title: 'Success', progress: 100, color: statusColorMap.success, icon: CheckIcon }
 };
 


### PR DESCRIPTION
**Description**
Pretty much what it says in the title again. We need to handle this device deployment status. According to the UX the name should be "Skipped" 🤷 

Ticket: MEN-9456