### PR TITLE
ci: retry internal gitlab runner job stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,14 @@ variables:
       - "true"
       - "false"
 
+  # Retries for internal Gitlab Runner job stages:
+  #   - https://docs.gitlab.com/ci/runners/configure_runners/#job-stages-attempts
+  # Used to workaround spurious 502s returned from gitlab.com during pipeline creation.
+  ARTIFACT_DOWNLOAD_ATTEMPTS: 2
+  EXECUTOR_JOB_SECTION_ATTEMPTS: 2
+  GET_SOURCES_ATTEMPTS: 2
+  RESTORE_CACHE_ATTEMPTS: 2
+
 include:
   - project: Northern.tech/Mender/mendertesting
     file:


### PR DESCRIPTION
**Description**

Add retries to internal gitlab runner job stages. The default for each of these are `1` (e.g they're not retries). My hope is that setting these will work around issues we're having where jobs fail before our own stuff even starts. For example, my hope is that setting `GET_SOURCES_ATTEMPTS` will mitigate issues like these: https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/14523408479.

The others I have less of direct proof is happening, but I rather just add retries for them while I'm at it as I don't really see the harm.

Ticket: None