### PR TITLE
CI ECR pull-through-cache 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,16 @@ variables:
   MENDER_IMAGE_TAG_TEST: "test-${CI_COMMIT_SHA}"
   MENDER_IMAGE_TAG_BUILDER: "builder-${CI_COMMIT_SHA}"
 
+  AWS_REGION:
+    value: "eu-central-1"
+    description: "AWS region of the ECR pull-through cache registry"
+  ECR_REGISTRY:
+    value: "017659451055.dkr.ecr.eu-central-1.amazonaws.com"
+    description: "ECR registry endpoint that fronts the Docker Hub pull-through cache"
+  MIRROR_REGISTRY:
+    value: "017659451055.dkr.ecr.eu-central-1.amazonaws.com/dockerhub"
+    description: "Registry mirror for Docker Hub images - used in Dockerfiles (--build-arg REGISTRY) and docker-compose files"
+
   GOCOVERDIR: "${CI_PROJECT_DIR}/backend/tests/cover"
 
   # release and changelog generators
@@ -169,6 +179,10 @@ renovate:
   - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
   - docker login --username $CI_DEPENDENCY_PROXY_USER --password $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
 
+.ecr-login: &ecr-login
+  - if ! command -v aws > /dev/null 2>&1; then apk add --no-cache aws-cli; fi
+  - aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
 .buildx-builder-setup: &buildx-builder-setup
   - docker context create ci
   - docker buildx create --name ci-builder --driver=docker-container ci
@@ -203,6 +217,7 @@ renovate:
     - *requires-docker
     - apk add make bash git
     - *dind-login
+    - *ecr-login
     - test "$CI_COMMIT_REF_PROTECTED" != "true" && unset DOCKER_PLATFORM
     - *buildx-builder-setup
     - if test -n "${DOCKER_PLATFORM}"; then
@@ -219,8 +234,9 @@ build:backend:docker:
     - |-
       make -j$(nproc) -C backend/services/deployments docker \
         DOCKER_BUILDARGS="${DOCKER_BUILDARGS} --target builder" \
-        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER}
-    - make -j$(nproc) -C backend docker
+        MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_BUILDER} \
+        MIRROR_REGISTRY="${MIRROR_REGISTRY}"
+    - make -j$(nproc) -C backend docker MIRROR_REGISTRY="${MIRROR_REGISTRY}"
 
 build:backend:docker-acceptance:
   extends: build:backend:docker
@@ -228,10 +244,11 @@ build:backend:docker-acceptance:
     - *requires-docker
     - apk add make bash git
     - *dind-login
+    - *ecr-login
     - unset DOCKER_PLATFORM
     - *buildx-builder-setup
   script:
-    - make -j$(nproc) -C backend docker-acceptance
+    - make -j$(nproc) -C backend docker-acceptance MIRROR_REGISTRY="${MIRROR_REGISTRY}"
 
 build:backend:docker-integration-tester:
   extends: .template:build:docker
@@ -239,12 +256,14 @@ build:backend:docker-integration-tester:
     - *requires-docker
     - apk add make bash git
     - *dind-login
+    - *ecr-login
     - unset DOCKER_PLATFORM
     - *buildx-builder-setup
   script:
     - docker build ${DOCKER_BUILDARGS}
         --cache-from ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
         -t ${CI_REGISTRY_IMAGE}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}
+        --build-arg REGISTRY="${MIRROR_REGISTRY}"
         -f backend/tests/Dockerfile.integration
         backend/tests
   rules:
@@ -553,6 +572,7 @@ test:backend:acceptance:
     - *requires-docker
     - apk add make bash git
     - *dind-login
+    - *ecr-login
     - make -C backend -j 4 docker-pull
     - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=${MENDER_IMAGE_TAG_TEST}
     - mkdir -p $GOCOVERDIR
@@ -595,6 +615,7 @@ test:backend:acceptance:
     - *requires-docker
     - apk add make bash git curl jq
     - *dind-login
+    - *ecr-login
     - make -C backend -j 4 docker-pull MENDER_IMAGE_TAG=$MENDER_IMAGE_TAG_TEST
 
 test:backend:integration:

