### PR TITLE
fix(deployments): removed omitempty from ImageMeta description

### DIFF
--- a/backend/services/deployments/model/image.go
+++ b/backend/services/deployments/model/image.go
@@ -52,7 +52,7 @@ func ImagePathFromContext(ctx context.Context, id string) string {
 // Information provided by the user
 type ImageMeta struct {
 	// Image description
-	Description string `json:"description,omitempty" valid:"length(1|4096),optional"`
+	Description string `json:"description" valid:"length(1|4096),optional"`
 }
 
 // Creates new, empty ImageMeta


### PR DESCRIPTION
**Description** 

The `description` property of ImageMeta maps to the description property of both ArtifactV2 and ArtifactV1 in the OAS. In V2, [description is marked as required](https://github.com/mendersoftware/mender-server/blob/main/backend/docs/api/deployments/management_v2.yaml#L680), while in V1 [it is not](https://github.com/mendersoftware/mender-server/blob/main/backend/docs/api/deployments/management_v1.yaml#L1769-L1773). Removing required from V2 would be a breaking change, so we must instead always return a (potentially empty) value in order to respect both versions.