### PR TITLE
test(e2e): wait for settings to be loaded before deciding on email verification

### DIFF
--- a/frontend/tests/e2e_tests/integration/02-baseline/02-settings.spec.ts
+++ b/frontend/tests/e2e_tests/integration/02-baseline/02-settings.spec.ts
@@ -92,6 +92,7 @@ test.describe('Settings', () => {
       test.skip(!emailClient, 'test requires configuring a mailbox');
       await page.getByRole('button', { name: username }).click();
       await page.getByRole('menuitem', { name: 'My profile' }).click();
+      await page.getByText(/Personal access token management/i).waitFor({ timeout: timeouts.default });
 
       test.skip(!(await page.getByText('Not verified').isVisible()), 'email is already verified');
 


### PR DESCRIPTION
to help with failures like in https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/14327862404 where settings are slower to load than the validation check takes to complete (usually due to stripe dependencies taking a while to load afaict) - which then leads to downstream failures in creating the RBAC users