### PR TITLE
ci: use branch-matching image tag for frontend acceptance tests

### DIFF
--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -67,8 +67,8 @@ services:
   ## use playwright locally using `npm install` in the e2e_tests directory and run `npm run test`
   ##
   gui:
-    # Provide override variable MENDER_IMAGE_GUI, but fall back on default from dev/docker-compose.yml
-    image: ${MENDER_IMAGE_GUI:-docker.io/mendersoftware/gui:main}
+    # Provide override variable MENDER_IMAGE_GUI, but fall back on default using MENDER_IMAGE_TAG
+    image: ${MENDER_IMAGE_GUI:-docker.io/mendersoftware/gui:${MENDER_IMAGE_TAG:-main}}
     environment:
       - GATEWAY_IP=docker.mender.io
       - DISABLE_ONBOARDING=true


### PR DESCRIPTION
The frontend acceptance jobs hardcoded MENDER_IMAGE_TAG=main, causing release branches (e.g. 4.1.x) to pull all backend and GUI images from main instead of the matching release tag.

- pipeline.yml: use CI_COMMIT_BRANCH as the image tag in the template before_script and in the enterprise acceptance jobs (falls back to main for tag pipelines or when unset)
- docker-compose.e2e-tests.yml: GUI image fallback now honours MENDER_IMAGE_TAG instead of hardcoding :main