### PR TITLE
ci: let e2e tests rely on minor versions of ent images on release-tags + -branches

### DIFF
--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -222,7 +222,7 @@ test:frontend:acceptance:enterprise:
     - unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
     - |
       if echo "$CI_COMMIT_REF_NAME" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9x]+$'; then
-        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/\.x$//')"
+        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/^v//; s/\.[^.]*$//')"
       else
         export MENDER_IMAGE_TAG=main
       fi
@@ -240,7 +240,7 @@ test:frontend:acceptance:enterprise:qemu:
     - unset MENDER_IMAGE_REGISTRY MENDER_IMAGE_REPOSITORY
     - |
       if echo "$CI_COMMIT_REF_NAME" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9x]+$'; then
-        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/\.x$//')"
+        export MENDER_IMAGE_TAG="v$(echo "$CI_COMMIT_REF_NAME" | sed 's/^v//; s/\.[^.]*$//')"
       else
         export MENDER_IMAGE_TAG=main
       fi


### PR DESCRIPTION
- since these will be tagged on saas releases already, we can rely on their presence
- also before/ during the tag or release pipeline