### PR TITLE
docs(deployments): added description of tag filtering in releases endpoint

### DIFF
--- a/backend/docs/api/deployments/management_v2.yaml
+++ b/backend/docs/api/deployments/management_v2.yaml
@@ -175,7 +175,9 @@ paths:
         name: name
         schema:
           type: string
-      - description: Tag filter.
+      - description: |-
+          Filter the releases based on their associated tags and only return
+          releases that have at least one matching tag (i.e. OR matching).
         explode: true
         in: query
         name: tag

--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -2358,7 +2358,9 @@ paths:
           name: name
           schema:
             type: string
-        - description: Tag filter.
+        - description: |-
+            Filter the releases based on their associated tags and only return
+            releases that have at least one matching tag (i.e. OR matching).
           explode: true
           in: query
           name: tag

--- a/backend/pkg/api/client/api/openapi.yaml
+++ b/backend/pkg/api/client/api/openapi.yaml
@@ -3121,7 +3121,9 @@ paths:
         schema:
           type: string
         style: form
-      - description: Tag filter.
+      - description: |-
+          Filter the releases based on their associated tags and only return
+          releases that have at least one matching tag (i.e. OR matching).
         explode: true
         in: query
         name: tag

--- a/backend/pkg/api/client/api_deployments_v2_management_api.go
+++ b/backend/pkg/api/client/api_deployments_v2_management_api.go
@@ -919,7 +919,7 @@ func (r ApiDeploymentsV2ListReleasesWithPaginationRequest) Name(name string) Api
 	return r
 }
 
-// Tag filter.
+// Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).
 func (r ApiDeploymentsV2ListReleasesWithPaginationRequest) Tag(tag []string) ApiDeploymentsV2ListReleasesWithPaginationRequest {
 	r.tag = &tag
 	return r

--- a/backend/tests/mender_client/api/deployments_v2_management_api_api.py
+++ b/backend/tests/mender_client/api/deployments_v2_management_api_api.py
@@ -1403,7 +1403,7 @@ class DeploymentsV2ManagementAPIApi:
     def deployments_v2_list_releases_with_pagination(
         self,
         name: Annotated[Optional[StrictStr], Field(description="Release name filter.")] = None,
-        tag: Annotated[Optional[List[StrictStr]], Field(description="Tag filter.")] = None,
+        tag: Annotated[Optional[List[StrictStr]], Field(description="Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).")] = None,
         update_type: Annotated[Optional[StrictStr], Field(description="Update type filter.")] = None,
         page: Annotated[Optional[StrictInt], Field(description="Starting page.")] = None,
         per_page: Annotated[Optional[Annotated[int, Field(le=500, strict=True)]], Field(description="Maximum number of results per page.")] = None,
@@ -1427,7 +1427,7 @@ class DeploymentsV2ManagementAPIApi:
 
         :param name: Release name filter.
         :type name: str
-        :param tag: Tag filter.
+        :param tag: Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).
         :type tag: List[str]
         :param update_type: Update type filter.
         :type update_type: str
@@ -1492,7 +1492,7 @@ class DeploymentsV2ManagementAPIApi:
     def deployments_v2_list_releases_with_pagination_with_http_info(
         self,
         name: Annotated[Optional[StrictStr], Field(description="Release name filter.")] = None,
-        tag: Annotated[Optional[List[StrictStr]], Field(description="Tag filter.")] = None,
+        tag: Annotated[Optional[List[StrictStr]], Field(description="Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).")] = None,
         update_type: Annotated[Optional[StrictStr], Field(description="Update type filter.")] = None,
         page: Annotated[Optional[StrictInt], Field(description="Starting page.")] = None,
         per_page: Annotated[Optional[Annotated[int, Field(le=500, strict=True)]], Field(description="Maximum number of results per page.")] = None,
@@ -1516,7 +1516,7 @@ class DeploymentsV2ManagementAPIApi:
 
         :param name: Release name filter.
         :type name: str
-        :param tag: Tag filter.
+        :param tag: Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).
         :type tag: List[str]
         :param update_type: Update type filter.
         :type update_type: str
@@ -1581,7 +1581,7 @@ class DeploymentsV2ManagementAPIApi:
     def deployments_v2_list_releases_with_pagination_without_preload_content(
         self,
         name: Annotated[Optional[StrictStr], Field(description="Release name filter.")] = None,
-        tag: Annotated[Optional[List[StrictStr]], Field(description="Tag filter.")] = None,
+        tag: Annotated[Optional[List[StrictStr]], Field(description="Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).")] = None,
         update_type: Annotated[Optional[StrictStr], Field(description="Update type filter.")] = None,
         page: Annotated[Optional[StrictInt], Field(description="Starting page.")] = None,
         per_page: Annotated[Optional[Annotated[int, Field(le=500, strict=True)]], Field(description="Maximum number of results per page.")] = None,
@@ -1605,7 +1605,7 @@ class DeploymentsV2ManagementAPIApi:
 
         :param name: Release name filter.
         :type name: str
-        :param tag: Tag filter.
+        :param tag: Filter the releases based on their associated tags and only return releases that have at least one matching tag (i.e. OR matching).
         :type tag: List[str]
         :param update_type: Update type filter.
         :type update_type: str


### PR DESCRIPTION
**Description**
Added a description of how tag based filtering works to the OAS list releases endpoint. The context of this is that I'm working through the Server API Docs epic and this is the one endpoint I could find where we don't document this behavior (which is an acceptance criteria in that Epic).

Ticket: None