--- a/backend/services/Makefile.common
+++ b/backend/services/Makefile.common
@@ -9,6 +9,8 @@ MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSITORY ?= mendersoftware
 MENDER_PUBLISH_TAG ?= $(MENDER_IMAGE_TAG)
 
+MIRROR_REGISTRY ?= docker.io
+
 bindir ?= $(GIT_ROOT)/bin
 binfile ?= $(bindir)/$(COMPONENT)
 
@@ -55,6 +57,7 @@ docker:
 		-f Dockerfile \
 		--build-arg BUILDFLAGS="$(BUILDFLAGS)" \
 		--build-arg LDFLAGS="$(LDFLAGS)" \
+		--build-arg REGISTRY="$(MIRROR_REGISTRY)" \
 		-t $(DOCKER_TAG) \
 		$(GIT_ROOT)
 

--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 as builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 as builder
 ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDFLAGS="-trimpath"
@@ -43,7 +44,7 @@ RUN \
   BUILDFLAGS="${BUILDFLAGS}" && \
   mkdir /var/cache/create-artifact-worker
 
-FROM alpine:3.23.4
+FROM ${REGISTRY}/library/alpine:3.23.4
 ARG TARGETARCH
 ARG TARGETOS
 ARG USER=65534:65534

--- a/backend/services/deployments/Dockerfile
+++ b/backend/services/deployments/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-tags nopkcs11 -trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceauth/Dockerfile
+++ b/backend/services/deviceauth/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconfig/Dockerfile
+++ b/backend/services/deviceconfig/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconfig/tests/docker-compose.yml
+++ b/backend/services/deviceconfig/tests/docker-compose.yml
@@ -6,7 +6,7 @@ include:
 
 services:
   mmock:
-      image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.0.0"
+      image: "${MIRROR_REGISTRY:-docker.io}/jordimartin/mmock:v3.0.0"
       command: ["-server-ip", "0.0.0.0", "-console-ip", "0.0.0.0", "-server-port", "8080"]
       ports:
         - "8082:8082"

--- a/backend/services/deviceconnect/Dockerfile
+++ b/backend/services/deviceconnect/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"

--- a/backend/services/deviceconnect/tests/docker-compose.acceptance.yml
+++ b/backend/services/deviceconnect/tests/docker-compose.acceptance.yml
@@ -14,7 +14,7 @@ services:
       - deviceconnect
 
   mmock:
-    image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.0.0"
+    image: "${MIRROR_REGISTRY:-docker.io}/jordimartin/mmock:v3.0.0"
     networks:
       default:
         aliases:

--- a/backend/services/inventory/Dockerfile
+++ b/backend/services/inventory/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/iot-manager/Dockerfile
+++ b/backend/services/iot-manager/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/iot-manager/tests/docker-compose.acceptance.yml
+++ b/backend/services/iot-manager/tests/docker-compose.acceptance.yml
@@ -15,7 +15,7 @@ services:
       - iot-manager
 
   mmock:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v3.1.6
+    image: ${MIRROR_REGISTRY:-docker.io}/jordimartin/mmock:v3.1.6
     command:
       - "-config-path=/config"
       - "-console-ip=0.0.0.0"

--- a/backend/services/useradm/Dockerfile
+++ b/backend/services/useradm/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/useradm/tests/docker-compose.yml
+++ b/backend/services/useradm/tests/docker-compose.yml
@@ -5,7 +5,7 @@ include:
     - docker-compose.acceptance.yml
 services:
   mmock:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v2.7.6
+    image: ${MIRROR_REGISTRY:-docker.io}/jordimartin/mmock:v2.7.6
     command:
       - -server-ip
       - 0.0.0.0

--- a/backend/services/workflows/Dockerfile
+++ b/backend/services/workflows/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:1.26.2 AS builder
 
 ARG BUILDFLAGS="-trimpath"
 ARG LDFLAGS="-s -w"

--- a/backend/services/workflows/tests/docker-compose.yml
+++ b/backend/services/workflows/tests/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       service: nats
 
   mmock:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/jordimartin/mmock:v2.7.6
