### PR TITLE
Add compatible_types to list software

### DIFF
--- a/backend/docs/api/deployments/management_v1alpha1.yaml
+++ b/backend/docs/api/deployments/management_v1alpha1.yaml
@@ -163,6 +163,15 @@ components:
           description: Last modification time for the Software.
           format: date-time
           type: string
+        compatible_types:
+          description: |
+            The "types" compatible with at least one of the Artifacts of 
+            the Software.  If the kind of Software is 'release', these types are 
+            "device types" while they are "system types" in the case of 'manifest'
+            Software kind.
+          type: array
+          items:
+            type: string
         kind:
           enum:
             - release

--- a/backend/docs/api/dist/openapi.yaml
+++ b/backend/docs/api/dist/openapi.yaml
@@ -8821,6 +8821,15 @@ components:
           description: Last modification time for the Software.
           format: date-time
           type: string
+        compatible_types:
+          description: |
+            The "types" compatible with at least one of the Artifacts of 
+            the Software.  If the kind of Software is 'release', these types are 
+            "device types" while they are "system types" in the case of 'manifest'
+            Software kind.
+          type: array
+          items:
+            type: string
         kind:
           enum:
             - release

--- a/backend/pkg/api/client/model_software.go
+++ b/backend/pkg/api/client/model_software.go
@@ -26,6 +26,8 @@ type Software struct {
 	Name string `json:"name"`
 	// Last modification time for the Software.
 	Modified *time.Time `json:"modified,omitempty"`
+	// The \"types\" compatible with at least one of the Artifacts of  the Software.  If the kind of Software is 'release', these types are  \"device types\" while they are \"system types\" in the case of 'manifest' Software kind. 
+	CompatibleTypes []string `json:"compatible_types,omitempty"`
 	Kind string `json:"kind"`
 	// Tags assigned to the Software used for filtering. Each tag must be valid a ASCII string and contain only lowercase and uppercase letters, digits, underscores, periods and hyphens.
 	Tags []string `json:"tags,omitempty"`
@@ -109,6 +111,38 @@ func (o *Software) HasModified() bool {
 // SetModified gets a reference to the given time.Time and assigns it to the Modified field.
 func (o *Software) SetModified(v time.Time) {
 	o.Modified = &v
+}
+
+// GetCompatibleTypes returns the CompatibleTypes field value if set, zero value otherwise.
+func (o *Software) GetCompatibleTypes() []string {
+	if o == nil || IsNil(o.CompatibleTypes) {
+		var ret []string
+		return ret
+	}
+	return o.CompatibleTypes
+}
+
+// GetCompatibleTypesOk returns a tuple with the CompatibleTypes field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Software) GetCompatibleTypesOk() ([]string, bool) {
+	if o == nil || IsNil(o.CompatibleTypes) {
+		return nil, false
+	}
+	return o.CompatibleTypes, true
+}
+
+// HasCompatibleTypes returns a boolean if a field has been set.
+func (o *Software) HasCompatibleTypes() bool {
+	if o != nil && !IsNil(o.CompatibleTypes) {
+		return true
+	}
+
+	return false
+}
+
+// SetCompatibleTypes gets a reference to the given []string and assigns it to the CompatibleTypes field.
+func (o *Software) SetCompatibleTypes(v []string) {
+	o.CompatibleTypes = v
 }
 
 // GetKind returns the Kind field value
@@ -213,6 +247,9 @@ func (o Software) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Modified) {
 		toSerialize["modified"] = o.Modified
 	}
+	if !IsNil(o.CompatibleTypes) {
+		toSerialize["compatible_types"] = o.CompatibleTypes
+	}
 	toSerialize["kind"] = o.Kind
 	if !IsNil(o.Tags) {
 		toSerialize["tags"] = o.Tags
@@ -266,6 +303,7 @@ func (o *Software) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "modified")
+		delete(additionalProperties, "compatible_types")
 		delete(additionalProperties, "kind")
 		delete(additionalProperties, "tags")
 		delete(additionalProperties, "notes")

