### PR TITLE
🍒 4.0.x - chore: Revert Use Virtual Device for OS updates in docker composition"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -389,12 +389,25 @@ services:
         aliases: [mender-nats]
 
   client:
-    image: mendersoftware/mender-client-qemu:mender-master
+    image: mendersoftware/mender-client-docker-addons:mender-master
     scale: 0
-    privileged: true
-    environment:
-      SERVER_URL: "${SERVER_URL:-https://docker.mender.io}"
-      TENANT_TOKEN: "${TENANT_TOKEN:-}"
+    configs:
+      - source: client_json
+        target: /etc/mender/mender.conf
+    volumes:
+      - ./compose/certs/mender.crt:/var/lib/mender/mender.crt
+
+configs:
+  client_json:
+    content: |
+      {
+        "InventoryPollIntervalSeconds": 5,
+        "RetryPollIntervalSeconds": 5,
+        "ServerURL": "${SERVER_URL:-https://docker.mender.io}",
+        "ServerCertificate": "/var/lib/mender/mender.crt",
+        "UpdatePollIntervalSeconds": 5,
+        "TenantToken": "${TENANT_TOKEN:-}"
+      }
 
 volumes:
   mongo: {}

--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -55,7 +55,6 @@ services:
 
   client:
     scale: 1
-    image: mendersoftware/mender-client-docker-addons:mender-master
     configs:
       - source: client_json
         target: /etc/mender/mender.conf


### PR DESCRIPTION
This reverts commit 9142d7aab449c043000d65b77cd66390d8ace461.

Once that we have branch out 4.0.x with the old Virtual Device, we can bring back the Virtual Device for Application Updates to `main` \o/

Ticket: MEN-7789