### PR TITLE
fix(pkg): masking error when checking for invalidated cache

### DIFF
--- a/backend/pkg/redis/redis.go
+++ b/backend/pkg/redis/redis.go
@@ -258,7 +258,10 @@ func GetCache(ctx context.Context, c Client, key string) *redis.StringCmd {
 		return cmd
 	}
 	cmd := c.Get(ctx, key)
-	if cmd.Val() == CacheInvalidValue && !IsErrRedisNil(cmd.Err()) {
+	if err := cmd.Err(); err != nil {
+		return cmd
+	}
+	if cmd.Val() == CacheInvalidValue {
 		cmd.SetErr(ErrCacheInvalid)
 	}
 


### PR DESCRIPTION
When getting a value from the cache using the pkg/redis.GetCache, any other error than redis.Nil is masked by ErrCacheInvalid making it appear that the cache was invalidated on any other type of error.