### PR TITLE
MEN-9851 - fix(gui): ensured manifest filter inputs are only usable for users on the required plan

### DIFF
--- a/frontend/src/js/components/releases/manifests/ManifestsFilters.tsx
+++ b/frontend/src/js/components/releases/manifests/ManifestsFilters.tsx
@@ -18,14 +18,16 @@ import { Typography } from '@mui/material';
 
 import ChipSelect from '@northern.tech/common-ui/ChipSelect';
 import { ControlledSearch } from '@northern.tech/common-ui/Search';
+import ClickFilter from '@northern.tech/common-ui/forms/ClickFilter';
 import { Filters } from '@northern.tech/common-ui/forms/Filters';
-import { getManifestTags, getManifestsListState } from '@northern.tech/store/selectors';
+import { getIsEnterprise, getManifestTags, getManifestsListState } from '@northern.tech/store/selectors';
 import { setManifestsListState } from '@northern.tech/store/thunks';
 import pluralize from 'pluralize';
 
 export const ManifestsFilters = ({ classes }: { classes: Record<string, string> }) => {
   const { selectedTags = [], searchTerm = '', searchTotal, total } = useSelector(getManifestsListState);
   const existingTags = useSelector(getManifestTags);
+  const isEnterprise = useSelector(getIsEnterprise);
   const dispatch = useDispatch();
 
   const manifestSearchUpdated = useCallback(searchTerm => dispatch(setManifestsListState({ searchTerm })), [dispatch]);
@@ -33,7 +35,7 @@ export const ManifestsFilters = ({ classes }: { classes: Record<string, string> 
   const onFiltersChange = useCallback(({ name, tags }) => dispatch(setManifestsListState({ selectedTags: tags, searchTerm: name })), [dispatch]);
 
   return (
-    <>
+    <ClickFilter disabled={!isEnterprise}>
       <Filters
         className={classes.container}
         onChange={onFiltersChange}
@@ -64,7 +66,7 @@ export const ManifestsFilters = ({ classes }: { classes: Record<string, string> 
       <Typography variant="caption" className={classes.searchNote}>
         {(searchTerm || selectedTags.length > 0) && searchTotal !== total ? `Filtered from ${total} ${pluralize('Manifest', total)}` : ''}
       </Typography>
-    </>
+    </ClickFilter>
   );
 };
 

--- a/frontend/src/js/components/releases/manifests/__snapshots__/ManifestsFilters.test.tsx.snap
+++ b/frontend/src/js/components/releases/manifests/__snapshots__/ManifestsFilters.test.tsx.snap
@@ -575,63 +575,41 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   border-radius: inherit;
 }
 
-<form
-  class="margin-bottom margin-top flexbox space-between emotion-0 test-container"
-  novalidate=""
+.emotion-17 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+}
+
+<div
+  style="pointer-events: none;"
 >
-  <div
-    class="emotion-1"
+  <form
+    class="margin-bottom margin-top flexbox space-between emotion-0 test-container"
+    novalidate=""
   >
     <div
-      class="filter-item"
+      class="emotion-1"
     >
-      <h6
-        class="MuiTypography-root MuiTypography-subtitle2 margin-top-small margin-bottom-small emotion-2"
-      >
-        Manifest name
-      </h6>
       <div
-        class="MuiFormControl-root MuiTextField-root emotion-3"
+        class="filter-item"
       >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2 margin-top-small margin-bottom-small emotion-2"
+        >
+          Manifest name
+        </h6>
         <div
-          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart emotion-4"
+          class="MuiFormControl-root MuiTextField-root emotion-3"
         >
           <div
-            class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall emotion-5"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart emotion-4"
           >
-            <span
-              aria-hidden="true"
-              class="notranslate"
-            >
-              ​
-            </span>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSmall emotion-6"
-              data-testid="SearchIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
-              />
-            </svg>
-          </div>
-          <input
-            aria-invalid="false"
-            class="MuiInputBase-input MuiOutlinedInput-input emotion-7"
-            id="_r_X_"
-            name="name"
-            placeholder="Starts with"
-            type="text"
-            value=""
-          />
-          <fieldset
-            aria-hidden="true"
-            class="MuiOutlinedInput-notchedOutline emotion-8"
-          >
-            <legend
-              class="emotion-9"
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall emotion-5"
             >
               <span
                 aria-hidden="true"
@@ -639,40 +617,24 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
               >
                 ​
               </span>
-            </legend>
-          </fieldset>
-        </div>
-      </div>
-    </div>
-    <div
-      class="filter-item"
-    >
-      <h6
-        class="MuiTypography-root MuiTypography-subtitle2 margin-top-small margin-bottom-small emotion-2"
-      >
-        Tags
-      </h6>
-      <div
-        class="MuiAutocomplete-root emotion-11"
-        name="tags"
-      >
-        <div
-          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-12"
-        >
-          <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiAutocomplete-inputRoot emotion-13"
-          >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSmall emotion-6"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+              </svg>
+            </div>
             <input
-              aria-autocomplete="list"
-              aria-expanded="false"
               aria-invalid="false"
-              autocapitalize="none"
-              autocomplete="off"
-              class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-14"
-              id="tags-chip-select"
-              placeholder="Select tags"
-              role="combobox"
-              spellcheck="false"
+              class="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+              id="_r_X_"
+              name="name"
+              placeholder="Starts with"
               type="text"
               value=""
             />
@@ -694,7 +656,61 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
           </div>
         </div>
       </div>
+      <div
+        class="filter-item"
+      >
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle2 margin-top-small margin-bottom-small emotion-2"
+        >
+          Tags
+        </h6>
+        <div
+          class="MuiAutocomplete-root emotion-11"
+          name="tags"
+        >
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-12"
+          >
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiAutocomplete-inputRoot emotion-13"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-invalid="false"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused emotion-14"
+                id="tags-chip-select"
+                placeholder="Select tags"
+                role="combobox"
+                spellcheck="false"
+                type="text"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline emotion-8"
+              >
+                <legend
+                  class="emotion-9"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</form>
+  </form>
+  <span
+    class="MuiTypography-root MuiTypography-caption test-search-note emotion-17"
+  />
+</div>
 `;


### PR DESCRIPTION
<img width="617" height="292" alt="Screenshot 2026-06-11 at 15 29 09" src="https://github.com/user-attachments/assets/6b2aaa46-aba1-4c69-8442-d7ea45cf17c5" />

note the selected text - an editable input would get focused when clicked on the placeholder text