### PR TITLE
Fix deviceconnect stream close error handling and improve rest errors

### DIFF
--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -75,7 +75,12 @@ func (a AccessLogger) LogFunc(
 		lc.addFields(logCtx)
 	}
 	if r := recover(); r != nil {
-		trace := log.CollectTrace()
+		// Skip 4
+		// = accesslog.LogFunc
+		// + log.CollectTrace
+		// + runtime.Callers
+		// + runtime.gopanic
+		trace := log.CollectTrace(4)
 		logCtx["trace"] = trace
 		logCtx["panic"] = r
 

--- a/backend/pkg/log/recovery.go
+++ b/backend/pkg/log/recovery.go
@@ -15,17 +15,12 @@ var (
 	ErrPanic = errors.New("recovered from panic")
 )
 
-func CollectTrace() string {
+func CollectTrace(skip int) string {
 	var (
 		trace     [MaxTraceback]uintptr
 		traceback strings.Builder
 	)
-	// Skip 4
-	// = accesslog.LogFunc
-	// + accesslog.collectTrace
-	// + runtime.Callers
-	// + runtime.gopanic
-	n := runtime.Callers(4, trace[:])
+	n := runtime.Callers(skip, trace[:])
 	frames := runtime.CallersFrames(trace[:n])
 	for frame, more := frames.Next(); frame.PC != 0 &&
 		n >= 0; frame, more = frames.Next() {
@@ -73,7 +68,11 @@ func (l *Logger) SimpleRecovery(opts ...*RecoveryOption) {
 	if r == nil {
 		return
 	}
-	trace := CollectTrace()
+	// = log.SimpleRecovery
+	// + log.CollectTrace
+	// + runtime.Callers
+	// + runtime.gopanic
+	trace := CollectTrace(4)
 	var err error
 	var opt *RecoveryOption
 	if len(opts) > 0 {

--- a/backend/pkg/rest.utils/utils.go
+++ b/backend/pkg/rest.utils/utils.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mendersoftware/mender-server/pkg/log"
 	"github.com/mendersoftware/mender-server/pkg/requestid"
 )
 
@@ -28,13 +29,29 @@ func RenderError(c *gin.Context, code int, err error) {
 }
 
 func RenderErrorWithMessage(c *gin.Context, code int, err error, apiMessage string) {
+	// Wrap the private function to give equal call depth.
+	renderErrorWithMessage(c, code, err, apiMessage)
+}
+
+func renderErrorWithMessage(c *gin.Context, code int, err error, apiMessage string) {
 	ctx := c.Request.Context()
 	_ = c.Error(err)
 	err = &Error{
 		Err:       apiMessage,
 		RequestID: requestid.FromContext(ctx),
 	}
-	c.JSON(code, err)
+	if c.Writer.Written() {
+		// Skip 4
+		// = rest.Render*
+		// + rest.renderErrorWithMessage
+		// + log.CollectTrace
+		// + runtime.Callers
+		log.FromContext(ctx).
+			WithField("trace", log.CollectTrace(4)).
+			Error("response already written")
+	} else {
+		c.JSON(code, err)
+	}
 }
 
 func RenderInternalError(c *gin.Context, err error) {

--- a/backend/pkg/rest.utils/utils.go
+++ b/backend/pkg/rest.utils/utils.go
@@ -24,13 +24,7 @@ import (
 )
 
 func RenderError(c *gin.Context, code int, err error) {
-	ctx := c.Request.Context()
-	_ = c.Error(err)
-	err = &Error{
-		Err:       err.Error(),
-		RequestID: requestid.FromContext(ctx),
-	}
-	c.JSON(code, err)
+	RenderErrorWithMessage(c, code, err, err.Error())
 }
 
 func RenderErrorWithMessage(c *gin.Context, code int, err error, apiMessage string) {
@@ -44,31 +38,23 @@ func RenderErrorWithMessage(c *gin.Context, code int, err error, apiMessage stri
 }
 
 func RenderInternalError(c *gin.Context, err error) {
-	msg := "internal error"
-	if err != nil {
-		RenderErrorWithMessage(c,
-			http.StatusInternalServerError,
-			err, msg,
-		)
-		return
+	const msg = "internal error"
+	if err == nil {
+		err = errors.New(msg)
 	}
-	RenderError(c,
+	RenderErrorWithMessage(c,
 		http.StatusInternalServerError,
-		errors.New(msg),
+		err, msg,
 	)
 }
 
 func RenderUnavailable(c *gin.Context, err error) {
-	msg := "service unavailable"
-	if err != nil {
-		RenderErrorWithMessage(c,
-			http.StatusServiceUnavailable,
-			err, msg,
-		)
-		return
+	const msg = "service unavailable"
+	if err == nil {
+		err = errors.New(msg)
 	}
-	RenderError(c,
+	RenderErrorWithMessage(c,
 		http.StatusServiceUnavailable,
-		errors.New(msg),
+		err, msg,
 	)
 }

--- a/backend/services/deviceconnect/api/http/device.go
+++ b/backend/services/deviceconnect/api/http/device.go
@@ -271,12 +271,19 @@ func (h DeviceController) handleManagementMessages(
 	errChan chan<- error,
 ) {
 	l := log.FromContext(ctx)
+	streamErr := make(chan error, 1)
 	defer close(errChan)
 	for {
 		s, err := listener.Accept(ctx)
 		if err != nil {
-			if errors.Is(err, stream.ErrClosed) {
-				return
+			if errors.Is(err, stream.ErrClosed) ||
+				errors.Is(err, context.Canceled) {
+				select {
+				case err = <-streamErr:
+				// Listener was closed by sub routine
+				default:
+					return
+				}
 			}
 			l.Errorf("error accepting connections: %s", err.Error())
 			select {
@@ -298,10 +305,13 @@ func (h DeviceController) handleManagementMessages(
 			for {
 				data, err := s.Recv(ctx)
 				if err != nil {
-					if !errors.Is(err, io.EOF) && !errors.Is(err, stream.ErrClosed) {
+					if !errors.Is(err, io.EOF) &&
+						!errors.Is(err, stream.ErrClosed) &&
+						!errors.Is(err, context.Canceled) {
 						l.Errorf("fatal error on channel: %s", err.Error())
 						select {
-						case errChan <- err:
+						case streamErr <- err:
+							_ = listener.Close(ctx)
 						default:
 						}
 					}
@@ -311,7 +321,8 @@ func (h DeviceController) handleManagementMessages(
 				if err != nil {
 					l.Errorf("fatal error writing to websocket: %s", err.Error())
 					select {
-					case errChan <- err:
+					case streamErr <- err:
+						_ = listener.Close(ctx)
 					default:
 					}
 					return

--- a/backend/services/deviceconnect/api/http/device.go
+++ b/backend/services/deviceconnect/api/http/device.go
@@ -298,9 +298,8 @@ func (h DeviceController) handleManagementMessages(
 			for {
 				data, err := s.Recv(ctx)
 				if err != nil {
-					if !errors.Is(err, io.EOF) {
+					if !errors.Is(err, io.EOF) && !errors.Is(err, stream.ErrClosed) {
 						l.Errorf("fatal error on channel: %s", err.Error())
-					} else {
 						select {
 						case errChan <- err:
 						default:

--- a/backend/services/deviceconnect/api/http/management.go
+++ b/backend/services/deviceconnect/api/http/management.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"sync"
@@ -332,7 +333,7 @@ func writerFinalizer(conn *websocket.Conn, e *error, l *log.Logger) {
 			if closeErr.Code == websocket.CloseNormalClosure {
 				return
 			}
-		} else {
+		} else if !errors.Is(err, net.ErrClosed) && !errors.Is(err, context.Canceled) {
 			errClose := conn.WriteControl(websocket.CloseMessage,
 				websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "internal error"),
 				time.Now().Add(writeWait),

--- a/backend/services/deviceconnect/api/http/management_filetransfer.go
+++ b/backend/services/deviceconnect/api/http/management_filetransfer.go
@@ -256,6 +256,7 @@ func (h ManagementController) handleResponseError(c *gin.Context, err error) {
 			statusCode = http.StatusRequestTimeout
 		default:
 			rest.RenderInternalError(c, err)
+			return
 		}
 		rest.RenderError(c, statusCode, err)
 	} else {


### PR DESCRIPTION
* Closing a NATS stream should not terminate the connection
* Refactored rest.utils error rendering utilities
* Prevent writing duplicate error responses if one is already written
  * write a meaningful log message instead