### PR TITLE
test: accounted for slower time in test runner, where 60s might be just 45s

### DIFF
--- a/frontend/tests/e2e_tests/integration/09-potentially-destructive/01-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-potentially-destructive/01-settings.spec.ts
@@ -251,8 +251,9 @@ test.describe('Settings', () => {
 
       await page.getByText(/Your subscription has been successfully updated to Mender Professional/i).waitFor({ timeout: timeouts.fifteenSeconds });
 
-      // Wait for the 1m timeout for the post-upgrade dialog taking the user back to the login page.
-      await page.getByText(/Log in with/i).waitFor({ timeout: timeouts.sixtySeconds + timeouts.fiveSeconds });
+      // Wait for the 1m timeout for the post-upgrade dialog taking the user back to the login page
+      // + some extra buffer time to account for slower moving time in the test environment
+      await page.getByText(/Log in with/i).waitFor({ timeout: timeouts.sixtySeconds + 2 * timeouts.fifteenSeconds });
       await page.context().close();
     });
     test('allows higher device limits once upgraded', async ({ baseUrl, browser, password, request, username }) => {


### PR DESCRIPTION
for https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/13737079770 where despite the 60s + 5s wait for the log in page, the countdown on the dialog only came to 14s left... 😕 