### PR TITLE
chore: move golinter to the k8s runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,6 +401,8 @@ test:backend:static:
   script:
     - cd backend
     - golangci-lint run -v
+  tags:
+    - k8s
 
 .template:combine-api:
   stage: test
@@ -622,7 +624,7 @@ test:backend:integration:ng:
     - make -C backend test-integration-ng
       GOCOVERDIR=${GOCOVERDIR}/integration-ng
       MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
-    
+
   after_script:
     - export MANTRA_PROJECT_NAME="backend_integration_ng_open_source"
     - !reference [.mantra-push-results]


### PR DESCRIPTION
- backport of https://github.com/mendersoftware/mender-server-enterprise/pull/1173

as this also prevents 4.1.x pipelines from passing