### PR TITLE
MEN-9836 - fix(gui): ensured manifest handles multi document yaml imports properly

### DIFF
--- a/frontend/src/js/components/releases/manifests/ManifestDrawer.test.tsx
+++ b/frontend/src/js/components/releases/manifests/ManifestDrawer.test.tsx
@@ -22,6 +22,18 @@ import { AddManifestDrawer } from './ManifestDrawer';
 
 vi.mock('@northern.tech/store/releasesSlice/thunks', { spy: true });
 
+const yamlContent = `api_version: v1
+kind: manifest
+name: my-manifest
+system_types_compatible:
+  - device-type-a
+  - device-type-b
+component_types:
+  rootfs:
+    update_strategy:
+      order: 1
+`;
+
 describe('AddManifestDrawer Component', () => {
   beforeEach(() => {
     vi.mocked(ReleasesThunks.uploadManifest).mockClear();
@@ -58,17 +70,6 @@ describe('AddManifestDrawer Component', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const { baseElement } = render(<AddManifestDrawer open onClose={vi.fn()} />);
 
-    const yamlContent = `api_version: v1
-kind: manifest
-name: my-manifest
-system_types_compatible:
-  - device-type-a
-  - device-type-b
-component_types:
-  rootfs:
-    update_strategy:
-      order: 1
-`;
     File.prototype.text = vi.fn().mockResolvedValue(yamlContent);
     const file = new File([yamlContent], 'test.yaml', { type: 'application/yaml' });
     const dropzoneInput = baseElement.querySelector('.dropzone input') as HTMLInputElement;
@@ -83,6 +84,26 @@ component_types:
       file: expect.objectContaining({ name: 'test.yaml' }),
       meta: { description: '', name: '', tags: [] }
     });
+  });
+
+  it('shows an error when a multi-document YAML is uploaded', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { baseElement } = render(<AddManifestDrawer open onClose={vi.fn()} />);
+
+    const multiDocYaml = `---
+${yamlContent}
+---
+kind: manifest
+name: missing-required-fields
+`;
+    File.prototype.text = vi.fn().mockResolvedValue(multiDocYaml);
+    const file = new File([multiDocYaml], 'multi.yaml', { type: 'application/yaml' });
+    const dropzoneInput = baseElement.querySelector('.dropzone input') as HTMLInputElement;
+    await user.upload(dropzoneInput, file);
+
+    expect(await screen.findByDisplayValue('multi.yaml')).toBeInTheDocument();
+    expect(screen.getByText(/only single-document/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^upload$/i })).toBeDisabled();
   });
 
   it('shows a validation error when an invalid YAML manifest is uploaded', async () => {

--- a/frontend/src/js/components/releases/manifests/ManifestDrawer.tsx
+++ b/frontend/src/js/components/releases/manifests/ManifestDrawer.tsx
@@ -35,7 +35,7 @@ import { checkReleasesExistence, generateManifest, getManifest, getSoftware, upl
 import { useAppDispatch } from '@northern.tech/store/store';
 import { getExistingSoftwareTags } from '@northern.tech/store/thunks';
 import type { ManifestContent, Software } from '@northern.tech/types/MenderTypes';
-import { parse, stringify } from 'yaml';
+import { parseAllDocuments, stringify } from 'yaml';
 import * as z from 'zod';
 
 import { SoftwareArtifactFilter } from '../../deployments/deployment-wizard/ReleaseArtifactFilter';
@@ -83,12 +83,15 @@ const validateFile = async (file: File) => {
     return { ok: false, message: 'Manifest Artifacts must be smaller than 1MB' };
   } else if (isYaml(name)) {
     const text = await file.text();
-    let parsed;
-    try {
-      parsed = parse(text);
-    } catch (e) {
-      return { ok: false, message: e instanceof Error ? e.message : String(e) };
+    const docs = parseAllDocuments(text);
+    if (docs.length !== 1) {
+      return { ok: false, message: 'Only single-document .yaml Manifests are supported' };
     }
+    const doc = docs[0];
+    if (doc.errors.length) {
+      return { ok: false, message: doc.errors.map(e => e.message).join('\n') };
+    }
+    const parsed = doc.toJS();
     const result = ManifestContentSchema.safeParse(parsed);
     if (!result.success) {
       return { ok: false, message: z.prettifyError(result.error) };


### PR DESCRIPTION
since there's no clear handling of such a scenario the user will only get informed
<img width="521" height="186" alt="Screenshot 2026-06-12 at 12 04 59" src="https://github.com/user-attachments/assets/68350c67-86fb-475f-af58-f3ff0f9fc55f" />

The `parseAllDocuments` handles errors slightly differently (collects all parsing errors per document instead of throwing), thus the changed error handling there/ the simple check for the presence of errors instead.