### PR TITLE
ci: switch test container images to per-image registry paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -754,7 +754,7 @@ test:staging-deployment:firefox:
 
 publish:backend:coverage:
   stage: publish
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   needs:
     - job: test:backend:unit
       artifacts: true

--- a/.gitlab/merge-enterprise.yml
+++ b/.gitlab/merge-enterprise.yml
@@ -11,7 +11,7 @@ merge-to-enterprise:
       when: always
       allow_failure: true
     - when: never
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers:base-alpine-master
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
   variables:
     GITHUB_REPOSITORY_ENTERPRISE: "mendersoftware/mender-server-enterprise"
     GITHUB_REPOSITORY_OPEN_SOURCE: "mendersoftware/mender-server"

--- a/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
+++ b/frontend/tests/e2e_tests/docker-compose.e2e-tests.yml
@@ -18,7 +18,7 @@ configs:
       }
 services:
   gui-tests-runner:
-    image: mendersoftware/mender-test-containers:gui-e2e-testing
+    image: registry.gitlab.com/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
     command: ['tail', '-f', '/dev/null']
     environment:
       - TEST_ENVIRONMENT


### PR DESCRIPTION
Migrates mender-test-containers image references from the legacy flat-tag format to the new per-image sub-repository format:

- `mender-test-containers:base-alpine-master` → `mender-test-containers/base-alpine:master`
- `mendersoftware/mender-test-containers:gui-e2e-testing` → `mender-test-containers/gui-e2e-testing:master`

Ticket: QA-1598, QA-1604