### PR TITLE
fix(gui): ensured device id selection dialog closes when saving the setting

### DIFF
--- a/frontend/src/js/components/devices/DeviceGroups.tsx
+++ b/frontend/src/js/components/devices/DeviceGroups.tsx
@@ -245,10 +245,7 @@ export const DeviceGroups = () => {
     return request.catch(console.log);
   };
 
-  const openSettingsDialog = e => {
-    e.preventDefault();
-    setOpenIdDialog(toggle);
-  };
+  const openSettingsDialog = () => setOpenIdDialog(toggle);
 
   const onCreateGroupClose = () => {
     setModifyGroupDialog(false);


### PR DESCRIPTION
regression after the split into global settings setting + device list dialog 😬 