### PR TITLE
fix(gui): make device detail tab strip scrollable so all tabs stay reachable on mobile (ME-683)

### DIFF
--- a/frontend/src/js/components/devices/ExpandedDevice.test.tsx
+++ b/frontend/src/js/components/devices/ExpandedDevice.test.tsx
@@ -11,6 +11,8 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
+import { tabsClasses } from '@mui/material';
+
 import { defaultState, render } from '@/testUtils';
 import { EXTERNAL_PROVIDER } from '@northern.tech/store/constants';
 import { undefineds } from '@northern.tech/testing/mockData';
@@ -66,5 +68,14 @@ describe('ExpandedDevice Component', () => {
     const view = baseElement;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
+  });
+  it('keeps the detail tabs reachable on narrow viewports by making the tab strip scrollable', async () => {
+    // ME-683: a standard (non-scrollable) tab strip clips overflowing tabs (e.g. Troubleshoot) on
+    // mobile, where the drawer is width-constrained, leaving no way to reach them. The strip must be
+    // horizontally scrollable so every tab stays reachable regardless of the drawer width.
+    const { baseElement } = render(<ExpandedDevice deviceId={defaultState.devices.byId.a1.id} setDetailsTab={vi.fn} />, { preloadedState });
+    const scroller = baseElement.querySelector(`.${tabsClasses.scroller}`);
+    expect(scroller).not.toBeNull();
+    expect(scroller?.classList.contains(tabsClasses.scrollableX)).toBe(true);
   });
 });

--- a/frontend/src/js/components/devices/ExpandedDevice.tsx
+++ b/frontend/src/js/components/devices/ExpandedDevice.tsx
@@ -298,7 +298,14 @@ export const ExpandedDevice = ({ actionCallbacks, deviceId, onClose, setDetailsT
       }}
       notification={<DeviceNotifications alerts={latestAlerts} device={device} onClick={scrollToMonitor} />}
     >
-      <Tabs value={selectedTab} onChange={(e, tab) => setDetailsTab(tab)} textColor="primary">
+      <Tabs
+        value={selectedTab}
+        onChange={(e, tab) => setDetailsTab(tab)}
+        textColor="primary"
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
+      >
         {availableTabs.map(item => (
           <Tab key={item.value} label={item.title({ integrations })} value={item.value} />
         ))}

--- a/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
+++ b/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
@@ -385,31 +385,40 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   display: flex;
 }
 
