### PR TITLE
CI: prevent IAM user overwrite

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,9 @@ renovate:
 
 .ecr-login: &ecr-login
   - if ! command -v aws > /dev/null 2>&1; then apk add --no-cache aws-cli; fi
-  - aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+  - /usr/bin/env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN
+    aws ecr get-login-password --region "${AWS_REGION}"
+    | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
 .buildx-builder-setup: &buildx-builder-setup
   - docker context create ci


### PR DESCRIPTION
The script is inheriting by default the IAM user from the AWS_ACCESS_KEY_ID variable already set in Gitlab Group level, out-of-scope in this project - unsetting the variables to prevent user replacement