### PR TITLE
fix(deviceconnect): resolve send on closed channel panic in PipeWriter

### DIFF
--- a/backend/services/deviceconnect/app/playback.go
+++ b/backend/services/deviceconnect/app/playback.go
@@ -24,33 +24,22 @@ const (
 )
 
 type PipeWriter struct {
-	mu        chan struct{}
 	dataChan  chan []byte
+	closed    chan struct{}
 	closeOnce sync.Once
 }
 
 func NewPipeWriter() *PipeWriter {
-	mu := make(chan struct{}, 1)
-	mu <- struct{}{}
 	return &PipeWriter{
 		dataChan: make(chan []byte),
-		mu:       mu,
+		closed:   make(chan struct{}),
 	}
 }
 
-func (r *PipeWriter) Write(d []byte) (n int, err error) {
-	if _, open := <-r.mu; !open {
-		return 0, io.EOF
-	}
-	defer func() {
-		if err != io.EOF {
-			r.mu <- struct{}{}
-		}
-	}()
+func (r *PipeWriter) Write(d []byte) (int, error) {
 	select {
-	case <-r.mu:
-		err = io.EOF
-		return 0, err
+	case <-r.closed:
+		return 0, io.EOF
 	case r.dataChan <- d:
 		return len(d), nil
 	}
@@ -62,7 +51,7 @@ func (r *PipeWriter) RecvChan() <-chan []byte {
 
 func (r *PipeWriter) Close() error {
 	r.closeOnce.Do(func() {
-		close(r.mu)
+		close(r.closed)
 	})
 
 	return nil

--- a/backend/services/deviceconnect/app/playback_test.go
+++ b/backend/services/deviceconnect/app/playback_test.go
@@ -34,15 +34,21 @@ func TestPipeWriter(t *testing.T) {
 	select {
 	case actual := <-r.RecvChan():
 		assert.Equal(t, d, actual, "did not receive the data written to PipeWriter")
-	case err := <-errCh:
-		assert.NoError(t, err, "unexpected error from PipeWriter.Write")
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for PipeWriter data")
 	}
 
+	// Drain errCh so we can re-use it below and avoid dangerous re-assignment
+	// (errCh = make(chan error, 1)) which is prone to data race
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "unexpected error from PipeWriter.Write")
+	default:
+		t.Fatal("no error in error channel")
+	}
+
 	assert.NoError(t, r.Close())
 
-	errCh = make(chan error, 1)
 	go func() {
 		_, err := r.Write(d)
 		errCh <- err


### PR DESCRIPTION
**Description**
Fix a race condition leading to `send on closed channel` panic in the deviceconnect PipeWriter. When the `mu` channel is closed between the `return len(d), nil` (line 44) and the deferred `r.mu <- struct{}{}` (line 47) the result is the above mentioned panic. I don't think the close handling of this PipeWriter needs to be that extravagant and this simpler version does the trick just fine afaict.

This issue has been provoked a couple of times in our CI test runs ([here](https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/jobs/14935180104) for example) and is made quite clear if one runs the tests with the race detector (`--race`).

Ticket: None