### PR TITLE
ci: remove ineffectual pipeline variable assignments

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -193,13 +193,6 @@ build:frontend:docker:
     - curl -fsSL https://get.docker.com | sh -s -- --version ${DOCKER_VERSION}
     - !reference [.requires-docker]
     - !reference [.dind-login]
-    # If branch is not protected, use upstream main
-    # Otherwise use the local pipeline reference.
-    - |
-      if test "$CI_COMMIT_REF_PROTECTED" != "true"; then
-        unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
-        export MENDER_IMAGE_TAG=main
-      fi
     - npm i --prefix frontend/tests/e2e_tests
   artifacts:
     expire_in: 2w
@@ -226,13 +219,6 @@ test:frontend:acceptance:enterprise:
     # This job can only run on protected branches
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
   script:
-    - unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
-    - |
-      if echo "$CI_COMMIT_REF_NAME" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9x]+$'; then
-        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/\.x$//')"
-      else
-        export MENDER_IMAGE_TAG=main
-      fi
     - docker login -u "$REGISTRY_MENDER_IO_USERNAME" -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io
     - npm run script --prefix frontend/tests/e2e_tests -- --environment enterprise
 
@@ -244,13 +230,6 @@ test:frontend:acceptance:enterprise:qemu:
     # This job can only run on protected branches
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
   script:
-    - unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
-    - |
-      if echo "$CI_COMMIT_REF_NAME" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9x]+$'; then
-        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/\.x$//')"
-      else
-        export MENDER_IMAGE_TAG=main
-      fi
     - docker login -u "$REGISTRY_MENDER_IO_USERNAME" -p "$REGISTRY_MENDER_IO_PASSWORD" registry.mender.io
     - npm run script --prefix frontend/tests/e2e_tests -- --environment enterprise --variant qemu
   retry:


### PR DESCRIPTION
`MENDER_IMAGE_GUI` is already expanded so redefining the tag and repository variables does not change it's value.