### PR TITLE
ci: use per-pod PVCs for SeaweedFS in pr based deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,11 +382,17 @@ review:stop:
     - echo "Configuring kubectl for EKS cluster ${REVIEW_APPS_EKS_CLUSTER_NAME}..."
     - aws eks update-kubeconfig --name ${REVIEW_APPS_EKS_CLUSTER_NAME} --region ${REVIEW_APPS_AWS_REGION}
 
-    - echo "Uninstalling Helm release ${RELEASE_NAME}..."
-    - helm uninstall ${RELEASE_NAME} -n ${NAMESPACE} --wait || echo "Release not found or already deleted"
+    - echo "Uninstalling Mender Helm release ${RELEASE_NAME}..."
+    - helm uninstall ${RELEASE_NAME} -n ${NAMESPACE} --wait --timeout 5m || echo "Release not found or already deleted"
+
+    - echo "Uninstalling SeaweedFS Helm release..."
+    - helm uninstall seaweedfs -n ${NAMESPACE} --wait --timeout 5m || echo "Release not found or already deleted"
+
+    - echo "Deleting PVCs in ${NAMESPACE}..."
+    - kubectl delete pvc --all -n ${NAMESPACE} --wait=false --ignore-not-found
 
     - echo "Deleting namespace ${NAMESPACE}..."
-    - kubectl delete namespace ${NAMESPACE} --wait=true --timeout=5m || echo "Namespace not found or already deleted"
+    - kubectl delete namespace ${NAMESPACE} --wait=true --timeout=10m || echo "Namespace not found or already deleted"
 
     - echo "Review app cleanup completed successfully!"
 

--- a/compose/k8s/setup-review-namespace.sh
+++ b/compose/k8s/setup-review-namespace.sh
@@ -174,17 +174,38 @@ kubectl create secret generic mender-s3-artifacts \
     --dry-run=client -o yaml | kubectl apply -f -
 
 # Deploy SeaweedFS using Helm
-log_info "Installing SeaweedFS Helm chart..."
+SEAWEEDFS_CHART_VERSION="${SEAWEEDFS_CHART_VERSION:-4.23.0}"
+SEAWEEDFS_STORAGE_CLASS="${SEAWEEDFS_STORAGE_CLASS:-}"
+
+log_info "Installing SeaweedFS Helm chart (version ${SEAWEEDFS_CHART_VERSION})..."
 helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm
 helm repo update
 
+STORAGE_CLASS_ARGS=()
+if [ -n "${SEAWEEDFS_STORAGE_CLASS}" ]; then
+    STORAGE_CLASS_ARGS=(
+        --set "master.data.storageClass=${SEAWEEDFS_STORAGE_CLASS}"
+        --set "volume.dataDirs[0].storageClass=${SEAWEEDFS_STORAGE_CLASS}"
+        --set "filer.data.storageClass=${SEAWEEDFS_STORAGE_CLASS}"
+    )
+fi
+
 helm upgrade --install seaweedfs seaweedfs/seaweedfs \
     -n "${NAMESPACE}" \
+    --version "${SEAWEEDFS_CHART_VERSION}" \
     --set nameOverride="${SEAWEEDFS_NAME_OVERRIDE}" \
     --set master.replicas=1 \
+    --set master.data.type=persistentVolumeClaim \
+    --set master.data.size=1Gi \
     --set volume.replicas=1 \
+    --set 'volume.dataDirs[0].name=data1' \
+    --set 'volume.dataDirs[0].type=persistentVolumeClaim' \
+    --set 'volume.dataDirs[0].size=10Gi' \
+    --set 'volume.dataDirs[0].maxVolumes=0' \
     --set filer.enabled=true \
     --set filer.replicas=1 \
+    --set filer.data.type=persistentVolumeClaim \
+    --set filer.data.size=2Gi \
     --set filer.s3.enabled=true \
     --set filer.s3.port=8333 \
     --set filer.s3.enableAuth=true \
@@ -206,7 +227,8 @@ helm upgrade --install seaweedfs seaweedfs/seaweedfs \
     --set filer.resources.requests.cpu=100m \
     --set filer.resources.limits.memory=512Mi \
     --set filer.resources.limits.cpu=250m \
-    --wait --timeout 5m
+    "${STORAGE_CLASS_ARGS[@]}" \
+    --wait --timeout 7m
 
 log_info "SeaweedFS deployed successfully"
 


### PR DESCRIPTION
To solve a hostpath fight between two seaweedfs setups, starting from the latest helm chart