### PR TITLE
fix(deployments): correct total count when result page overshoots

### DIFF
--- a/backend/services/deployments/app/app.go
+++ b/backend/services/deployments/app/app.go
@@ -1953,7 +1953,7 @@ func (d *Deployments) LookupDeployment(ctx context.Context,
 	}
 
 	if list == nil {
-		return make([]*model.Deployment, 0), 0, nil
+		list = []*model.Deployment{}
 	}
 
 	for _, deployment := range list {

--- a/backend/services/deployments/app/app_test.go
+++ b/backend/services/deployments/app/app_test.go
@@ -1689,6 +1689,16 @@ func TestLookupDeployment(t *testing.T) {
 			res:                []*model.Deployment{},
 			resCount:           0,
 		},
+		"empty page with non-zero total": {
+			query: model.Query{
+				Limit: 10,
+				Skip:  10, // page 2 of a one-page result
+			},
+			dbDeployments:      nil,
+			dbDeploymentsCount: 5,
+			res:                []*model.Deployment{},
+			resCount:           5,
+		},
 		"database error": {
 			query: model.Query{
 				IDs: []string{

--- a/backend/services/deployments/store/mongo/datastore_mongo.go
+++ b/backend/services/deployments/store/mongo/datastore_mongo.go
@@ -2694,7 +2694,7 @@ func (db *DataStoreMongo) FindDeployments(ctx context.Context,
 	count := int64(0)
 	if !match.DisableCount {
 		count = int64(len(deployments))
-		if count >= int64(match.Limit) {
+		if count >= int64(match.Limit) || (count == 0 && match.Skip > 0) {
 			count, err = collDpl.CountDocuments(ctx, query)
 			if err != nil {
 				return nil, 0, err

--- a/backend/services/deployments/store/mongo/datastore_mongo_test.go
+++ b/backend/services/deployments/store/mongo/datastore_mongo_test.go
@@ -2521,6 +2521,7 @@ func TestFindDeployments(t *testing.T) {
 		query            model.Query
 
 		outputDeployments []*model.Deployment
+		expectedCount     int64
 	}{
 		"ok, empty query": {
 			inputDeployments: []interface{}{
@@ -2567,6 +2568,7 @@ func TestFindDeployments(t *testing.T) {
 					Active: true,
 				},
 			},
+			expectedCount: 3,
 		},
 		"ok, Ids in query": {
 			inputDeployments: []interface{}{
@@ -2616,6 +2618,7 @@ func TestFindDeployments(t *testing.T) {
 					Active: true,
 				},
 			},
+			expectedCount: 2,
 		},
 		"ok, names in query": {
 			inputDeployments: []interface{}{
@@ -2665,10 +2668,12 @@ func TestFindDeployments(t *testing.T) {
 					Active: true,
 				},
 			},
+			expectedCount: 2,
 		},
 		"no deployments": {
 			query:             model.Query{},
 			outputDeployments: nil,
+			expectedCount:     0,
 		},
 		"ok, DeviceIDs matches by name (single-device deployment)": {
 			inputDeployments: []interface{}{
@@ -2700,6 +2705,7 @@ func TestFindDeployments(t *testing.T) {
 					Active: true,
 				},
 			},
+			expectedCount: 1,
 		},
 		"ok, DeviceIDs matches by device_list (multi-device deployment)": {
 			inputDeployments: []interface{}{
@@ -2734,6 +2740,7 @@ func TestFindDeployments(t *testing.T) {
 					Active:     true,
 				},
 			},
+			expectedCount: 1,
 		},
 		"ok, DeviceIDs no match": {
 			inputDeployments: []interface{}{
@@ -2749,6 +2756,25 @@ func TestFindDeployments(t *testing.T) {
 				DeviceIDs: []string{"nonexistent-device"},
 			},
 			outputDeployments: nil,
+			expectedCount:     0,
+		},
+		"empty page on overshoot returns true total": {
+			inputDeployments: []interface{}{
+				&model.Deployment{
+					DeploymentConstructor: &model.DeploymentConstructor{
+						ArtifactName: "foo",
+						Name:         "some-name",
+					},
+					Id: "a108ae14-bb4e-455f-9b40-2ef4bab97bb7",
+				},
+			},
+			query: model.Query{
+				Names: []string{"some-name"},
+				Skip:  10, // page 2 of a one-page result
+				Limit: 10,
+			},
+			outputDeployments: nil,
+			expectedCount:     1,
 		},
 	}
 
@@ -2774,7 +2800,7 @@ func TestFindDeployments(t *testing.T) {
 
 			deployments, count, err := ds.FindDeployments(ctx, tc.query)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(len(tc.outputDeployments)), count)
+			assert.Equal(t, tc.expectedCount, count)
 			assert.Equal(t, tc.outputDeployments, deployments)
 		})
 	}

--- a/backend/tests/integration/test_deployments.py
+++ b/backend/tests/integration/test_deployments.py
@@ -443,6 +443,14 @@ class _TestDeploymentsBase(object):
         assert len(resp.json()) == 5
         assert 5 == int(resp.headers["X-Total-Count"])
 
+        # pagination overshoot: page beyond last should return correct X-Total-Count
+        resp = api_dep_v2.with_auth(user_token).call(
+            "GET", "/deployments" + "?per_page=10&page=2"
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()) == 0
+        assert int(resp.headers["X-Total-Count"]) == 5
+
         # per_page query parameter
         resp = api_dep_v2.with_auth(user_token).call(
             "GET", "/deployments" + "?per_page=18446744073709551617"


### PR DESCRIPTION
The `/api/management/v2/deployments/deployments` endpoint previously returned `X-Total-Count: 0` when the requested page was beyond the last page of a non-empty result set. The total count is now preserved through empty pages.

Changelog: Fix wrong total count header for deployments when page overshoots
Ticket: MEN-9643