### PR TITLE
🍒 4.0.x - ci: enabled wider tracing in e2e tests

### DIFF
--- a/frontend/tests/e2e_tests/playwright.config.ts
+++ b/frontend/tests/e2e_tests/playwright.config.ts
@@ -69,6 +69,7 @@ const options: PlaywrightTestConfig = {
     ...contextArgs,
     contextOptions: contextArgs,
     screenshot: 'only-on-failure',
+    trace: 'on',
     video: 'retain-on-failure',
     // headless: false,
     launchOptions


### PR DESCRIPTION
mainly to debug the e2e failures seen in the enterprise repo (e.g. https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/13488588621) and since I can't reproduce this locally, nor see a reason why this would happen in the first place 😬