+    image: ${MIRROR_REGISTRY:-docker.io}/jordimartin/mmock:v2.7.6
     command:
       [
         "-server-ip",

--- a/backend/tests/Dockerfile.acceptance
+++ b/backend/tests/Dockerfile.acceptance
@@ -1,4 +1,5 @@
-FROM python:3.14-slim-bookworm
+ARG REGISTRY=docker.io
+FROM ${REGISTRY}/library/python:3.14-slim-bookworm
 ARG MENDER_ARTIFACT_VERSION=4.4.0
 COPY requirements-acceptance.txt requirements.txt
 RUN apt update && apt install -qy wget && \

--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -1,4 +1,5 @@
-FROM python:3.14-trixie
+ARG REGISTRY=docker.io
+FROM ${REGISTRY}/library/python:3.14-trixie
 WORKDIR /tests
 
 # Install mender-artifact

--- a/backend/tests/docker/docker-compose.backend-tests-compat.yml
+++ b/backend/tests/docker/docker-compose.backend-tests-compat.yml
@@ -3,7 +3,7 @@ services:
     command:
       - integration_compat
   mender-client-2-0:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.0.1
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.0.1
     scale: 1
     stdin_open: true
     tty: true
@@ -16,67 +16,67 @@ services:
   mender-client-2-1:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.1.3
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.1.3
   mender-client-2-2:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.2.1
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.2.1
   mender-client-2-3:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.3.2
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.3.2
   mender-client-2-4:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.4.2
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.4.2
   mender-client-2-5:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.5.4
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.5.4
   mender-client-2-6:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:2.6.1
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:2.6.1
   mender-client-3-0:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:3.0.2
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:3.0.2
   mender-client-3-1:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:3.1.1
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:3.1.1
   mender-client-3-2:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.2.2
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.2.2
   mender-client-3-3:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.3.2
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.3.2
   mender-client-3-4:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.4.0
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.4.0
   mender-client-3-5:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.5.1
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.5.1
   mender-client-3-6:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.6.5
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.6.5
   mender-client-3-7:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:mender-3.7.9
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:mender-3.7.9
   mender-client-5.0.0:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker:client-5.0.0
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker:client-5.0.0
   mender-client-6.0.0:
     extends:
       service: mender-client-2-0
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mendersoftware/mender-client-docker-addons:client-6.0.0
+    image: ${MIRROR_REGISTRY:-docker.io}/mendersoftware/mender-client-docker-addons:client-6.0.0
     configs:
       - source: server_cert
         target: /etc/mender/server.crt

--- a/backend/tests/docker/docker-compose.backend-tests.yml
+++ b/backend/tests/docker/docker-compose.backend-tests.yml
@@ -62,7 +62,7 @@ services:
     volumes:
       - ${GOCOVERDIR:-cover}:/cover
   mock-httpd:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mockserver/mockserver:5.15.0
+    image: ${MIRROR_REGISTRY:-docker.io}/mockserver/mockserver:5.15.0
 
 volumes:
   cover: {}

--- a/compose/docker-compose.enterprise.yml
+++ b/compose/docker-compose.enterprise.yml
@@ -175,7 +175,7 @@ services:
     image: ${MENDER_IMAGE_REGISTRY:-registry.mender.io}/${MENDER_IMAGE_REPOSITORY:-mender-server-enterprise}/workflows:${MENDER_IMAGE_TAG:-latest}
 
   redis:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/redis:8.6
+    image: ${MIRROR_REGISTRY:-docker.io}/library/redis:8.6
     networks:
       default:
         aliases: [mender-redis]

--- a/compose/docker-compose.seaweedfs.yml
+++ b/compose/docker-compose.seaweedfs.yml
@@ -24,7 +24,7 @@ configs:
 
 services:
   s3-master:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
+    image: ${MIRROR_REGISTRY:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - master
       - -mdir=/data
@@ -37,7 +37,7 @@ services:
       - s3:/data
 
   s3-volume:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
+    image: ${MIRROR_REGISTRY:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - volume
       - -mserver=s3-master:9333
@@ -51,7 +51,7 @@ services:
       - s3:/data
 
   s3-filer:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
+    image: ${MIRROR_REGISTRY:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - filer
       - -master=s3-master:9333
@@ -63,7 +63,7 @@ services:
       - s3:/data
 
   s3:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/chrislusf/seaweedfs:4.22
+    image: ${MIRROR_REGISTRY:-docker.io}/chrislusf/seaweedfs:4.22
     command:
       - s3
       - -port=8080

--- a/compose/docker-compose.smtp4dev.yml
+++ b/compose/docker-compose.smtp4dev.yml
@@ -4,7 +4,7 @@
 # A web interface for the inbox can be accessed on port 8025 on your machine.
 services:
   smtp4dev:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/rnwood/smtp4dev:3.15.0
+    image: ${MIRROR_REGISTRY:-docker.io}/rnwood/smtp4dev:3.15.0
     ports:
       # Change the number before : to the port the web interface should be accessible on
       # Add 127.0.0.1: prefix for localhost-only access (recommended for security)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,7 +341,7 @@ services:
       default:
         aliases: [mender-workflows]
   traefik:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/traefik:v3.6.15
+    image: ${MIRROR_REGISTRY:-docker.io}/library/traefik:v3.6.15
     command:
       - --api=true
       - --api.insecure=true
@@ -382,7 +382,7 @@ services:
           - s3.docker.mender.io
 
   mongo:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/mongo:${MONGO_VERSION:-8.0}
+    image: ${MIRROR_REGISTRY:-docker.io}/library/mongo:${MONGO_VERSION:-8.0}
     healthcheck:
       test: ["CMD", "mongosh", "mongodb://localhost:27017/test", "--quiet", "--eval", "db.runCommand('ping').ok"]
       interval: 10s
@@ -399,7 +399,7 @@ services:
         aliases: [mender-mongo]
 
   nats:
-    image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX:-docker.io}/nats:2.14-alpine
+    image: ${MIRROR_REGISTRY:-docker.io}/library/nats:2.14-alpine
     command: [-js, -m, '8222']
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8222/healthz | grep -q 'ok'"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM node:25.9.0-alpine3.22 AS base
+ARG REGISTRY=docker.io
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/node:25.9.0-alpine3.22 AS base
 WORKDIR /usr/src/app
 RUN apk add --no-cache gzip
 COPY package-lock.json package.json ./
@@ -13,7 +14,7 @@ ENV SENTRY_URL=$SENTRY_URL
 RUN --mount=type=secret,id=sentryAuthToken export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentryAuthToken) && npm run build
 RUN gzip -r -k dist/*
 
-FROM nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
+FROM ${REGISTRY}/nginxinc/nginx-unprivileged:1.29.3-alpine3.22-slim AS unprivileged
 EXPOSE 8090
 WORKDIR /var/www/mender-gui/dist
 ARG GIT_COMMIT_TAG

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -151,6 +151,7 @@ build:frontend:docker:
       --build-arg GIT_COMMIT_SHA="${CI_COMMIT_SHA}"
       --build-arg SENTRY_ORG="${SENTRY_ORG}"
       --build-arg SENTRY_URL="${SENTRY_URL}"
+      --build-arg REGISTRY="${MIRROR_REGISTRY}"
       --secret id=sentryAuthToken,env=SENTRY_AUTH_TOKEN
       --platform ${DOCKER_PLATFORM:-linux/amd64}
       --provenance false
@@ -185,6 +186,7 @@ build:frontend:docker:
   before_script:
     - !reference [.requires-docker]
     - !reference [.dind-login]
+    - !reference [.ecr-login]
     - npm i --prefix frontend/tests/e2e_tests
   artifacts:
     expire_in: 2w


### PR DESCRIPTION
Pull containers from Amazon ECR which is a pass-through cache for docker.io

Ticket: QA-1643

Co-authored-with: Claude

Requires:
* [x] https://github.com/mendersoftware/saas/pull/1850
* [x] https://github.com/NorthernTechHQ/nt-iac/pull/527
* [x] https://github.com/mendersoftware/mender-test-containers/pull/710