### PR TITLE
fix(deployments) Stop returning more pages than the query returns

### DIFF
--- a/backend/services/deployments/api/http/api_deployments.go
+++ b/backend/services/deployments/api/http/api_deployments.go
@@ -1839,6 +1839,15 @@ func (d *DeploymentsApiHandlers) LookupDeploymentV2(c *gin.Context) {
 	query.Skip = int((page - 1) * perPage)
 	query.Limit = int(perPage + 1)
 
+	// Validate pagination - if requested page exceeds available pages, return 404
+	if perPage > 0 {
+		totalPages := (totalCount + perPage - 1) / perPage
+		if page > totalPages {
+			d.view.RenderError(c, errors.New("No more pages available"), http.StatusNotFound)
+			return
+		}
+	}
+
 	deps, totalCount, err := d.app.LookupDeployment(ctx, query)
 	if err != nil {
 		d.view.RenderError(c, err, http.StatusBadRequest)

--- a/backend/services/deployments/api/http/api_deployments_test.go
+++ b/backend/services/deployments/api/http/api_deployments_test.go
@@ -1972,6 +1972,30 @@ func TestLookupDeploymentV2(t *testing.T) {
 			count:        0,
 			ResponseCode: http.StatusOK,
 		},
+		{
+			Name:         "page beyond available pages returns 404",
+			query:        &model.Query{Limit: 50, Sort: model.SortDirectionDescending},
+			deployments:  []*model.Deployment{{Name: "deployment-1"}},
+			count:        34, // Only 34 items total
+			sort:         model.SortDirectionDescending,
+			ResponseCode: http.StatusNotFound,
+		},
+		{
+			Name:         "zero page returns 400",
+			query:        &model.Query{Limit: 50, Sort: model.SortDirectionDescending},
+			deployments:  []*model.Deployment{},
+			count:        34,
+			sort:         model.SortDirectionDescending,
+			ResponseCode: http.StatusBadRequest,
+		},
+		{
+			Name:         "very large page number returns 404",
+			query:        &model.Query{Limit: 50, Sort: model.SortDirectionDescending},
+			deployments:  []*model.Deployment{{Name: "deployment-1"}},
+			count:        34,
+			sort:         model.SortDirectionDescending,
+			ResponseCode: http.StatusNotFound,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When a client requests a page beyond the available pages, the endpoint would
incorrectly fall back to a different query and return incorrect data.

This fix adds pagination validation to return a 404 (Not Found) response when
the requested page exceeds the available pages, with error message:
"No more pages available".

Ticket: ME-651
Changelog: Return 404 when requested page exceeds available pages