### PR TITLE
ci: parallel docker builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,10 +186,10 @@ build:backend:docker:
     #        We're assuming the images have consistent GOTOOLCHAIN.
     #        Will be fixed once we optimize to template based pipeline.
     - |-
-      make -C backend/services/deployments docker \
+      make -j$(nproc) -C backend/services/deployments docker \
         DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
         MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
-    - make -C backend docker
+    - make -j$(nproc) -C backend docker
 
 build:backend:docker-acceptance:
   extends: build:backend:docker
@@ -201,7 +201,7 @@ build:backend:docker-acceptance:
     - unset DOCKER_PLATFORM
   script:
     # NOTE: Only build for test platform (default) for the acceptance test images
-    - make -C backend docker-acceptance
+    - make -j$(nproc) -C backend docker-acceptance
 
 #
 # Review Apps


### PR DESCRIPTION
To improve build time. Note: the result won't change with a 32vcpu build machine, so let's keep the default k8s tag which is 8vcpu runner.

Ticket: QA-1545

Reference:
* build:backend:docker:
  * [main](https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13703761466): 4 minutes 39 seconds
  * [this pr](https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13704191393): 2 minutes 16 seconds
* build:backend:docker-acceptance:
  * [main](https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13703761469): 3 minutes 33 seconds
  * [this pr](https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13704191394): 3 minutes 25 seconds 
