### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/backend/services/deployments/tests/common.py
+++ b/backend/services/deployments/tests/common.py
@@ -163,7 +163,7 @@ def artifact_rootfs_from_data(
 
             cmd = (
                 f"mender-artifact write rootfs-image"
-                + f' --device-type "{devicetype}"'
+                + f' --compatible-types "{devicetype}"'
                 + f' --file "{tdata.name}"'
                 + f' --artifact-name "{name}"'
                 + f' --output-path "{tmender.name}"'
@@ -201,7 +201,7 @@ def artifact_update_module_from_data(
             cmd = (
                 f"mender-artifact write module-image"
                 + f' -T "{update_type}"'
-                + f' --device-type "{devicetype}"'
+                + f' --compatible-types "{devicetype}"'
                 + f' --file "{tdata.name}"'
                 + f' --artifact-name "{name}"'
                 + f' --output-path "{tmender.name}"'
@@ -234,7 +234,7 @@ def artifact_bootstrap_from_data(
         )
         cmd = (
             f"mender-artifact write bootstrap-artifact"
-            + f' --device-type "{devicetype}"'
+            + f' --compatible-types "{devicetype}"'
             + f' --artifact-name "{name}"'
             + f' --output-path "{tmender.name}"'
             + f"{provides_arg}"


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344