### PR TITLE
ci: use Gitlab Dependency proxy in docker composition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,8 +219,9 @@ build:backend:docker:
     - |-
       make -j$(nproc) -C backend/services/deployments docker \
         DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
-        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
-    - make -j$(nproc) -C backend docker
+        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER} \
+        DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
+    - make -j$(nproc) -C backend docker DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
 
 build:backend:docker-acceptance:
   extends: build:backend:docker
@@ -232,7 +233,7 @@ build:backend:docker-acceptance:
     - unset DOCKER_PLATFORM
   script:
     # NOTE: Only build for test platform (default) for the acceptance test images
-    - make -j$(nproc) -C backend docker-acceptance
+    - make -j$(nproc) -C backend docker-acceptance DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
 
 build:backend:docker-integration-tester:
   extends: .template:build:docker
@@ -245,6 +246,7 @@ build:backend:docker-integration-tester:
     - docker build ${DOCKER_BUILDARGS}
         --cache-from ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
         -t ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
+        --build-arg REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
         -f backend/tests/Dockerfile.integration
         backend/tests
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -168,7 +168,9 @@ renovate:
 
 .dind-login: &dind-login
   - mkdir -p $HOME/.docker && echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
+  - unset DOCKER_AUTH_CONFIG
   - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
+  - docker login --username $CI_DEPENDENCY_PROXY_USER --password $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
 
 .build:base:
   before_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -405,7 +405,7 @@ test:backend:static:
     - changes:
         paths: ["backend/**/*.go", "backend/go.mod", ".gitlab-ci.yml"]
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-  image: "golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
+  image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
   script:
     - cd backend
     - golangci-lint run -v
@@ -840,7 +840,7 @@ publish:backend:licenses:
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: golang:${GOLANG_VERSION}
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:${GOLANG_VERSION}
   variables:
     GOFLAGS: -tags=nopkcs11
   before_script:

--- a/backend/services/Makefile.common
+++ b/backend/services/Makefile.common
@@ -9,6 +9,8 @@ MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSITORY ?= mendersoftware
 MENDER_PUBLISH_TAG ?= $(MENDER_IMAGE_TAG)
 
+DOCKER_HUB_BUILD_REGISTRY ?= docker.io
+
 bindir ?= $(GIT_ROOT)/bin
 binfile ?= $(bindir)/$(COMPONENT)
 
@@ -55,6 +57,7 @@ docker:
 		-f Dockerfile \
 		--build-arg BUILDFLAGS="$(BUILDFLAGS)" \
 		--build-arg LDFLAGS="$(LDFLAGS)" \
+		--build-arg REGISTRY="$(DOCKER_HUB_BUILD_REGISTRY)" \
 		-t $(DOCKER_TAG) \
 		$(GIT_ROOT)
 

--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 as builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDFLAGS="-trimpath"
@@ -43,7 +44,7 @@ RUN \
   BUILDFLAGS="${BUILDFLAGS}" && \
   mkdir /var/cache/create-artifact-worker
 
-FROM alpine:3.23.4
+FROM ${REGISTRY}/alpine:3.23.4
 ARG TARGETARCH
 ARG TARGETOS
 ARG USER=65534:65534

--- a/backend/services/deployments/Dockerfile
+++ b/backend/services/deployments/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-tags nopkcs11 -trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceauth/Dockerfile
+++ b/backend/services/deviceauth/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconfig/Dockerfile
+++ b/backend/services/deviceconfig/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconfig/tests/docker-compose.yml
+++ b/backend/services/deviceconfig/tests/docker-compose.yml
@@ -6,7 +6,7 @@ include:
 
 services:
   mmock:
-      image: "jordimartin/mmock:v3.0.0"
+      image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.0.0"
       command: ["-server-ip", "0.0.0.0", "-console-ip", "0.0.0.0", "-server-port", "8080"]
       ports:
         - "8082:8082"

--- a/backend/services/deviceconnect/Dockerfile
+++ b/backend/services/deviceconnect/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconnect/tests/docker-compose.acceptance.yml
+++ b/backend/services/deviceconnect/tests/docker-compose.acceptance.yml
@@ -14,7 +14,7 @@ services:
       - deviceconnect
 
   mmock:
