### PR TITLE
4.1.x - ci: ensured commit links in changelog can point to the correct repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -788,7 +788,7 @@ release:mender-docs-changelog:
     - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
   script:
     # Generate the change for this release only
-    - git cliff --use-branch-tags --current --output this_mender_docs_changelog.md
+    - git cliff --use-branch-tags --current --output this_mender_docs_changelog.md --github-repo ${GITHUB_REPO_URL}
     - git clone https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_CHANGELOG_REPO_URL}
     - cd ${GITHUB_CHANGELOG_REPO_URL#*/}
     - git checkout -b changelog-${CI_JOB_ID}


### PR DESCRIPTION
to prevent https://github.com/mendersoftware/mender-docs-changelog/pull/193/changes#diff-2bdfb898251bd081d88ebde7ab4aea4358e28ccd1ce0ad3f0d7c130508130104R17 on branches w/o the changelog generator script...