### PR TITLE
test: let slow loading editor only be focused after it is initialized to ease metadata entry

### DIFF
--- a/frontend/tests/e2e_tests/integration/02-baseline/03-saml.spec.ts
+++ b/frontend/tests/e2e_tests/integration/02-baseline/03-saml.spec.ts
@@ -59,9 +59,9 @@ test.describe('SAML Login via sso/id/login', () => {
       await page.getByText('input with the text editor').click();
 
       const cleanedMetaData = metadata.replace(/(?:\r\n|\r|\n)/g, '');
-      await page.getByTestId('monaco-editor').click();
       const editorLoadingIndicator = page.locator('.loaderContainer');
       await expect(editorLoadingIndicator).not.toBeVisible();
+      await page.getByTestId('monaco-editor').click();
       await page.keyboard.insertText(cleanedMetaData);
       console.log('typing metadata done.');
       // The screenshot saves the view of the typed metadata


### PR DESCRIPTION
passing enterprise job is here: https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13468524371 - although based on the trace files I'm not 100% sure if this is the actual issue, I'm quite certain that it at least will improve the likelihood of success for the test