### PR TITLE
ci: remove AWS env var unsetting workaround from ECR login

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,8 +189,7 @@ renovate:
 
 .ecr-login: &ecr-login
   - if ! command -v aws > /dev/null 2>&1; then apk add --no-cache aws-cli; fi
-  - /usr/bin/env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN
-    aws ecr get-login-password --region "${AWS_REGION}"
+  - aws ecr get-login-password --region "${AWS_REGION}"
     | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
 .buildx-builder-setup: &buildx-builder-setup


### PR DESCRIPTION
## Summary

Removes the `/usr/bin/env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN` prefix from the ECR login step.

This workaround was added because the Mender GitLab group variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (tied to the `jenkins-mender` S3-only IAM user) were inherited on protected branches and caused `AccessDeniedException` when the AWS CLI tried to use them for ECR operations.

⚠️ This PR should be merged **after** the sre-tools roll-n-renew PR is applied and the old group variables no longer exist.

Ticket: QA-1648