### PR TITLE
fix(gui): refresh the configuration device details on finished deployment

### DIFF
--- a/frontend/src/js/components/devices/device-details/Configuration.test.tsx
+++ b/frontend/src/js/components/devices/device-details/Configuration.test.tsx
@@ -144,6 +144,7 @@ describe('Configuration Component', () => {
     await user.click(screen.getByRole('button', { name: /save/i }));
     await waitFor(() => expect(screen.queryByText(/Updating configuration/i)).toBeInTheDocument());
     await act(async () => vi.runOnlyPendingTimers());
-    expect(await screen.findByText(/Configuration up-to-date on the device/i)).toBeInTheDocument();
+    const successNote = await screen.findByText(/Configuration up-to-date on the device/i, {}, { timeout: 2000 });
+    expect(successNote).toBeInTheDocument();
   });
 });

--- a/frontend/src/js/components/devices/device-details/Configuration.tsx
+++ b/frontend/src/js/components/devices/device-details/Configuration.tsx
@@ -57,6 +57,8 @@ const textStyle = { textTransform: 'capitalize', textAlign: 'left' };
 
 const defaultReportTimeStamp = '0001-01-01T00:00:00Z';
 
+const maxDeploymentsChecks = 128;
+
 const configHelpTipsMap = {
   'mender-demo-raspberrypi-led': {
     position: 'right',
@@ -160,8 +162,10 @@ export const DeviceConfiguration = ({ defaultConfig = {}, device: { id: deviceId
   const [showLog, setShowLog] = useState(false);
   const [updateFailed, setUpdateFailed] = useState();
   const [updateLog, setUpdateLog] = useState();
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const dispatch = useDispatch();
-  const deploymentTimer = useRef();
+  const deploymentTimer = useRef(null);
+  const deploymentCheckCount = useRef(0);
 
   useEffect(() => {
     if (!isEmpty(config) && !isEmpty(changedConfig) && !isEditingConfig) {
@@ -174,26 +178,39 @@ export const DeviceConfiguration = ({ defaultConfig = {}, device: { id: deviceId
     if (deployment.devices && deployment.devices[device.id]?.log) {
       setUpdateLog(deployment.devices[device.id].log);
     }
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(deployment.devices), device.id]);
 
   useEffect(() => {
-    clearInterval(deploymentTimer.current);
-    if (isRelevantDeployment && deployment.status !== DEPLOYMENT_STATES.finished) {
-      deploymentTimer.current = setInterval(() => dispatch(getSingleDeployment(deployment_id)), TIMEOUTS.refreshDefault);
-    } else if (deployment_id && !isRelevantDeployment) {
-      dispatch(getSingleDeployment(deployment_id));
-    }
-    return () => {
-      clearInterval(deploymentTimer.current);
-    };
-  }, [deployment.status, deployment_id, dispatch, isRelevantDeployment]);
-
-  useEffect(() => {
-    if (!isRelevantDeployment) {
+    if (!deployment_id || isRefreshing) {
       return;
     }
+    deploymentCheckCount.current = 0;
+    deploymentTimer.current = setInterval(() => {
+      if (deploymentCheckCount.current > maxDeploymentsChecks) {
+        clearInterval(deploymentTimer.current);
+        setIsRefreshing(false);
+        return;
+      }
+      setIsRefreshing(true);
+      deploymentCheckCount.current++;
+      dispatch(getSingleDeployment(deployment_id));
+    }, TIMEOUTS.refreshDefault);
+    dispatch(getSingleDeployment(deployment_id));
+    return () => {
+      clearInterval(deploymentTimer.current);
+      setIsRefreshing(false);
+    };
+  }, [deployment_id, isRefreshing]);
+
+  useEffect(() => {
+    if (deployment.status === DEPLOYMENT_STATES.finished) {
+      clearInterval(deploymentTimer.current);
+      setIsRefreshing(false);
+    }
+  }, [deployment.status]);
+
+  useEffect(() => {
     if (deployment.status === DEPLOYMENT_STATES.finished) {
       // we have to rely on the device stats here as the state change might not have propagated to the deployment status
       // leaving all stats at 0 and giving a false impression of deployment success
@@ -215,9 +232,6 @@ export const DeviceConfiguration = ({ defaultConfig = {}, device: { id: deviceId
   }, [JSON.stringify(configured), JSON.stringify(deployment.stats), deployment.created, deployment.status, deployment.finished, isRelevantDeployment]);
 
   useEffect(() => {
-    if (!isRelevantDeployment) {
-      return;
-    }
     if (!changedConfig && !isEmpty(config) && (!deployment_id || deployment.status)) {
       // let currentConfig = reported;
       const stats = groupDeploymentStats(deployment);


### PR DESCRIPTION
fix(gui): refresh the configuration device details on finished deployment

Introduces:

* a maximum number of iterations for which deployments are queried
* a modified logic for the interval in the `DeviceConfiguration` component

Changelog: Title
Ticket: MEN-6415
Signed-off-by: Peter Grzybowski <peter@northern.tech>