### PR TITLE
Route docker.io through dep proxy via buildkit mirror with fallback

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,6 +172,16 @@ renovate:
   - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
   - docker login --username $CI_DEPENDENCY_PROXY_USER --password $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
 
+.buildkit-mirror-setup: &buildkit-mirror-setup
+  - |
+    cat > /tmp/buildkitd.toml <<EOF
+    [registry."docker.io"]
+      mirrors = ["${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"]
+    EOF
+  - docker context create ci
+  - docker buildx create ${DOCKER_BUILDKITARGS} --name ci-builder --driver=docker-container --config /tmp/buildkitd.toml ci
+  - export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --builder=ci-builder"
+
 .build:base:
   before_script:
     - *requires-docker
@@ -201,12 +211,10 @@ renovate:
     - *requires-docker
     - apk add make bash git
     - *dind-login
-    # NOTE: If we're running on a PR, do not build multiplatform
     - test "$CI_COMMIT_REF_PROTECTED" != "true" && unset DOCKER_PLATFORM
+    - *buildkit-mirror-setup
     - if test -n "${DOCKER_PLATFORM}"; then
-      docker context create ci;
-      docker builder create ${DOCKER_BUILDKITARGS} --name ci-builder ci;
-      export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --builder=ci-builder";
+        export DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --platform=${DOCKER_PLATFORM}";
       fi
 
 build:backend:docker:
@@ -219,9 +227,8 @@ build:backend:docker:
     - |-
       make -j$(nproc) -C backend/services/deployments docker \
         DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
-        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER} \
-        DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
-    - make -j$(nproc) -C backend docker DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
+        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
+    - make -j$(nproc) -C backend docker
 
 build:backend:docker-acceptance:
   extends: build:backend:docker
@@ -229,11 +236,10 @@ build:backend:docker-acceptance:
     - *requires-docker
     - apk add make bash git
     - *dind-login
-    # We're only building acceptance test images for CI runner platform.
     - unset DOCKER_PLATFORM
+    - *buildkit-mirror-setup
   script:
-    # NOTE: Only build for test platform (default) for the acceptance test images
-    - make -j$(nproc) -C backend docker-acceptance DOCKER_HUB_BUILD_REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
+    - make -j$(nproc) -C backend docker-acceptance
 
 build:backend:docker-integration-tester:
   extends: .template:build:docker
@@ -242,11 +248,11 @@ build:backend:docker-integration-tester:
     - apk add make bash git
     - *dind-login
     - unset DOCKER_PLATFORM
+    - *buildkit-mirror-setup
   script:
     - docker build ${DOCKER_BUILDARGS}
         --cache-from ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
         -t ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
-        --build-arg REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
         -f backend/tests/Dockerfile.integration
         backend/tests
   rules:

--- a/backend/services/Makefile.common
+++ b/backend/services/Makefile.common
@@ -9,8 +9,6 @@ MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSITORY ?= mendersoftware
 MENDER_PUBLISH_TAG ?= $(MENDER_IMAGE_TAG)
 
-DOCKER_HUB_BUILD_REGISTRY ?= docker.io
-
 bindir ?= $(GIT_ROOT)/bin
 binfile ?= $(bindir)/$(COMPONENT)
 
@@ -57,7 +55,6 @@ docker:
 		-f Dockerfile \
 		--build-arg BUILDFLAGS="$(BUILDFLAGS)" \
 		--build-arg LDFLAGS="$(LDFLAGS)" \
-		--build-arg REGISTRY="$(DOCKER_HUB_BUILD_REGISTRY)" \
 		-t $(DOCKER_TAG) \
 		$(GIT_ROOT)
 

--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDFLAGS="-trimpath"
@@ -44,7 +43,7 @@ RUN \
   BUILDFLAGS="${BUILDFLAGS}" && \
   mkdir /var/cache/create-artifact-worker
 
-FROM ${REGISTRY}/alpine:3.23.4
+FROM alpine:3.23.4
 ARG TARGETARCH
 ARG TARGETOS
 ARG USER=65534:65534

--- a/backend/services/deployments/Dockerfile
+++ b/backend/services/deployments/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-tags nopkcs11 -trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceauth/Dockerfile
+++ b/backend/services/deviceauth/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconfig/Dockerfile
+++ b/backend/services/deviceconfig/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconnect/Dockerfile
+++ b/backend/services/deviceconnect/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/inventory/Dockerfile
+++ b/backend/services/inventory/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/iot-manager/Dockerfile
+++ b/backend/services/iot-manager/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/useradm/Dockerfile
+++ b/backend/services/useradm/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/workflows/Dockerfile
+++ b/backend/services/workflows/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/tests/Dockerfile.acceptance
+++ b/backend/tests/Dockerfile.acceptance
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM ${REGISTRY}/python:3.14-slim-bookworm
+FROM python:3.14-slim-bookworm
 ARG MENDER_ARTIFACT_VERSION=4.4.0
 COPY requirements-acceptance.txt requirements.txt
 RUN apt update && apt install -qy wget && \

--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM ${REGISTRY}/python:3.14-trixie
+FROM python:3.14-trixie
 WORKDIR /tests
 
 # Install mender-artifact

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,4 @@
-ARG REGISTRY=docker.io
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/node:25.9.0-alpine3.22 AS base
+FROM --platform=$BUILDPLATFORM node:25.9.0-alpine3.22 AS base
 WORKDIR /usr/src/app
 RUN apk add --no-cache gzip
 COPY package-lock.json package.json ./
@@ -14,7 +13,7 @@ ENV SENTRY_URL=$SENTRY_URL
 RUN --mount=type=secret,id=sentryAuthToken export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentryAuthToken) && npm run build
 RUN gzip -r -k dist/*
 
-FROM ${REGISTRY}/nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
+FROM nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
 EXPOSE 8090
 WORKDIR /var/www/mender-gui/dist
 ARG GIT_COMMIT_TAG

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -145,23 +145,15 @@ build:frontend:docker:
   # no rules as the job have to build every time for the review jobs
   script:
     - cd frontend
-    - if test -z "${DOCKER_PLATFORM}"; then
-    - docker context create ci;
-    - fi
-    - docker buildx create ${DOCKER_BUILDKITARGS} --name gui-builder --driver=docker-container ci
-    # build production target
-    - docker build
+    - docker build ${DOCKER_BUILDARGS}
       --tag ${MENDER_IMAGE_GUI}
-      --builder=gui-builder
       --build-arg GIT_COMMIT_TAG="${CI_COMMIT_TAG}"
       --build-arg GIT_COMMIT_SHA="${CI_COMMIT_SHA}"
       --build-arg SENTRY_ORG="${SENTRY_ORG}"
       --build-arg SENTRY_URL="${SENTRY_URL}"
-      --build-arg REGISTRY="${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}"
       --secret id=sentryAuthToken,env=SENTRY_AUTH_TOKEN
       --platform ${DOCKER_PLATFORM:-linux/amd64}
       --provenance false
-      --push
       .
     - docker context use ci
     - docker run --rm --entrypoint "/bin/sh" -v $(pwd):/extract ${MENDER_IMAGE_GUI} -c "cp licenses.json /extract/"


### PR DESCRIPTION
Replace the per-Dockerfile ARG REGISTRY  with a
BuildKit registry-mirror config on the ci-builder. Containerd falls back to docker.io on 502 responses.

Ticket: QA-1617

Co-authored-with: Claude