-@media (max-width:599.95px) {
-  .emotion-13 .MuiTabs-scrollButtons {
-    display: none;
-  }
+.emotion-14 {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
 }
 
-.emotion-14 {
+.emotion-14::-webkit-scrollbar {
+  display: none;
+}
+
+.emotion-15 {
   position: relative;
   display: inline-block;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   white-space: nowrap;
-  overflow-x: hidden;
-  width: 100%;
+  scrollbar-width: none;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
-.emotion-15 {
+.emotion-15::-webkit-scrollbar {
+  display: none;
+}
+
+.emotion-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.emotion-16 {
+.emotion-17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -465,31 +474,31 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-16::-moz-focus-inner {
+.emotion-17::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-16.Mui-disabled {
+.emotion-17.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-16 {
+  .emotion-17 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-16.Mui-selected {
+.emotion-17.Mui-selected {
   color: #1976d2;
 }
 
-.emotion-16.Mui-disabled {
+.emotion-17.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-25 {
+.emotion-26 {
   position: absolute;
   height: 2px;
   bottom: 0;
@@ -499,7 +508,7 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   background-color: #1976d2;
 }
 
-.emotion-26 {
+.emotion-27 {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: max-content;
@@ -511,13 +520,13 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   min-height: 40px;
 }
 
-.emotion-28.two-columns.column-data {
+.emotion-29.two-columns.column-data {
   grid-template-columns: max-content minmax(auto, 650px);
   max-width: initial;
   row-gap: 8px;
 }
 
-.emotion-29 {
+.emotion-30 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 500;
@@ -526,7 +535,7 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   letter-spacing: 0.00714em;
 }
 
-.emotion-30>svg {
+.emotion-31>svg {
   cursor: pointer;
   fill: rgba(0, 0, 0, 0.54);
   opacity: 0;
@@ -534,11 +543,11 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   transition: opacity 0.2s ease-in-out;
 }
 
-.emotion-30:hover>svg {
+.emotion-31:hover>svg {
   opacity: 1;
 }
 
-.emotion-32 {
+.emotion-33 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -563,38 +572,38 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   font-size: 0.8125rem;
 }
 
-.emotion-32.Mui-disabled {
+.emotion-33.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-32:hover .MuiOutlinedInput-notchedOutline {
+.emotion-33:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-32:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-33:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-32.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-33.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-width: 2px;
 }
 
-.emotion-32.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-33.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
 }
 
-.emotion-32.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-33.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-32.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-33.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-33 {
+.emotion-34 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -618,80 +627,80 @@ exports[`ExpandedDevice Component > renders correctly 1`] = `
   padding-right: 0;
 }
 
-.emotion-33::-webkit-input-placeholder {
+.emotion-34::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-33::-moz-placeholder {
+.emotion-34::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-33::-ms-input-placeholder {
+.emotion-34::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-33:focus {
+.emotion-34:focus {
   outline: 0;
 }
 
-.emotion-33:invalid {
+.emotion-34:invalid {
   box-shadow: none;
 }
 
-.emotion-33::-webkit-search-decoration {
+.emotion-34::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-34:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-33.Mui-disabled {
+.emotion-34.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-33:-webkit-autofill {
+.emotion-34:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-33:-webkit-autofill {
+.emotion-34:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-34 {
+.emotion-35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -706,7 +715,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   margin-left: 8px;
 }
 
-.emotion-35 {
+.emotion-36 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -755,42 +764,42 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-35::-moz-focus-inner {
+.emotion-36::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-35.Mui-disabled {
+.emotion-36.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-35 {
+  .emotion-36 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-35:hover {
+.emotion-36:hover {
   background-color: var(--IconButton-hoverBg);
 }
 
 @media (hover: none) {
-  .emotion-35:hover {
+  .emotion-36:hover {
     background-color: transparent;
   }
 }
 
-.emotion-35.Mui-disabled {
+.emotion-36.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-35.MuiIconButton-loading {
+.emotion-36.MuiIconButton-loading {
   color: transparent;
 }
 
-.emotion-37 {
+.emotion-38 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -808,7 +817,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-38 {
+.emotion-39 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -818,7 +827,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.emotion-39 {
+.emotion-40 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -836,7 +845,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   color: rgba(0, 0, 0, 0.54);
 }
 
-.emotion-54 {
+.emotion-55 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -845,23 +854,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   letter-spacing: 0.00938em;
 }
 
-.emotion-56 {
+.emotion-57 {
   background-color: rgb(255, 255, 255);
   margin-bottom: 16px;
   min-width: 700px;
   padding: 16px;
 }
 
-.emotion-57 {
+.emotion-58 {
   margin: auto;
   margin-left: 0;
 }
 
-.emotion-57:hover svg {
+.emotion-58:hover svg {
   color: #1565c0;
 }
 
-.emotion-58 {
+.emotion-59 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -879,11 +888,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-58.read {
+.emotion-59.read {
   color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-59 {
+.emotion-60 {
   position: absolute;
   top: -4px;
   bottom: -4px;
@@ -893,22 +902,22 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   border-radius: 50%;
 }
 
-.emotion-59.read {
+.emotion-60.read {
   border-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-59:hover {
+.emotion-60:hover {
   border-color: #1565c0;
 }
 
-.emotion-60 .columnHeader,
-.emotion-60 .MuiAccordionSummary-root,
-.emotion-60 .MuiAccordionSummary-content {
+.emotion-61 .columnHeader,
+.emotion-61 .MuiAccordionSummary-root,
+.emotion-61 .MuiAccordionSummary-content {
   cursor: default;
 }
 
-.emotion-60 .header,
-.emotion-60 .body .MuiAccordionSummary-content {
+.emotion-61 .header,
+.emotion-61 .body .MuiAccordionSummary-content {
   display: grid;
   grid-column-gap: 16px;
   grid-template-columns: 0.5fr 1fr 1.5fr 2fr 2fr 2fr;
@@ -918,15 +927,15 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   align-items: center;
 }
 
-.emotion-61 {
+.emotion-62 {
   padding: 16px;
 }
 
-.emotion-61.columns-5 {
+.emotion-62.columns-5 {
   grid-template-columns: 0.5fr 1fr 1.5fr 2fr 2fr;
 }
 
-.emotion-62 {
+.emotion-63 {
   background-color: #fff;
   color: rgba(0, 0, 0, 0.87);
   -webkit-transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -939,7 +948,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   overflow-anchor: none;
 }
 
-.emotion-62::before {
+.emotion-63::before {
   position: absolute;
   left: 0;
   top: -1px;
@@ -952,57 +961,57 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-62:first-of-type::before {
+.emotion-63:first-of-type::before {
   display: none;
 }
 
-.emotion-62.Mui-expanded::before {
+.emotion-63.Mui-expanded::before {
   opacity: 0;
 }
 
-.emotion-62.Mui-expanded:first-of-type {
+.emotion-63.Mui-expanded:first-of-type {
   margin-top: 0;
 }
 
-.emotion-62.Mui-expanded:last-of-type {
+.emotion-63.Mui-expanded:last-of-type {
   margin-bottom: 0;
 }
 
-.emotion-62.Mui-expanded+.emotion-62.Mui-expanded::before {
+.emotion-63.Mui-expanded+.emotion-63.Mui-expanded::before {
   display: none;
 }
 
-.emotion-62.Mui-disabled {
+.emotion-63.Mui-disabled {
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-62.Mui-expanded {
+.emotion-63.Mui-expanded {
   margin: 16px 0;
 }
 
-.emotion-62:before {
+.emotion-63:before {
   display: none;
 }
 
-.emotion-62$expanded {
+.emotion-63$expanded {
   margin: auto;
 }
 
-.emotion-62 .columns-5 .MuiAccordionSummary-content {
+.emotion-63 .columns-5 .MuiAccordionSummary-content {
   grid-template-columns: 0.5fr 1fr 1.5fr 2fr 2fr;
 }
 
-.emotion-62 .MuiAccordionDetails-root {
+.emotion-63 .MuiAccordionDetails-root {
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
 }
 
-.emotion-63 {
+.emotion-64 {
   all: unset;
 }
 
-.emotion-64 {
+.emotion-65 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1046,39 +1055,39 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: min-height 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-64::-moz-focus-inner {
+.emotion-65::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-64.Mui-disabled {
+.emotion-65.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-64 {
+  .emotion-65 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-64.Mui-focusVisible {
+.emotion-65.Mui-focusVisible {
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-64.Mui-disabled {
+.emotion-65.Mui-disabled {
   opacity: 0.38;
 }
 
-.emotion-64:hover:not(.Mui-disabled) {
+.emotion-65:hover:not(.Mui-disabled) {
   cursor: pointer;
 }
 
-.emotion-64.Mui-expanded {
+.emotion-65.Mui-expanded {
   min-height: 64px;
 }
 
-.emotion-65 {
+.emotion-66 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1093,17 +1102,17 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: margin 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-65.Mui-expanded {
+.emotion-66.Mui-expanded {
   margin: 20px 0;
 }
 
-.emotion-66 {
+.emotion-67 {
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-.emotion-67 {
+.emotion-68 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1160,33 +1169,33 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-67::-moz-focus-inner {
+.emotion-68::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-67.Mui-disabled {
+.emotion-68.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-67 {
+  .emotion-68 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-67:hover {
+.emotion-68:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-67.Mui-disabled {
+.emotion-68.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
 }
 
 @media (hover: hover) {
-  .emotion-67:hover {
+  .emotion-68:hover {
     --variant-containedBg: #1565c0;
     --variant-textBg: rgba(25, 118, 210, 0.04);
     --variant-outlinedBorder: #1976d2;
@@ -1194,11 +1203,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   }
 }
 
-.emotion-67.MuiButton-loading {
+.emotion-68.MuiButton-loading {
   color: transparent;
 }
 
-.emotion-71 {
+.emotion-72 {
   height: 0;
   overflow: hidden;
   -webkit-transition: height 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -1206,7 +1215,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   visibility: hidden;
 }
 
-.emotion-72 {
+.emotion-73 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1214,15 +1223,15 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   width: 100%;
 }
 
-.emotion-73 {
+.emotion-74 {
   width: 100%;
 }
 
-.emotion-75 {
+.emotion-76 {
   padding: 8px 16px 16px;
 }
 
-.emotion-76 {
+.emotion-77 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -1233,7 +1242,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   margin-left: auto;
 }
 
-.emotion-77 {
+.emotion-78 {
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -1241,7 +1250,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   margin-top: 16px;
 }
 
-.emotion-78 {
+.emotion-79 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1298,33 +1307,33 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-78::-moz-focus-inner {
+.emotion-79::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-78.Mui-disabled {
+.emotion-79.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-78 {
+  .emotion-79 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-78:hover {
+.emotion-79:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-78.Mui-disabled {
+.emotion-79.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
 }
 
 @media (hover: hover) {
-  .emotion-78:hover {
+  .emotion-79:hover {
     --variant-containedBg: #7b1fa2;
     --variant-textBg: rgba(156, 39, 176, 0.04);
     --variant-outlinedBorder: #9c27b0;
@@ -1332,11 +1341,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   }
 }
 
-.emotion-78.MuiButton-loading {
+.emotion-79.MuiButton-loading {
   color: transparent;
 }
 
-.emotion-81 {
+.emotion-82 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1393,61 +1402,61 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-81::-moz-focus-inner {
+.emotion-82::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-81.Mui-disabled {
+.emotion-82.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-81 {
+  .emotion-82 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-81:hover {
+.emotion-82:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.emotion-81.Mui-disabled {
+.emotion-82.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-81::before {
+.emotion-82::before {
   content: "\\200b";
   width: 0;
   overflow: hidden;
 }
 
 @media (hover: hover) {
-  .emotion-81:hover {
+  .emotion-82:hover {
     --variant-containedBg: #f5f5f5;
     --variant-textBg: rgba(0, 0, 0, 0.04);
     --variant-outlinedBg: rgba(0, 0, 0, 0.04);
   }
 }
 
-.emotion-81.MuiButton-loading {
+.emotion-82.MuiButton-loading {
   color: transparent;
 }
 
-.emotion-82 {
+.emotion-83 {
   display: inherit;
   margin-right: 8px;
   margin-left: -4px;
   margin-left: -2px;
 }
 
-.emotion-82>*:nth-of-type(1) {
+.emotion-83>*:nth-of-type(1) {
   font-size: 18px;
 }
 
-.emotion-85 {
+.emotion-86 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1470,13 +1479,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   pointer-events: none;
 }
 
-.emotion-85 .MuiSpeedDialAction-staticTooltipLabel {
+.emotion-86 .MuiSpeedDialAction-staticTooltipLabel {
   min-width: -webkit-max-content;
   min-width: -moz-max-content;
   min-width: max-content;
 }
 
-.emotion-86 {
+.emotion-87 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -1493,7 +1502,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   pointer-events: auto;
 }
 
-.emotion-87 {
+.emotion-88 {
   z-index: 1050;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1511,7 +1520,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   margin-right: 16px;
 }
 
-.emotion-87 .MuiSpeedDial-actions {
+.emotion-88 .MuiSpeedDial-actions {
   -webkit-flex-direction: column-reverse;
   -ms-flex-direction: column-reverse;
   flex-direction: column-reverse;
@@ -1519,7 +1528,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   padding-bottom: 48px;
 }
 
-.emotion-88 {
+.emotion-89 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1575,68 +1584,68 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   pointer-events: auto;
 }
 
-.emotion-88::-moz-focus-inner {
+.emotion-89::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-88.Mui-disabled {
+.emotion-89.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-88 {
+  .emotion-89 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-88:active {
+.emotion-89:active {
   box-shadow: 0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);
 }
 
-.emotion-88:hover {
+.emotion-89:hover {
   background-color: #f5f5f5;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media (hover: none) {
-  .emotion-88:hover {
+  .emotion-89:hover {
     background-color: #e0e0e0;
   }
 }
 
-.emotion-88.Mui-focusVisible {
+.emotion-89.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-88:hover {
+.emotion-89:hover {
   background-color: #1565c0;
 }
 
 @media (hover: none) {
-  .emotion-88:hover {
+  .emotion-89:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-88.Mui-disabled {
+.emotion-89.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-89 {
+.emotion-90 {
   height: 24px;
 }
 
-.emotion-89 .MuiSpeedDialIcon-icon {
+.emotion-90 .MuiSpeedDialIcon-icon {
   -webkit-transition: -webkit-transform 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-89 .MuiSpeedDialIcon-openIcon {
+.emotion-90 .MuiSpeedDialIcon-openIcon {
   position: absolute;
   -webkit-transition: -webkit-transform 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
@@ -1647,7 +1656,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transform: rotate(-45deg);
 }
 
-.emotion-91 {
+.emotion-92 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1658,7 +1667,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   pointer-events: none;
 }
 
-.emotion-92 {
+.emotion-93 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1670,13 +1679,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   align-items: center;
 }
 
-.emotion-92 .MuiSpeedDialAction-staticTooltipLabel {
+.emotion-93 .MuiSpeedDialAction-staticTooltipLabel {
   -webkit-transition: -webkit-transform 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   opacity: 1;
 }
 
-.emotion-92 .MuiSpeedDialAction-staticTooltipLabel {
+.emotion-93 .MuiSpeedDialAction-staticTooltipLabel {
   opacity: 0;
   -webkit-transform: scale(0.5);
   -moz-transform: scale(0.5);
@@ -1684,13 +1693,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transform: scale(0.5);
 }
 
-.emotion-92 .MuiSpeedDialAction-staticTooltipLabel {
+.emotion-93 .MuiSpeedDialAction-staticTooltipLabel {
   transform-origin: 100% 50%;
   right: 100%;
   margin-right: 8px;
 }
 
-.emotion-93 {
+.emotion-94 {
   position: absolute;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -1705,7 +1714,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   word-break: keep-all;
 }
 
-.emotion-94 {
+.emotion-95 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1771,53 +1780,53 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
   transform: scale(0);
 }
 
-.emotion-94::-moz-focus-inner {
+.emotion-95::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-94.Mui-disabled {
+.emotion-95.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-94 {
+  .emotion-95 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-94:active {
+.emotion-95:active {
   box-shadow: 0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);
 }
 
-.emotion-94:hover {
+.emotion-95:hover {
   background-color: #f5f5f5;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media (hover: none) {
-  .emotion-94:hover {
+  .emotion-95:hover {
     background-color: #e0e0e0;
   }
 }
 
-.emotion-94.Mui-focusVisible {
+.emotion-95.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-94.Mui-disabled {
+.emotion-95.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-94:hover {
+.emotion-95:hover {
   background-color: rgb(216, 216, 216);
 }
 
-.emotion-107 {
+.emotion-108 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1981,16 +1990,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
         class="MuiTabs-root emotion-13"
       >
         <div
-          class="MuiTabs-scroller MuiTabs-fixed emotion-14"
-          style="overflow: hidden; margin-bottom: 0px;"
+          class="MuiTabs-scrollableX MuiTabs-hideScrollbar emotion-14"
+          style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll; pointer-events: none;"
+        />
+        <div
+          class="MuiTabs-scroller MuiTabs-hideScrollbar MuiTabs-scrollableX emotion-15"
+          style="margin-bottom: 0px;"
         >
           <div
-            class="MuiTabs-list emotion-15"
+            class="MuiTabs-list emotion-16"
             role="tablist"
           >
             <button
               aria-selected="true"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary Mui-selected emotion-17"
               role="tab"
               tabindex="0"
               type="button"
@@ -1999,7 +2012,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2008,7 +2021,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2017,7 +2030,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2026,7 +2039,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2035,7 +2048,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2044,7 +2057,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2053,7 +2066,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2062,7 +2075,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
             <button
               aria-selected="false"
-              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-16"
+              class="MuiButtonBase-root MuiTab-root MuiTab-textColorPrimary emotion-17"
               role="tab"
               tabindex="-1"
               type="button"
@@ -2071,7 +2084,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </button>
           </div>
           <span
-            class="MuiTabs-indicator emotion-25"
+            class="MuiTabs-indicator emotion-26"
             style="left: 0px; width: 0px;"
           />
         </div>
@@ -2083,7 +2096,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           class="flexbox space-between"
         >
           <div
-            class="margin-bottom-x-small emotion-26"
+            class="margin-bottom-x-small emotion-27"
           >
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 emotion-3"
@@ -2093,26 +2106,26 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           </div>
         </div>
         <div
-          class="break-all two-columns emotion-28 column-data "
+          class="break-all two-columns emotion-29 column-data "
         >
           <h6
-            class="MuiTypography-root MuiTypography-subtitle2 key emotion-29"
+            class="MuiTypography-root MuiTypography-subtitle2 key emotion-30"
             style="white-space: nowrap;"
           >
             Name
           </h6>
           <div
-            class="flexbox align-items-center emotion-30"
+            class="flexbox align-items-center emotion-31"
           >
             <div
               class="MuiTypography-root MuiTypography-body2 clickable emotion-9"
               style="display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; word-break: break-word; text-overflow: ellipsis;"
             >
               <div
-                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-sizeSmall MuiInputBase-adornedEnd emotion-32"
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-disabled MuiInputBase-sizeSmall MuiInputBase-adornedEnd emotion-33"
               >
                 <input
-                  class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled emotion-33"
+                  class="MuiInputBase-input MuiOutlinedInput-input Mui-disabled emotion-34"
                   disabled=""
                   id="a1-id-input"
                   placeholder="a1..."
@@ -2120,10 +2133,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                   value=""
                 />
                 <div
-                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-34"
+                  class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-35"
                 >
                   <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall emotion-35"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-sizeSmall emotion-36"
                     tabindex="0"
                     type="button"
                   >
@@ -2142,10 +2155,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                 </div>
                 <fieldset
                   aria-hidden="true"
-                  class="MuiOutlinedInput-notchedOutline emotion-37"
+                  class="MuiOutlinedInput-notchedOutline emotion-38"
                 >
                   <legend
-                    class="emotion-38"
+                    class="emotion-39"
                   >
                     <span
                       aria-hidden="true"
@@ -2160,7 +2173,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             <svg
               aria-hidden="true"
               aria-label="Copy to clipboard"
-              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-39"
+              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-40"
               data-mui-internal-clone-element="true"
               data-testid="FileCopyOutlinedIcon"
               focusable="false"
@@ -2172,13 +2185,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </svg>
           </div>
           <h6
-            class="MuiTypography-root MuiTypography-subtitle2 key emotion-29"
+            class="MuiTypography-root MuiTypography-subtitle2 key emotion-30"
             style="white-space: nowrap;"
           >
             ID
           </h6>
           <div
-            class="flexbox align-items-center emotion-30"
+            class="flexbox align-items-center emotion-31"
           >
             <p
               class="MuiTypography-root MuiTypography-body2 clickable emotion-9"
@@ -2190,7 +2203,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             <svg
               aria-hidden="true"
               aria-label="Copy to clipboard"
-              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-39"
+              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-40"
               data-mui-internal-clone-element="true"
               data-testid="FileCopyOutlinedIcon"
               focusable="false"
@@ -2202,13 +2215,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </svg>
           </div>
           <h6
-            class="MuiTypography-root MuiTypography-subtitle2 key emotion-29"
+            class="MuiTypography-root MuiTypography-subtitle2 key emotion-30"
             style="white-space: nowrap;"
           >
             mac
           </h6>
           <div
-            class="flexbox align-items-center emotion-30"
+            class="flexbox align-items-center emotion-31"
           >
             <p
               class="MuiTypography-root MuiTypography-body2 clickable emotion-9"
@@ -2220,7 +2233,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             <svg
               aria-hidden="true"
               aria-label="Copy to clipboard"
-              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-39"
+              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-40"
               data-mui-internal-clone-element="true"
               data-testid="FileCopyOutlinedIcon"
               focusable="false"
@@ -2232,13 +2245,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </svg>
           </div>
           <h6
-            class="MuiTypography-root MuiTypography-subtitle2 key emotion-29"
+            class="MuiTypography-root MuiTypography-subtitle2 key emotion-30"
             style="white-space: nowrap;"
           >
             First request
           </h6>
           <div
-            class="flexbox align-items-center emotion-30"
+            class="flexbox align-items-center emotion-31"
           >
             <div
               class="MuiTypography-root MuiTypography-body2 clickable emotion-9"
@@ -2254,7 +2267,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             <svg
               aria-hidden="true"
               aria-label="Copy to clipboard"
-              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-39"
+              class="MuiSvgIcon-root MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall margin-left-x-small emotion-40"
               data-mui-internal-clone-element="true"
               data-testid="FileCopyOutlinedIcon"
               focusable="false"
@@ -2274,7 +2287,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           class="flexbox space-between"
         >
           <div
-            class="margin-bottom-x-small emotion-26"
+            class="margin-bottom-x-small emotion-27"
           >
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 emotion-3"
@@ -2282,7 +2295,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               Authentication status
             </h6>
             <p
-              class="MuiTypography-root MuiTypography-body1 capitalized emotion-54"
+              class="MuiTypography-root MuiTypography-body1 capitalized emotion-55"
             >
               accepted
             </p>
@@ -2301,19 +2314,19 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           </div>
         </div>
         <div
-          class="emotion-56"
+          class="emotion-57"
         >
           <div
             class="margin-bottom-small flexbox space-between"
           >
             Authorization sets
             <div
-              class="relative flexbox emotion-57  margin-left-small"
+              class="relative flexbox emotion-58  margin-left-small"
               data-mui-internal-clone-element="true"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium emotion-58"
+                class="MuiSvgIcon-root MuiSvgIcon-colorPrimary MuiSvgIcon-fontSizeMedium emotion-59"
                 data-testid="HelpIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -2323,15 +2336,15 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                 />
               </svg>
               <div
-                class="emotion-59 "
+                class="emotion-60 "
               />
             </div>
           </div>
           <div
-            class="authsets emotion-60"
+            class="authsets emotion-61"
           >
             <div
-              class="header columns-6 emotion-61"
+              class="header columns-6 emotion-62"
             >
               <div
                 class="columnHeader"
@@ -2366,20 +2379,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               class="body relative"
             >
               <div
-                class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAccordion-root MuiAccordion-gutters emotion-62"
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation1 MuiAccordion-root MuiAccordion-gutters emotion-63"
                 style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
               >
                 <h3
-                  class="MuiAccordion-heading emotion-63"
+                  class="MuiAccordion-heading emotion-64"
                 >
                   <div
                     aria-expanded="false"
-                    class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters columns-6 emotion-64"
+                    class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters columns-6 emotion-65"
                     role="button"
                     tabindex="0"
                   >
                     <span
-                      class="MuiAccordionSummary-content emotion-65"
+                      class="MuiAccordionSummary-content emotion-66"
                     >
                       <div
                         class="capitalized"
@@ -2392,13 +2405,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                         accepted
                       </div>
                       <div
-                        class="capitalized clickable flexbox align-items-center emotion-66"
+                        class="capitalized clickable flexbox align-items-center emotion-67"
                         data-mui-internal-clone-element="true"
                       >
                         <div />
                       </div>
                       <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-67"
+                        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-68"
                         tabindex="0"
                         type="button"
                       >
@@ -2414,7 +2427,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                         class="action-buttons flexbox"
                       >
                         <button
-                          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-67"
+                          class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-68"
                           disabled=""
                           tabindex="-1"
                           type="button"
@@ -2422,14 +2435,14 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                           Accept
                         </button>
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-67"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-68"
                           tabindex="0"
                           type="button"
                         >
                           Reject
                         </button>
                         <button
-                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-67"
+                          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorPrimary emotion-68"
                           tabindex="0"
                           type="button"
                         >
@@ -2440,24 +2453,24 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
                   </div>
                 </h3>
                 <div
-                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-71"
+                  class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden emotion-72"
                   style="min-height: 0px;"
                 >
                   <div
-                    class="MuiCollapse-wrapper MuiCollapse-vertical emotion-72"
+                    class="MuiCollapse-wrapper MuiCollapse-vertical emotion-73"
                   >
                     <div
-                      class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-73"
+                      class="MuiCollapse-wrapperInner MuiCollapse-vertical emotion-74"
                     >
                       <div
-                        class="MuiAccordion-region emotion-74"
+                        class="MuiAccordion-region emotion-75"
                         role="region"
                       >
                         <div
-                          class="MuiAccordionDetails-root emotion-75"
+                          class="MuiAccordionDetails-root emotion-76"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body1 emotion-76"
+                            class="MuiTypography-root MuiTypography-body1 emotion-77"
                           >
                              Are you sure you want to continue?
                           </p>
@@ -2470,10 +2483,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </div>
           </div>
           <div
-            class="flexbox relative emotion-77"
+            class="flexbox relative emotion-78"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary emotion-78"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeMedium MuiButton-colorSecondary emotion-79"
               tabindex="0"
               type="button"
             >
@@ -2489,7 +2502,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           class="flexbox space-between"
         >
           <div
-            class="margin-bottom-x-small emotion-26"
+            class="margin-bottom-x-small emotion-27"
           >
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 emotion-3"
@@ -2497,13 +2510,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               Tags
             </h6>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit emotion-81"
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorInherit emotion-82"
               style="padding: 5px;"
               tabindex="0"
               type="button"
             >
               <span
-                class="MuiButton-icon MuiButton-startIcon emotion-82"
+                class="MuiButton-icon MuiButton-startIcon emotion-83"
               >
                 <svg
                   aria-hidden="true"
@@ -2526,22 +2539,22 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           style="max-width: 700px;"
         >
           <h6
-            class="MuiTypography-root MuiTypography-subtitle2 emotion-29"
+            class="MuiTypography-root MuiTypography-subtitle2 emotion-30"
           >
             No tags have been set for this device.
           </h6>
         </div>
       </div>
       <div
-        class="emotion-85"
+        class="emotion-86"
       >
         <p
-          class="MuiTypography-root MuiTypography-body1 clickable emotion-86"
+          class="MuiTypography-root MuiTypography-body1 clickable emotion-87"
         >
           Device actions
         </p>
         <div
-          class="MuiSpeedDial-root MuiSpeedDial-directionUp emotion-87"
+          class="MuiSpeedDial-root MuiSpeedDial-directionUp emotion-88"
           role="presentation"
         >
           <button
@@ -2549,13 +2562,13 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             aria-expanded="false"
             aria-haspopup="true"
             aria-label="device-actions"
-            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-primary MuiSpeedDial-fab emotion-88"
+            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-primary MuiSpeedDial-fab emotion-89"
             style="transform: none; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiSpeedDialIcon-root emotion-89"
+              class="MuiSpeedDialIcon-root emotion-90"
             >
               <svg
                 aria-hidden="true"
@@ -2572,17 +2585,17 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
           </button>
           <div
             aria-orientation="vertical"
-            class="MuiSpeedDial-actions MuiSpeedDial-actionsClosed emotion-91"
+            class="MuiSpeedDial-actions MuiSpeedDial-actionsClosed emotion-92"
             id="device-actions-actions"
             role="menu"
           >
             <span
               aria-label="dismiss"
-              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-92"
+              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-93"
               id="device-actions-action-0"
             >
               <span
-                class="MuiSpeedDialAction-staticTooltipLabel emotion-93"
+                class="MuiSpeedDialAction-staticTooltipLabel emotion-94"
                 id="device-actions-action-0-label"
                 style="transition-delay: 150ms;"
               >
@@ -2592,7 +2605,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               </span>
               <button
                 aria-labelledby="device-actions-action-0-label"
-                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-94"
+                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-95"
                 role="menuitem"
                 style="transition-delay: 150ms;"
                 tabindex="-1"
@@ -2613,11 +2626,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </span>
             <span
               aria-label="reject"
-              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-92"
+              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-93"
               id="device-actions-action-1"
             >
               <span
-                class="MuiSpeedDialAction-staticTooltipLabel emotion-93"
+                class="MuiSpeedDialAction-staticTooltipLabel emotion-94"
                 id="device-actions-action-1-label"
                 style="transition-delay: 120ms;"
               >
@@ -2627,7 +2640,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               </span>
               <button
                 aria-labelledby="device-actions-action-1-label"
-                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-94"
+                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-95"
                 role="menuitem"
                 style="transition-delay: 120ms;"
                 tabindex="-1"
@@ -2648,11 +2661,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </span>
             <span
               aria-label="group-change"
-              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-92"
+              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-93"
               id="device-actions-action-2"
             >
               <span
-                class="MuiSpeedDialAction-staticTooltipLabel emotion-93"
+                class="MuiSpeedDialAction-staticTooltipLabel emotion-94"
                 id="device-actions-action-2-label"
                 style="transition-delay: 90ms;"
               >
@@ -2662,7 +2675,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               </span>
               <button
                 aria-labelledby="device-actions-action-2-label"
-                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-94"
+                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-95"
                 role="menuitem"
                 style="transition-delay: 90ms;"
                 tabindex="-1"
@@ -2683,11 +2696,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </span>
             <span
               aria-label="group-remove"
-              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-92"
+              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-93"
               id="device-actions-action-3"
             >
               <span
-                class="MuiSpeedDialAction-staticTooltipLabel emotion-93"
+                class="MuiSpeedDialAction-staticTooltipLabel emotion-94"
                 id="device-actions-action-3-label"
                 style="transition-delay: 60ms;"
               >
@@ -2697,7 +2710,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               </span>
               <button
                 aria-labelledby="device-actions-action-3-label"
-                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-94"
+                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-95"
                 role="menuitem"
                 style="transition-delay: 60ms;"
                 tabindex="-1"
@@ -2705,7 +2718,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               >
                 <svg
                   aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-107"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-108"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -2717,11 +2730,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
             </span>
             <span
               aria-label="create-deployment"
-              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-92"
+              class="MuiSpeedDialAction-staticTooltip MuiSpeedDialAction-tooltipPlacementLeft MuiSpeedDialAction-staticTooltipClosed emotion-93"
               id="device-actions-action-4"
             >
               <span
-                class="MuiSpeedDialAction-staticTooltipLabel emotion-93"
+                class="MuiSpeedDialAction-staticTooltipLabel emotion-94"
                 id="device-actions-action-4-label"
                 style="transition-delay: 30ms;"
               >
@@ -2731,7 +2744,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-33:focus::-ms-input-
               </span>
               <button
                 aria-labelledby="device-actions-action-4-label"
-                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-94"
+                class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeSmall MuiFab-default MuiSpeedDialAction-fab MuiSpeedDialAction-fabClosed emotion-95"
                 role="menuitem"
                 style="transition-delay: 30ms;"
                 tabindex="-1"


### PR DESCRIPTION
## Summary

On the device-details drawer, the trailing tabs (e.g. **Troubleshoot**, **Monitoring**) become unreachable on narrow / mobile viewports — there is no way to scroll the tab strip to them. Reported as ME-683 (reproduced on mobile Firefox).

### Root cause

`frontend/src/js/components/devices/ExpandedDevice.tsx` renders `<Tabs>` with MUI's default `variant="standard"`, which has **no horizontal scrolling** — overflowing tabs are clipped, with no scroll buttons and no touch-drag.

This stayed hidden until `72d1fa0c` _("refactor(gui): adopted basedrawer across applicable drawer instances", 2026-04-14)_ migrated the drawer to `<BaseDrawer size="lg">`. `BaseDrawer` pins the paper width (`100vw` on mobile, `67vw` at ≥sm), whereas the previous `<Drawer>` set only `minWidth` and grew with its content — so the user could pan/slide horizontally to reach the hidden tabs. With a fixed width the standard strip now clips and the last tabs are stranded.

### Fix

Make the tab strip scroll on its own, independent of drawer width — the standard MUI pattern:

```jsx
<Tabs ... variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
```

`allowScrollButtonsMobile` keeps the scroll arrows available on touch (MUI hides them on mobile by default); native touch-drag scrolling comes with `scrollable`.

### Notes

- Test-first: the first commit is the failing regression test (asserts the scroller carries `tabsClasses.scrollableX`); the fix + snapshot update follow.
- Verified locally with `vitest` — test red before the fix, green after.
