### PR TITLE
fix(deployments): remove shadowing of ReleaseBase `kind` property

### DIFF
--- a/backend/services/deployments/model/software.go
+++ b/backend/services/deployments/model/software.go
@@ -25,7 +25,6 @@ func (s SoftwareTagsFilter) Validate() error {
 
 type Software struct {
 	ReleaseBase `bson:"inline"`
-	Kind        ReleaseKind `json:"kind" bson:"kind,omitempty"`
 }
 
 // custom marshal to include the kind in the response


### PR DESCRIPTION
**Description**

Kind is already a property of ReleaseBase which was being shadowed here. The value was being written into this value instead of the ReleaseBase.Kind value and the database layer incorrectly sees that there is no ReleaseBase.Kind and sets it to "release" even for manifests.

We can't really create manifests in os so adding tests for this here is not really doable. I'll follow-up with a PR in enterprise that adds test coverage for this.

Ticket: MEN-9753