### PR TITLE
Backend integration sharding

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,6 +232,29 @@ build:backend:docker-acceptance:
     # NOTE: Only build for test platform (default) for the acceptance test images
     - make -j$(nproc) -C backend docker-acceptance
 
+build:backend:docker-integration-tester:
+  extends: .template:build:docker
+  before_script:
+    - *requires-docker
+    - apk add make bash git
+    - *dind-login
+    - unset DOCKER_PLATFORM
+  script:
+    - docker build ${DOCKER_BUILDARGS}
+        --cache-from ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
+        -t ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
+        -f backend/tests/Dockerfile.integration
+        backend/tests
+  rules:
+    - changes:
+        paths:
+          - backend/tests/Dockerfile.integration
+          - backend/tests/requirements-integration.txt
+        compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
+      when: on_success
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+
 #
 # Review Apps
 #
@@ -513,6 +536,9 @@ test:backend:acceptance:
       artifacts: false
     - job: build:backend:docker-acceptance
       artifacts: false
+    - job: build:backend:docker-integration-tester
+      artifacts: false
+      optional: true
   before_script:
     - *requires-docker
     - apk add make bash git
@@ -565,6 +591,7 @@ test:backend:integration:
   extends: .template:test:backend:integration
   variables:
     MANTRA_PROJECT_NAME: "backend_integration_open_source"
+  parallel: 2
   script:
     - mkdir -p ${GOCOVERDIR}/integration
     - make -C backend test-integration

--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -47,4 +47,6 @@ ENV GOPATH=/go
 ENV PATH=$PATH:$GOPATH/bin
 RUN go version
 
+LABEL last_refreshed="2026-03-30"
+
 ENTRYPOINT ["python3", "-m", "pytest"]

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -57,8 +57,6 @@ services:
         - go_build_cache:/root/.cache/go-build
         - go_tmp_cache:/tmp
         - /var/run/docker.sock:/var/run/docker.sock
-    command:
-      - integration
     environment:
         GOMODCACHE: /go/pkg/mod
         PYTHONPATH: "/tests"

--- a/backend/tests/pyproject.toml
+++ b/backend/tests/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
 junit_family = "xunit1"
 minversion = "6.0"
-markers = ["storage_test: marks tests that uses artifact storage"]
+markers = ["storage_test: marks tests that uses artifact storage", "slow: marks tests as slow running"]
 testpaths = ["integration"]

--- a/backend/tests/requirements-integration.txt
+++ b/backend/tests/requirements-integration.txt
@@ -3,7 +3,6 @@ azure-iot-hub-api==0.2.2
 boto3==1.42.81
 certifi==2026.2.25
 cffi==2.0.0
-chardet==6.0.0.post1
 cryptography==46.0.6
 docker==7.1.0
 execnet==2.1.2

--- a/backend/tests/run-integration.bash
+++ b/backend/tests/run-integration.bash
@@ -27,7 +27,7 @@ COMPOSE_FILES=""
 COMPOSE_UP_EXTRA_ARGS="--remove-orphans"
 
 compose_cmd() {
-    $docker_compose_cmd -p backend-tests $COMPOSE_FILES $@
+    $docker_compose_cmd -p backend-tests $COMPOSE_FILES "$@"
 }
 
 PYTEST_FILTER_OPEN="not Enterprise and not Multitenant"
@@ -136,7 +136,24 @@ run_tests() {
         RUN_ARGS="${RUN_ARGS} -e AZURE_IOTHUB_CONNECTIONSTRING=${AZURE_IOTHUB_CONNECTIONSTRING}"
     fi
     # ... then the runner
-    compose_cmd run $RUN_ARGS integration-tester
+    if [ "${CI_NODE_TOTAL:-1}" -gt 1 ]; then
+        compose_cmd run $RUN_ARGS \
+            -e CI_NODE_INDEX -e CI_NODE_TOTAL \
+            --entrypoint /bin/bash \
+            integration-tester -c '
+                echo "shard $CI_NODE_INDEX/$CI_NODE_TOTAL" >&2
+                pytest --co -q -m "not slow" -k "not Enterprise and not Multitenant" 2>/tmp/co_err.txt | grep "::" | split -n "l/${CI_NODE_INDEX}/${CI_NODE_TOTAL}" > /tmp/nodes
+                echo "not-slow collected: $(wc -l < /tmp/nodes), co_err: $(wc -l < /tmp/co_err.txt)" >&2
+                pytest --co -q -m "slow" -k "not Enterprise and not Multitenant" 2>>/tmp/co_err.txt | grep "::" | split -n "l/${CI_NODE_INDEX}/${CI_NODE_TOTAL}" >> /tmp/nodes
+                sort -u /tmp/nodes > /tmp/nodes.final
+                echo "total nodes: $(wc -l < /tmp/nodes.final)" >&2
+                if [ -s /tmp/co_err.txt ]; then echo "collection stderr:" >&2; cat /tmp/co_err.txt >&2; fi
+                [ -s /tmp/nodes.final ] || { echo "No tests for this shard"; exit 0; }
+                mapfile -t nodes < /tmp/nodes.final && exec python3 -m pytest "${nodes[@]}"
+            '
+    else
+        compose_cmd run $RUN_ARGS integration-tester
+    fi
     return $?
 }
 


### PR DESCRIPTION
Split the test:backend:integration into multiple parallel jobs (2 for OS repo).

Also adding the build:backend:docker-integration-tester: job to build the base image integration_v3 which is referenced but never used in CICD, only fallen back to full container build

Ticket: QA-1545

Ent reference: https://github.com/mendersoftware/mender-server-enterprise/pull/1106

Co-authored-with: Claude