### PR TITLE
fix: deserialization of Setting preventing use of AI summary

### DIFF
--- a/backend/services/useradm/model/settings.go
+++ b/backend/services/useradm/model/settings.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -63,8 +64,10 @@ func (s Settings) MarshalBSON() ([]byte, error) {
 }
 
 func (s *Settings) UnmarshalBSON(b []byte) error {
-	value := map[string]interface{}{}
-	err := bson.Unmarshal(b, &value)
+	value := map[string]any{}
+	decoder := bson.NewDecoder(bson.NewDocumentReader(bytes.NewReader(b)))
+	decoder.DefaultDocumentMap()
+	err := decoder.Decode(&value)
 	if val, ok := value[settingsID]; ok {
 		if valString, ok := val.(string); ok {
 			s.ID = valString

--- a/backend/services/useradm/model/settings_test.go
+++ b/backend/services/useradm/model/settings_test.go
@@ -91,6 +91,9 @@ func TestSettingsMarshalBSON(t *testing.T) {
 		Values: map[string]interface{}{
 			"key":       "value",
 			"tenant_id": "this is reserved",
+			"complex": map[string]any{
+				"nested": "setting",
+			},
 		},
 	}
 
@@ -106,6 +109,9 @@ func TestSettingsMarshalBSON(t *testing.T) {
 		ETag: "etag",
 		Values: map[string]interface{}{
 			"key": "value",
+			"complex": map[string]any{
+				"nested": "setting",
+			},
 		},
 	}
 	assert.Equal(t, expected, unmarshalled)


### PR DESCRIPTION
A change in the default deserialization of bson document in the mongo v2 driver blocks the consent check to use AI feature.