### PR TITLE
ME-655 - fixed an issue that squashed the phase size inputs

### DIFF
--- a/frontend/src/js/common-ui/forms/NumberField.tsx
+++ b/frontend/src/js/common-ui/forms/NumberField.tsx
@@ -102,7 +102,7 @@ export const NumberField = (props: NumberFieldProps) => {
                 endAdornment
               )
             }
-            sx={showSteps ? { pr: 0 } : undefined}
+            sx={{ minWidth: 80, ...(showSteps ? { pr: 0 } : undefined) }}
           />
         )}
       />

--- a/frontend/src/js/common-ui/forms/__snapshots__/NumberField.test.tsx.snap
+++ b/frontend/src/js/common-ui/forms/__snapshots__/NumberField.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`NumberField Component > renders correctly 1`] = `
   align-items: center;
   position: relative;
   border-radius: 4px;
+  min-width: 80px;
 }
 
 .emotion-2.Mui-disabled {

--- a/frontend/src/js/components/deployments/CreateDeployment.tsx
+++ b/frontend/src/js/components/deployments/CreateDeployment.tsx
@@ -263,7 +263,7 @@ export const CreateDeployment = props => {
   };
   const hasReleases = !!Object.keys(releasesById).length;
   return (
-    <BaseDrawer open={open} onClose={closeWizard} size="sm" slotProps={{ header: { title: 'Create a deployment' } }}>
+    <BaseDrawer open={open} onClose={closeWizard} size="md" slotProps={{ header: { title: 'Create a deployment' } }}>
       <FormGroup>
         {!hasReleases ? (
           <ReleasesWarning />

--- a/frontend/src/js/components/deployments/__snapshots__/CreateDeployment.test.tsx.snap
+++ b/frontend/src/js/components/deployments/__snapshots__/CreateDeployment.test.tsx.snap
@@ -3920,6 +3920,7 @@ exports[`CreateDeployment Component > smaller components > renders Retries corre
   align-items: center;
   position: relative;
   border-radius: 4px;
+  min-width: 80px;
 }
 
 .emotion-15.Mui-disabled {
@@ -4990,6 +4991,7 @@ exports[`CreateDeployment Component > smaller components > renders Retries corre
   align-items: center;
   position: relative;
   border-radius: 4px;
+  min-width: 80px;
 }
 
 .emotion-15.Mui-disabled {

--- a/frontend/src/js/components/settings/__snapshots__/Global.test.tsx.snap
+++ b/frontend/src/js/components/settings/__snapshots__/Global.test.tsx.snap
@@ -796,6 +796,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-ms-input-
   align-items: center;
   position: relative;
   border-radius: 4px;
+  min-width: 80px;
 }
 
 .emotion-36.Mui-disabled {

--- a/frontend/src/js/components/subscription/__snapshots__/SubscriptionConfirmation.test.tsx.snap
+++ b/frontend/src/js/components/subscription/__snapshots__/SubscriptionConfirmation.test.tsx.snap
@@ -1058,6 +1058,7 @@ exports[`Subscription Page component > renders correctly 1`] = `
   position: relative;
   border-radius: 4px;
   padding-right: 14px;
+  min-width: 80px;
   padding-right: 0px;
 }
 

--- a/frontend/src/js/components/subscription/__snapshots__/SubscriptionDrawer.test.tsx.snap
+++ b/frontend/src/js/components/subscription/__snapshots__/SubscriptionDrawer.test.tsx.snap
@@ -2463,6 +2463,7 @@ exports[`Subscription Page component > renders correctly 1`] = `
   position: relative;
   border-radius: 4px;
   padding-right: 14px;
+  min-width: 80px;
   padding-right: 0px;
 }
 

--- a/frontend/src/js/components/subscription/__snapshots__/SubscriptionPage.test.tsx.snap
+++ b/frontend/src/js/components/subscription/__snapshots__/SubscriptionPage.test.tsx.snap
@@ -519,6 +519,7 @@ exports[`Subscription Page component > renders correctly 1`] = `
   position: relative;
   border-radius: 4px;
   padding-right: 14px;
+  min-width: 80px;
   padding-right: 0px;
 }
 

--- a/frontend/src/js/components/subscription/__snapshots__/SubscriptionSummary.test.tsx.snap
+++ b/frontend/src/js/components/subscription/__snapshots__/SubscriptionSummary.test.tsx.snap
@@ -519,6 +519,7 @@ exports[`Subscription Page component > renders correctly 1`] = `
   position: relative;
   border-radius: 4px;
   padding-right: 14px;
+  min-width: 80px;
   padding-right: 0px;
 }
 


### PR DESCRIPTION
set a base width on all number inputs to ensure numbers are visible despite a potential adornment

<img width="263" height="242" alt="Screenshot 2026-05-06 at 21 34 38" src="https://github.com/user-attachments/assets/d9fec93b-0f5c-4094-a338-61887b5562ab" />