--- a/backend/services/deployments/model/software.go
+++ b/backend/services/deployments/model/software.go
@@ -25,17 +25,33 @@ func (s SoftwareTagsFilter) Validate() error {
 
 type Software struct {
 	ReleaseBase `bson:"inline"`
+	Artifacts   []Image `json:"-" bson:"artifacts"`
 }
 
-// custom marshal to include the kind in the response
+// custom marshal to include the kind and compatible_types in the response
 func (s Software) MarshalJSON() ([]byte, error) {
+	var compatible_types []string
+	for _, a := range s.Artifacts {
+		compatible_types = append(
+			compatible_types,
+			a.DeviceTypesCompatible...,
+		)
+	}
+
 	type Alias Software
 	return json.Marshal(&struct {
 		Alias
 		Kind ReleaseKind `json:"kind"` // expose Kind
+		// CompatibleTypes is the external name adopted by `mender-artifact`
+		// for what is still `device_types_compatible` in the actual artifact
+		// format. The reason for the name change is that `device_types_compatible``
+		// can also hold `system_types_compatible` in the case where the Software
+		// (aka Artifact) is a Manifest
+		CompatibleTypes []string `json:"compatible_types"`
 	}{
-		Alias: (Alias)(s),
-		Kind:  s.ReleaseBase.Kind,
+		Alias:           (Alias)(s),
+		Kind:            s.ReleaseBase.Kind,
+		CompatibleTypes: compatible_types,
 	})
 }
 

--- a/backend/tests/mender_client/models/software.py
+++ b/backend/tests/mender_client/models/software.py
@@ -30,10 +30,11 @@ class Software(BaseModel):
     """ # noqa: E501
     name: StrictStr = Field(description="The name of the Software.")
     modified: Optional[datetime] = Field(default=None, description="Last modification time for the Software.")
+    compatible_types: Optional[List[StrictStr]] = Field(default=None, description="The \"types\" compatible with at least one of the Artifacts of  the Software.  If the kind of Software is 'release', these types are  \"device types\" while they are \"system types\" in the case of 'manifest' Software kind. ")
     kind: StrictStr
     tags: Optional[List[StrictStr]] = Field(default=None, description="Tags assigned to the Software used for filtering. Each tag must be valid a ASCII string and contain only lowercase and uppercase letters, digits, underscores, periods and hyphens.")
     notes: Optional[StrictStr] = Field(default=None, description="Additional information describing a Software limited to 1024 characters. ")
-    __properties: ClassVar[List[str]] = ["name", "modified", "kind", "tags", "notes"]
+    __properties: ClassVar[List[str]] = ["name", "modified", "compatible_types", "kind", "tags", "notes"]
 
     @field_validator('kind')
     def kind_validate_enum(cls, value):
@@ -95,6 +96,7 @@ class Software(BaseModel):
         _obj = cls.model_validate({
             "name": obj.get("name"),
             "modified": obj.get("modified"),
+            "compatible_types": obj.get("compatible_types"),
             "kind": obj.get("kind"),
             "tags": obj.get("tags"),
             "notes": obj.get("notes")

--- a/backend/tests/runner/tests/opensource/deployments_management_v1alpha1_test.go
+++ b/backend/tests/runner/tests/opensource/deployments_management_v1alpha1_test.go
@@ -142,6 +142,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 			})
 
 		}
+
 		// create a release with update type
 		name := fmt.Sprintf("test-not-a-manifest-%s", uuid.NewString())
 		i := handlers.NewModuleImage("definitely-not-a-manifest")
@@ -184,6 +185,36 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 		// there shoud be minimum 3 softwares.
 		require.True(u.T(), len(softwares) > 2)
 		require.NotEmpty(u.T(), res.Header.Get("X-Total-Count"))
+	})
+
+	u.Run("Success/CompatibleTypes", func() {
+		var (
+			ctx     = common.JWTAuthContext(u.T().Context(), u.JWT)
+			require = require.New(u.T())
+		)
+
+		// add second artifact to first release
+		i := handlers.NewModuleImage("single-file")
+		artifact, err := createArtifact(
+			allSoftwares[0].Name,
+			u.T(),
+			withModuleImage(i),
+			withCompatibleDevices([]string{"device-type-2"}),
+		)
+		require.NoError(err)
+		_, err = u.uploadArtifact(ctx, artifact, nil)
+		require.NoError(err)
+
+		softwares, _, err := u.APIClient.DeploymentsV1alpha1ManagementAPIAPI.
+			GetDeploymentSoftware(ctx).
+			Name([]string{allSoftwares[0].Name}).
+			Execute()
+		require.NoError(err)
+		require.Len(softwares, 1, "expected one software to be returned")
+		require.ElementsMatch(
+			[]string{"device-type-1", "device-type-2"},
+			softwares[0].GetCompatibleTypes(),
+		)
 	})
 
 	u.Run("Success/FilterExactName", func() {
@@ -345,13 +376,9 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 
 	u.Run("Success/Sort", func() {
 		ctx := u.T().Context()
-		createdOrder := []client.Software{
-			allSoftwares[0], allSoftwares[1],
-		}
-		reversedOrder := []client.Software{
-			allSoftwares[1], allSoftwares[0],
-		}
+
 		// name:asc is the default, we don't need to test it
+		nameDescOrder := []client.Software{allSoftwares[1], allSoftwares[0]}
 		softwares, _, err := u.APIClient.DeploymentsV1alpha1ManagementAPIAPI.
 			GetDeploymentSoftware(common.JWTAuthContext(ctx, u.JWT)).
 			Sort("name:desc").
@@ -359,7 +386,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 			Execute()
 		require.NoError(u.T(), err)
 
-		err = compareSoftwares(softwares, reversedOrder...)
+		err = compareSoftwares(softwares, nameDescOrder...)
 		require.NoError(u.T(), err)
 
 		softwares, _, err = u.APIClient.DeploymentsV1alpha1ManagementAPIAPI.
@@ -369,9 +396,11 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 			Execute()
 		require.NoError(u.T(), err)
 
-		err = compareSoftwares(softwares, createdOrder...)
+		updatedOrder := []client.Software{allSoftwares[1], allSoftwares[0]}
+		err = compareSoftwares(softwares, updatedOrder...)
 		require.NoError(u.T(), err)
 
+		updatedDescOrder := []client.Software{allSoftwares[0], allSoftwares[1]}
 		softwares, _, err = u.APIClient.DeploymentsV1alpha1ManagementAPIAPI.
 			GetDeploymentSoftware(common.JWTAuthContext(ctx, u.JWT)).
 			Sort("modified:desc").
@@ -379,7 +408,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 			Execute()
 		require.NoError(u.T(), err)
 
-		err = compareSoftwares(softwares, reversedOrder...)
+		err = compareSoftwares(softwares, updatedDescOrder...)
 		require.NoError(u.T(), err)
 	})
 }


### PR DESCRIPTION
**Description**

Adds `compatible_types` to software returned from the list software endpoint. `compatible_types` is the name adopted by mender-artifact to cover both `device_types_compatible` (normal Artifact) and `system_types_compatible` (Manifest) and since Software wraps both of those I kept the same name here (it's all still just `device_types_compatible` in the Artifact though). 