-    image: "jordimartin/mmock:v3.0.0"
+    image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.0.0"
     networks:
       default:
         aliases:

--- a/backend/services/inventory/Dockerfile
+++ b/backend/services/inventory/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/iot-manager/Dockerfile
+++ b/backend/services/iot-manager/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/iot-manager/tests/docker-compose.acceptance.yml
+++ b/backend/services/iot-manager/tests/docker-compose.acceptance.yml
@@ -15,7 +15,7 @@ services:
       - iot-manager
 
   mmock:
-    image: jordimartin/mmock:v3.1.6
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.1.6
     command:
       - "-config-path=/config"
       - "-console-ip=0.0.0.0"

--- a/backend/services/useradm/Dockerfile
+++ b/backend/services/useradm/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/useradm/tests/docker-compose.yml
+++ b/backend/services/useradm/tests/docker-compose.yml
@@ -5,7 +5,7 @@ include:
     - docker-compose.acceptance.yml
 services:
   mmock:
-    image: jordimartin/mmock:v2.7.6
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v2.7.6
     command:
       - -server-ip
       - 0.0.0.0

--- a/backend/services/workflows/Dockerfile
+++ b/backend/services/workflows/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/workflows/tests/docker-compose.yml
+++ b/backend/services/workflows/tests/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       service: nats
 
   mmock:
-    image: jordimartin/mmock:v2.7.6
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v2.7.6
     command:
       [
         "-server-ip",

--- a/backend/tests/Dockerfile.acceptance
+++ b/backend/tests/Dockerfile.acceptance
@@ -1,4 +1,5 @@
-FROM python:3.14-slim-bookworm
+ARG REGISTRY=docker.io
+FROM ${REGISTRY}/python:3.14-slim-bookworm
 ARG MENDER_ARTIFACT_VERSION=4.4.0
 COPY requirements-acceptance.txt requirements.txt
 RUN apt update && apt install -qy wget && \

--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -1,4 +1,5 @@
-FROM python:3.14-trixie
+ARG REGISTRY=docker.io
+FROM ${REGISTRY}/python:3.14-trixie
 WORKDIR /tests
 
 # Install mender-artifact

--- a/backend/tests/docker/docker-compose.backend-tests-compat.yml
+++ b/backend/tests/docker/docker-compose.backend-tests-compat.yml
@@ -3,7 +3,7 @@ services:
     command:
       - integration_compat
   mender-client-2-0:
-    image: mendersoftware/mender-client-docker:2.0.1
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.0.1
     scale: 1
     stdin_open: true
     tty: true
@@ -16,67 +16,67 @@ services:
   mender-client-2-1:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.1.3
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.1.3
   mender-client-2-2:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.2.1
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.2.1
   mender-client-2-3:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.3.2
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.3.2
   mender-client-2-4:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.4.2
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.4.2
   mender-client-2-5:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.5.4
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.5.4
   mender-client-2-6:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:2.6.1
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.6.1
   mender-client-3-0:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:3.0.2
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:3.0.2
   mender-client-3-1:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:3.1.1
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:3.1.1
   mender-client-3-2:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.2.2
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.2.2
   mender-client-3-3:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.3.2
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.3.2
   mender-client-3-4:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.4.0
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.4.0
   mender-client-3-5:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.5.1
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.5.1
   mender-client-3-6:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.6.5
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.6.5
   mender-client-3-7:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:mender-3.7.9
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.7.9
   mender-client-5.0.0:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker:client-5.0.0
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:client-5.0.0
   mender-client-6.0.0:
     extends:
       service: mender-client-2-0
-    image: mendersoftware/mender-client-docker-addons:client-6.0.0
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker-addons:client-6.0.0
     configs:
       - source: server_cert
         target: /etc/mender/server.crt

--- a/backend/tests/docker/docker-compose.backend-tests.yml
+++ b/backend/tests/docker/docker-compose.backend-tests.yml
@@ -62,7 +62,7 @@ services:
     volumes:
       - ${GOCOVERDIR:-cover}:/cover
   mock-httpd:
-    image: mockserver/mockserver:5.15.0
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mockserver/mockserver:5.15.0
 
 volumes:
   cover: {}

--- a/compose/docker-compose.enterprise.yml
+++ b/compose/docker-compose.enterprise.yml
@@ -175,7 +175,7 @@ services:
     image: ${MENDER_IMAGE_REGISTRY:-registry.mender.io}/${MENDER_IMAGE_REPOSITORY:-mender-server-enterprise}/workflows:${MENDER_IMAGE_TAG:-latest}
 
   redis:
-    image: redis:8.6
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/redis:8.6
     networks:
       default:
         aliases: [mender-redis]

--- a/compose/docker-compose.seaweedfs.yml
+++ b/compose/docker-compose.seaweedfs.yml
@@ -24,7 +24,7 @@ configs:
 
 services:
   s3-master:
-    image: chrislusf/seaweedfs:4.22
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - master
       - -mdir=/data
@@ -37,7 +37,7 @@ services:
       - s3:/data
 
   s3-volume:
-    image: chrislusf/seaweedfs:4.22
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - volume
       - -mserver=s3-master:9333
@@ -51,7 +51,7 @@ services:
       - s3:/data
 
   s3-filer:
-    image: chrislusf/seaweedfs:4.22
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - filer
       - -master=s3-master:9333
@@ -63,7 +63,7 @@ services:
       - s3:/data
 
   s3:
-    image: chrislusf/seaweedfs:4.22
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - s3
       - -port=8080

--- a/compose/docker-compose.smtp4dev.yml
+++ b/compose/docker-compose.smtp4dev.yml
@@ -4,7 +4,7 @@
 # A web interface for the inbox can be accessed on port 8025 on your machine.
 services:
   smtp4dev:
-    image: rnwood/smtp4dev:3.15.0
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/rnwood/smtp4dev:3.15.0
     ports:
       # Change the number before : to the port the web interface should be accessible on
       # Add 127.0.0.1: prefix for localhost-only access (recommended for security)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,7 +341,7 @@ services:
       default:
         aliases: [mender-workflows]
   traefik:
-    image: traefik:v3.6.15
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/traefik:v3.6.15
     command:
       - --api=true
       - --api.insecure=true
@@ -382,7 +382,7 @@ services:
           - s3.docker.mender.io
 
   mongo:
-    image: mongo:${MONGO_VERSION:-8.0}
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mongo:${MONGO_VERSION:-8.0}
     healthcheck:
       test: ["CMD", "mongosh", "mongodb://localhost:27017/test", "--quiet", "--eval", "db.runCommand('ping').ok"]
       interval: 10s
@@ -399,7 +399,7 @@ services:
         aliases: [mender-mongo]
 
   nats:
-    image: nats:2.14-alpine
+    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/nats:2.14-alpine
     command: [-js, -m, '8222']
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz | grep -q 'ok'"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM node:25.9.0-alpine3.22 AS base
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/node:25.9.0-alpine3.22 AS base
 WORKDIR /usr/src/app
 RUN apk add --no-cache gzip
 COPY package-lock.json package.json ./
@@ -13,7 +14,7 @@ ENV SENTRY_URL=$SENTRY_URL
 RUN --mount=type=secret,id=sentryAuthToken export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentryAuthToken) && npm run build
 RUN gzip -r -k dist/*
 
-FROM nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
+FROM ${REGISTRY}/nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
 EXPOSE 8090
 WORKDIR /var/www/mender-gui/dist
 ARG GIT_COMMIT_TAG

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -157,6 +157,7 @@ build:frontend:docker:
       --build-arg GIT_COMMIT_SHA="${CI_COMMIT_SHA}"
       --build-arg SENTRY_ORG="${SENTRY_ORG}"
       --build-arg SENTRY_URL="${SENTRY_URL}"
+      --build-arg REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
       --secret id=sentryAuthToken,env=SENTRY_AUTH_TOKEN
       --platform ${DOCKER_PLATFORM:-linux/amd64}
       --provenance false


### PR DESCRIPTION
Use Gitlab Dependency Proxy in the docker compositions if available - otherwise it falls-back to docker.io

Ticket: QA-1617

Co-authored-with: Claude