### PR TITLE
ci: let e2e test jobs rely on docker install from testing image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -703,7 +703,6 @@ test:prep:
   before_script:
     - mv mender-stress-test-client frontend/tests/e2e_tests/
     - cd frontend/tests/e2e_tests
-    - curl -fsSL https://get.docker.com | sh
     - docker pull mendersoftware/mender-client-docker-addons:mender-master
     - npm ci --cache .npm --prefer-offline
   script:

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -190,7 +190,6 @@ build:frontend:docker:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
   before_script:
-    - curl -fsSL https://get.docker.com | sh -s -- --version ${DOCKER_VERSION}
     - !reference [.requires-docker]
     - !reference [.dind-login]
     - npm i --prefix frontend/tests/e2e_tests


### PR DESCRIPTION
relying on https://github.com/mendersoftware/mender-test-containers/pull/696