### PR TITLE
MEN-9840 - fix(gui): ensured manifests can be linked to directly

### DIFF
--- a/frontend/src/js/components/releases/manifests/ManifestDetails.tsx
+++ b/frontend/src/js/components/releases/manifests/ManifestDetails.tsx
@@ -168,9 +168,7 @@ export const ManifestDetails = ({ onCopy }: { onCopy?: (name: string) => void })
   }, [dispatch, manifestContent?.component_types]);
 
   const copyLinkToClipboard = () => {
-    copy(
-      `${window.location.origin}/ui${generateReleasesPath({ pageState: { selectedRelease: manifestName } })}?${formatReleases({ pageState: { tab: 'manifests' } })}`
-    );
+    copy(`${window.location.origin}/ui${generateReleasesPath({ pageState: {} })}?${formatReleases({ pageState: { tab: 'manifests', id: manifestName } })}`);
     dispatch(setSnackbar('Link copied to clipboard'));
   };
 


### PR DESCRIPTION
only releases are supposed to be referenced via the browser path, manifests & delta jobs via an id query param