### PR TITLE
ci: os/ent prefix to pr based deployment to avoid name collision

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,20 +224,18 @@ review:deploy:
       aud: https://gitlab.com
   environment:
     name: review/${CI_COMMIT_REF_NAME}
-    url: https://${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}
+    url: https://${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}
     on_stop: review:stop
     auto_stop_in: 7 days
   variables:
-    NAMESPACE: mender-${CI_COMMIT_REF_SLUG}
+    NAMESPACE: mender-${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}
   before_script:
     - echo "Deploying review app for branch ${CI_COMMIT_REF_NAME}"
-
-    # Generate short identifier to avoid Kubernetes 52 character name limit
-    # Use first 12 characters of branch slug hash for uniqueness
-    - export RELEASE_NAME="mender-$(echo -n ${CI_COMMIT_REF_SLUG} | md5sum | cut -c1-12)"
+    - test -n "${REVIEW_APPS_PROJECT_PREFIX}" || (echo "REVIEW_APPS_PROJECT_PREFIX is not set"; exit 1)
+    - export RELEASE_NAME="mender-$(echo -n "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}" | md5sum | cut -c1-12)"
     - echo "Release name - ${RELEASE_NAME}"
     - echo "Namespace - ${NAMESPACE}"
-    - echo "URL - https://${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+    - echo "URL - https://${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
   script:
     - echo "Authenticating to AWS using OIDC..."
     - export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"
@@ -283,7 +281,7 @@ review:deploy:
     - ./compose/k8s/create-initial-user.sh
 
     - echo "=== Deployment Information ==="
-    - echo "URL - https://${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+    - echo "URL - https://${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
     - echo "Namespace - ${NAMESPACE}"
     - echo ""
     - echo "Note - Login credentials were displayed above by the create-initial-user script"
@@ -295,13 +293,6 @@ review:deploy:
     - echo "=== Ingress ==="
     - kubectl get ingress -n ${NAMESPACE}
     - echo "Review app deployed successfully!"
-  artifacts:
-    reports:
-      dotenv: review-deploy.env
-    paths:
-      - review-deploy.env
-    expire_in: 1 week
-
 review:stop:
   stage: review
   image: registry.gitlab.com/northern.tech/mender/mender-test-containers:aws-k8s-v1-master
@@ -318,12 +309,12 @@ review:stop:
     name: review/${CI_COMMIT_REF_NAME}
     action: stop
   variables:
-    NAMESPACE: mender-${CI_COMMIT_REF_SLUG}
+    NAMESPACE: mender-${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}
     GIT_STRATEGY: none
   script:
-    # Generate same short identifier used during deploy
-    - export RELEASE_NAME="mender-$(echo -n ${CI_COMMIT_REF_SLUG} | md5sum | cut -c1-12)"
-    - echo "Cleaning up review app - ${RELEASE_NAME}"
+    - test -n "${REVIEW_APPS_PROJECT_PREFIX}" || (echo "REVIEW_APPS_PROJECT_PREFIX is not set"; exit 1)
+    - export RELEASE_NAME="mender-$(echo -n "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}" | md5sum | cut -c1-12)"
+    - echo "Cleaning up review app - ${RELEASE_NAME} in namespace ${NAMESPACE}"
 
     - echo "Authenticating to AWS using OIDC..."
     - export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"

--- a/compose/k8s/README.md
+++ b/compose/k8s/README.md
@@ -50,10 +50,18 @@ GitLab Push → CI Pipeline → Build Images → Deploy to EKS
 
 ### Namespace Strategy
 
-Each review app is deployed to an isolated namespace:
-- **Namespace Naming**: `mender-${CI_COMMIT_REF_SLUG}`
-- **Naming**: `mender-$(echo -n ${CI_COMMIT_REF_SLUG} | md5sum | cut -c1-12)`
-- **Example**: Branch `feature/new-auth` → Namespace `mender-feature-new-auth`
+Each review app is deployed to an isolated namespace. A short project prefix derived
+from `CI_PROJECT_NAME` ensures no collision between `mender-server` and
+`mender-server-enterprise` deployments that share the same PR number.
+
+| `CI_PROJECT_NAME` | Prefix |
+|---|---|
+| `mender-server` | `os` |
+| `mender-server-enterprise` | `ent` |
+
+- **Namespace**: `mender-<prefix>-${CI_COMMIT_REF_SLUG}` (e.g. `mender-os-pr-42`, `mender-ent-pr-42`)
+- **Helm release**: `mender-$(echo -n "<prefix>-${CI_COMMIT_REF_SLUG}" | md5sum | cut -c1-12)` (hashed to stay within the 52-char limit)
+- **URL**: `<prefix>-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}` (e.g. `os-pr-42.staging.hosted.mender.io`)
 - **Isolation**: Each namespace contains all services and dependencies
 - **Cleanup**: Namespace is deleted when branch is deleted or manually stopped
 
@@ -119,6 +127,9 @@ Add these variables to your GitLab project (Settings → CI/CD → Variables):
 | `REVIEW_APPS_REGISTRY_TOKEN` | Deploy token for Registry access (long-lived, doesn't expire with CI job) |
 | `REVIEW_APPS_REGISTRY_USERNAME` | Username for the Deploy token for Registry access |
 
+The project prefix (`os` / `ent`) is derived automatically from the predefined
+`CI_PROJECT_NAME` variable - no extra CI/CD variable is required.
+
 **Important**: We use GitLab deploy tokens instead of `CI_JOB_TOKEN` or `CI_REGISTRY_PASSWORD` because Karpenter may provision new nodes after the CI job completes. Deploy tokens are long-lived and allow those nodes to pull images successfully.
 
 ## Usage
@@ -145,7 +156,7 @@ Review apps are deployed automatically when you push to a non-protected branch: 
    - Check the job output for the review app URL
 
 4. **Access your review app**:
-   - URL: `https://feature-my-new-feature.staging.hosted.mender.io`
+   - URL: `https://os-pr-1234.staging.hosted.mender.io` (OS repo) or `https://ent-pr-1234.staging.hosted.mender.io` (enterprise repo)
    - The URL is also available in GitLab → Deployments → Environments
 
 ### Manual Stop

--- a/compose/k8s/review-values.yaml.tpl
+++ b/compose/k8s/review-values.yaml.tpl
@@ -6,7 +6,7 @@
 global:
   # Domain for this review app
   # Example: feature-auth.staging.hosted.mender.io
-  url: "https://${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+  url: "https://${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
 
   enterprise: false
 
@@ -112,9 +112,9 @@ ingress:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/ip-address-type: dualstack
   hosts:
-    - "${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+    - "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
   tls:
     - secretName: mender-review-ingress-tls
       hosts:
-        - "${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+        - "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
 


### PR DESCRIPTION
Avoid PR Based deployment name collision when the PR number is the same in both OS and ENT repos

Ticket: QA-1524