### PR TITLE
fix(gui): removed react-ga workaround to allow re-enabling ga tracking

### DIFF
--- a/frontend/src/js/tracking.js
+++ b/frontend/src/js/tracking.js
@@ -11,12 +11,10 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-import ReactGA4 from 'react-ga4';
+import ReactGA from 'react-ga4';
 
 const cookieConsentCSS = 'https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css';
 const cookieConsentJS = 'https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js';
-
-const ReactGA = ReactGA4.default;
 
 class Tracker {
   constructor() {


### PR DESCRIPTION
as a short term fix before we can think about maybe relying on nt-gui for this/ https://github.com/NorthernTechHQ/nt-gui/pull/657