### PR TITLE
fix(deviceconnect): consolidate default config with config.yaml file

### DIFF
--- a/backend/services/deviceconnect/config.yaml
+++ b/backend/services/deviceconnect/config.yaml
@@ -2,25 +2,25 @@
 # Defauls to: ":8080" which will listen on all avalable interfaces.
 # Overwrite with environment variable: DEVICECONNECT_LISTEN
 
-listen: :8080
+# listen: :8080
 
 # NATS uri
 # Defauls to: "nats://localhost:4222"
 # Overwrite with environment variable: DEVICECONNECT_NATS_URI
 
-nats_uri: "nats://mender-nats:4222"
+# nats_uri: "nats://mender-nats:4222"
 
 # Mongodb connection string
 # Defaults to: "mongodb://localhost"
 # Overwrite with environment variable: DEVICECONNECT_MONGO_URL
 
-mongo_url: mongodb://mender-mongo:27017
+# mongo_url: mongodb://mender-mongo:27017
 
 # Mongodb database name
 # Defaults to: "deviceconnect"
 # Overwrite with environment variable: DEVICECONNECT_MONGO_DBNAME
 
-mongo_dbname: deviceconnect
+# mongo_dbname: deviceconnect
 
 # Enable SSL for mongo connections
 # Defaults to: false

--- a/backend/services/deviceconnect/config/config.go
+++ b/backend/services/deviceconnect/config/config.go
@@ -27,7 +27,7 @@ const (
 	// SettingNatsURI is the config key for the nats uri
 	SettingNatsURI = "nats_uri"
 	// SettingNatsURIDefault is the default value for the nats uri
-	SettingNatsURIDefault = "nats://localhost:4222"
+	SettingNatsURIDefault = "nats://mender-nats:4222"
 
 	// SettingMongo is the config key for the mongo URL
 	SettingMongo = "mongo_url"


### PR DESCRIPTION
The default nats configuration was silently overwritten by the default configuration file. The actual default does not make much sense in a containerized environments so aligned the default with the value inherited (by accident) from the config file.