### PR TITLE
chore(devauth): Change const name LimitMaxDevicesCount to match Enterprise repo

### DIFF
--- a/backend/services/deviceauth/api/http/api_devauth_test.go
+++ b/backend/services/deviceauth/api/http/api_devauth_test.go
@@ -1387,7 +1387,7 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 				},
 			}),
 			limit: model.Limit{
-				Name:  model.LimitMaxDeviceCount,
+				Name:  model.LimitMaxDevicesCount,
 				Value: 123,
 			},
 			tenant: "foo",
@@ -1422,7 +1422,7 @@ func TestApiDevAuthPutTenantLimit(t *testing.T) {
 				},
 			}),
 			tenant: "foo",
-			limit:  model.Limit{Name: model.LimitMaxDeviceCount, Value: 123},
+			limit:  model.Limit{Name: model.LimitMaxDevicesCount, Value: 123},
 			code:   http.StatusInternalServerError,
 			err:    errors.New("failed"),
 			body:   RestError("internal error"),
@@ -1463,7 +1463,7 @@ func TestApiDevAuthDeleteTenantLimit(t *testing.T) {
 				Method: "DELETE",
 				Path:   "http://localhost/api/internal/v1/devauth/tenant/foo/limits/max_devices",
 			}),
-			limit:  model.LimitMaxDeviceCount,
+			limit:  model.LimitMaxDevicesCount,
 			tenant: "foo",
 			code:   http.StatusNoContent,
 		},
@@ -1481,7 +1481,7 @@ func TestApiDevAuthDeleteTenantLimit(t *testing.T) {
 				Path:   "http://localhost/api/internal/v1/devauth/tenant/foo/limits/max_devices",
 			}),
 			tenant: "foo",
-			limit:  model.LimitMaxDeviceCount,
+			limit:  model.LimitMaxDevicesCount,
 			code:   http.StatusInternalServerError,
 			err:    errors.New("failed"),
 			body:   RestError("internal error"),
@@ -1522,7 +1522,7 @@ func TestApiV2DevAuthGetLimit(t *testing.T) {
 			limit: "max_devices",
 
 			daLimit: &model.Limit{
-				Name:  model.LimitMaxDeviceCount,
+				Name:  model.LimitMaxDevicesCount,
 				Value: 123,
 			},
 			daErr: nil,
@@ -1591,7 +1591,7 @@ func TestApiDevAuthGetTenantLimit(t *testing.T) {
 			tenantId: "tenant-foo",
 
 			daLimit: &model.Limit{
-				Name:  model.LimitMaxDeviceCount,
+				Name:  model.LimitMaxDevicesCount,
 				Value: 123,
 			},
 			daErr: nil,

--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -1406,7 +1406,7 @@ func (d *DevAuth) GetDevCountByStatus(ctx context.Context, status string) (int, 
 
 // canAcceptDevice checks if model.LimitMaxDeviceCount will be exceeded
 func (d *DevAuth) canAcceptDevice(ctx context.Context) (bool, error) {
-	limit, err := d.GetLimit(ctx, model.LimitMaxDeviceCount)
+	limit, err := d.GetLimit(ctx, model.LimitMaxDevicesCount)
 	if err != nil {
 		return false, errors.Wrap(err, "can't get current device limit")
 	}

--- a/backend/services/deviceauth/devauth/devauth_test.go
+++ b/backend/services/deviceauth/devauth/devauth_test.go
@@ -767,7 +767,7 @@ func TestDevAuthSubmitAuthRequestPreauth(t *testing.T) {
 			// for a preauthorized set - check if we're not over the limit
 			db.On("GetLimit",
 				ctxMatcher,
-				model.LimitMaxDeviceCount,
+				model.LimitMaxDevicesCount,
 			).Return(
 				tc.dbGetLimitRes,
 				tc.dbGetLimitErr,
@@ -1266,7 +1266,7 @@ func TestDevAuthAcceptDevice(t *testing.T) {
 				dummyAuthID).
 				Return(tc.aset, tc.dbGetErr)
 			db.On("GetLimit", context.Background(),
-				model.LimitMaxDeviceCount).
+				model.LimitMaxDevicesCount).
 				Return(tc.dbLimit, tc.dbLimitErr)
 			db.On("GetDevCountByStatus", context.Background(),
 				model.DevStatusAccepted).
@@ -2565,12 +2565,12 @@ func TestDevAuthGetLimit(t *testing.T) {
 			outErr:   nil,
 		},
 		"ok max_devices": {
-			inName: model.LimitMaxDeviceCount,
+			inName: model.LimitMaxDevicesCount,
 
-			dbLimit: &model.Limit{Name: model.LimitMaxDeviceCount, Value: 123},
+			dbLimit: &model.Limit{Name: model.LimitMaxDevicesCount, Value: 123},
 			dbErr:   nil,
 
-			outLimit: &model.Limit{Name: model.LimitMaxDeviceCount, Value: 123},
+			outLimit: &model.Limit{Name: model.LimitMaxDevicesCount, Value: 123},
 			outErr:   nil,
 		},
 		"limit not found": {

--- a/backend/services/deviceauth/model/limit.go
+++ b/backend/services/deviceauth/model/limit.go
@@ -16,11 +16,11 @@ package model
 import "github.com/mendersoftware/mender-server/pkg/mongo/v2/oid"
 
 const (
-	LimitMaxDeviceCount = "max_devices"
+	LimitMaxDevicesCount = "max_devices"
 )
 
 var (
-	ValidLimits = []string{LimitMaxDeviceCount}
+	ValidLimits = []string{LimitMaxDevicesCount}
 )
 
 type Limit struct {


### PR DESCRIPTION
Currently, the OS repo uses LimitMaxDeviceCount, while the Enterprise repo uses LimitMaxDevicesCount (note Device vs. Devices), for precisely the same variable. I cannot think of a good reason for this, so I updated it.