### PR TITLE
fix(deployments): skip inventory fallback when result page overshoots

### DIFF
--- a/backend/services/deployments/app/app.go
+++ b/backend/services/deployments/app/app.go
@@ -1903,7 +1903,7 @@ func (d *Deployments) LookupDeployment(ctx context.Context,
 	// Fallback: if name search returned no results and device identity
 	// lookup params are provided, resolve the device UUID via inventory
 	// and search deployments targeting that device.
-	if len(list) == 0 &&
+	if totalCount == 0 &&
 		len(query.Names) > 0 &&
 		query.IdAttribute != "" &&
 		query.IdScope != "" {

--- a/backend/services/deployments/app/app_test.go
+++ b/backend/services/deployments/app/app_test.go
@@ -1874,6 +1874,30 @@ func TestLookupDeploymentFallback(t *testing.T) {
 		assert.Len(t, deployments, 1)
 	})
 
+	t.Run("fallback skipped on pagination overshoot", func(t *testing.T) {
+		ctx := identity.WithContext(context.Background(), &identity.Identity{
+			Tenant: "tenant123",
+		})
+		query := model.Query{
+			Names:       []string{"my-device"},
+			IdAttribute: "id",
+			IdScope:     "identity",
+			Limit:       10,
+			Skip:        10, // page 2 of a one-page result
+		}
+		db := mocks.DataStore{}
+		defer db.AssertExpectations(t)
+		db.On("FindDeployments", ctx, query).
+			Return(nil, int64(5), nil)
+
+		ds := &Deployments{db: &db}
+
+		deployments, count, err := ds.LookupDeployment(ctx, query)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(5), count)
+		assert.Equal(t, []*model.Deployment{}, deployments)
+	})
+
 	t.Run("fallback inventory search returns no devices", func(t *testing.T) {
 		ctx := identity.WithContext(context.Background(), &identity.Identity{
 			Tenant: "tenant123",


### PR DESCRIPTION
The `/api/management/v2/deployments/deployments` endpoint previously triggered the inventory fallback whenever the returned page was empty, including when the user paginated past the last page of a non-empty result set. The fallback gate now checks the underlying total count, so overshoot pages no longer trigger an inventory lookup that returns unrelated deployments.

Changelog: Title
Ticket: ME-651