### PR TITLE
test: use specific version of python in integration tests

### DIFF
--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -1,4 +1,4 @@
-FROM python:3.14-trixie
+FROM python:3.14.5-trixie
 WORKDIR /tests
 
 # Install mender-artifact


### PR DESCRIPTION
**Description**

We're experiencing consistent issues with fetching python:3.14-trixie from docker hub / ci mirror. Trying a specific immutable version instead as a workaround.

Ticket: None