### PR TITLE
Ci/staging runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -715,7 +715,7 @@ test:prep:
       - frontend/tests/e2e_tests/traces
     when: always
   tags:
-    - hetzner-amd-beefy-privileged
+    - k8s
   allow_failure:
     exit_codes: 464
 


### PR DESCRIPTION
while the test job https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/14101924964 failed, it was due to the email verification requirement and the earlier tests reliant on the device worked fine