### PR TITLE
test: gave test time to watch the time count down

### DIFF
--- a/frontend/tests/e2e_tests/integration/09-potentially-destructive/01-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/09-potentially-destructive/01-settings.spec.ts
@@ -224,6 +224,7 @@ test.describe('Settings', () => {
     });
 
     test('allows upgrading to Professional', async ({ baseUrl, browser, password, request, username }) => {
+      test.setTimeout(2 * timeouts.sixtySeconds);
       const page = await prepareNewPage({ baseUrl, browser, password, request, username });
       const wasUpgraded = await page.isVisible(`css=#limit >> text=350`);
       test.skip(wasUpgraded, 'looks like the account was upgraded already, continue with the remaining tests');


### PR DESCRIPTION
it was not the 🃏 playwright after all - it was the 🤡 that didn't read the trace file right