### PR TITLE
ci: pull CI job images from ECR instead of GitLab Dependency Proxy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ variables:
     description: "ECR registry endpoint that fronts the Docker Hub pull-through cache"
   MIRROR_REGISTRY:
     value: "017659451055.dkr.ecr.eu-central-1.amazonaws.com/dockerhub"
-    description: "Registry mirror for Docker Hub images - used in Dockerfiles (--build-arg REGISTRY) and docker-compose files"
+    description: "Registry mirror for Docker Hub images - used in Dockerfiles (--build-arg REGISTRY), docker-compose files and CI job images (image:/services:)"
 
   GOCOVERDIR: "${CI_PROJECT_DIR}/backend/tests/cover"
 
@@ -185,7 +185,6 @@ renovate:
   - mkdir -p $HOME/.docker && echo $DOCKER_AUTH_CONFIG > $HOME/.docker/config.json
   - unset DOCKER_AUTH_CONFIG
   - docker login --username $CI_REGISTRY_USER --password $CI_REGISTRY_PASSWORD $CI_REGISTRY
-  - docker login --username $CI_DEPENDENCY_PROXY_USER --password $CI_DEPENDENCY_PROXY_PASSWORD $CI_DEPENDENCY_PROXY_SERVER
 
 .ecr-login: &ecr-login
   - if ! command -v aws > /dev/null 2>&1; then apk add --no-cache aws-cli; fi
@@ -217,9 +216,9 @@ renovate:
   stage: build
   extends: .build:base
   needs: []
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  image: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-cli
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   variables:
     DOCKER_BUILDARGS: "--push"
@@ -291,7 +290,7 @@ build:backend:docker-integration-tester:
 #
 review:deploy:
   stage: review
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
   needs:
     - job: build:backend:docker
       artifacts: false
@@ -378,7 +377,7 @@ review:deploy:
     - echo "Review app deployed successfully!"
 review:stop:
   stage: review
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
   needs: []
   rules:
     # Trigger on manual stop or branch deletion
@@ -434,7 +433,7 @@ test:backend:static:
     - changes:
         paths: ["backend/**/*.go", "backend/go.mod", ".gitlab-ci.yml"]
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
-  image: "${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
+  image: "${MIRROR_REGISTRY}/golangci/golangci-lint:${IMAGE_GOLANGCI_VERSION}"
   script:
     - cd backend
     - golangci-lint run -v
@@ -449,13 +448,14 @@ test:backend:static:
         paths: ["backend/docs/api/*.yaml", "backend/docs/api/**/*.yaml"]
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
       when: on_success
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  image: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-cli
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   before_script:
     - apk add --no-cache npm make
     - npm install -g @redocly/cli@2.2.2
+    - *ecr-login
   artifacts:
     when: always
     expire_in: 2 weeks
@@ -467,7 +467,7 @@ test:backend:api-spec:
   script:
     - make -C backend generate-openapi-spec
     - git diff --exit-code backend/docs/api/dist/openapi.yaml
-    - make -C backend tests/mender_client
+    - make -C backend tests/mender_client MIRROR_REGISTRY="${MIRROR_REGISTRY}"
     - git diff --exit-code backend/tests/mender_client
   allow_failure: false
 
@@ -502,7 +502,7 @@ test:backend:validate-open-api:
       when: on_success
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/base-alpine:master
   before_script:
     - curl -L https://raw.githubusercontent.com/stoplightio/spectral/master/scripts/install.sh -o install.sh
     - sh install.sh
@@ -537,7 +537,7 @@ test:backend:unit:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/mongo:${MONGO_VERSION}
+    - name: ${MIRROR_REGISTRY}/library/mongo:${MONGO_VERSION}
       alias: mongo
   variables:
     TEST_MONGO_URL: "mongodb://mongo"
@@ -557,7 +557,7 @@ test:backend:unit:
     - k8s
 
 test:backend:acceptance:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  image: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-cli
   extends: .build:base
   stage: test
   rules:
@@ -568,7 +568,7 @@ test:backend:acceptance:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   needs:
     - job: build:backend:docker
@@ -597,7 +597,7 @@ test:backend:acceptance:
       - ${GOCOVERDIR}/*-acceptance
 
 .template:test:backend:integration:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-cli
+  image: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-cli
   stage: test
   extends: .build:base
   rules:
@@ -612,7 +612,7 @@ test:backend:acceptance:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
       variables:
         HEALTHCHECK_TCP_PORT: "2376"
@@ -708,12 +708,12 @@ test:integration:
 test:prep:
   stage: test
   extends: .build:base
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker
+  image: ${MIRROR_REGISTRY}/library/docker
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   script:
     - docker create --name stress-client mendersoftware/mender-stress-test-client:master
@@ -725,10 +725,10 @@ test:prep:
     expire_in: 2w
 
 .template:test:staging-deployment:
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
   stage: .post
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   rules:
     - when: never
@@ -783,7 +783,7 @@ test:staging-deployment:firefox:
 
 publish:backend:coverage:
   stage: publish
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:${GOLANG_VERSION}-alpine
+  image: ${MIRROR_REGISTRY}/library/golang:${GOLANG_VERSION}-alpine
   needs:
     - job: test:backend:unit
       artifacts: true
@@ -831,7 +831,7 @@ publish:backend:coverage:
 publish:backend:docker:
   stage: publish
   image:
-    name: quay.io/skopeo/stable:${SKOPEO_VERSION}
+    name: ${ECR_REGISTRY}/quay/skopeo/stable:${SKOPEO_VERSION}
     # https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#override-the-entrypoint-of-an-image
     entrypoint: [""]
   rules:
@@ -880,7 +880,7 @@ publish:backend:licenses:
         compare_to: "${RULES_CHANGES_COMPARE_TO_REF}"
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/golang:${GOLANG_VERSION}
+  image: ${MIRROR_REGISTRY}/library/golang:${GOLANG_VERSION}
   variables:
     GOFLAGS: -tags=nopkcs11
   before_script:
@@ -908,7 +908,7 @@ publish:licenses:docs-site:
     # Only make available for stable branches
     - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
       allow_failure: true
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/release-please:master
   needs:
     - job: publish:backend:licenses
       artifacts: true
@@ -938,7 +938,7 @@ publish:licenses:docs-site:
 
 
 changelog:
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/release-please:master
   stage: changelog
   variables:
     GIT_DEPTH: 0 # Always get the full history
@@ -1021,7 +1021,7 @@ changelog:
     - git remote remove github-${CI_JOB_ID}
 
 release:github:
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/release-please:master
   stage: .post
   rules:
     # Only make available for protected branches (main and maintenance branches)
@@ -1039,7 +1039,7 @@ release:github:
       --target-branch=${CI_COMMIT_REF_NAME}
 
 release:mender-docs-changelog:
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/release-please:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/release-please:master
   stage: .post
   rules:
     # Only make available for stable branches
@@ -1105,7 +1105,7 @@ release:mender-docs-changelog:saas:
     - if: '$CI_COMMIT_REF_NAME =~ /^\d+\.\d+\.x$/' # Disabled on Maintenance branches
       when: never
   allow_failure: true
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/aws-k8s-toolbox:master
   variables:
     HELM_PATCH_VERSION: ${CI_PIPELINE_ID}
   before_script:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,6 +8,8 @@ MENDER_PUBLISH_REGISTRY ?= docker.io
 MENDER_PUBLISH_REPOSTIORY ?= mendersoftware
 MENDER_PUBLISH_TAG ?= $(MENDER_IMAGE_TAG)
 
+MIRROR_REGISTRY ?= docker.io
+
 SERVICES = $(subst services,,$(subst /,,$(sort $(dir $(wildcard services/*/)))))
 BUILD_TARGETS := $(addsuffix -build, $(SERVICES))
 TEST_TARGETS := $(addsuffix -test, $(SERVICES))
@@ -54,7 +56,7 @@ tests/mender_client: $(COMBINED_SPEC)
 	docker run --rm -t -v $(MAKEDIR):/work -w /work \
 		--ulimit nofile=65536:65536 \
 		-u $(shell id -u):$(shell id -g) \
-		openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION} generate \
+		$(MIRROR_REGISTRY)/openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION} generate \
 		-g python -i $< \
 		-c $(dir $@).openapi-generator.yaml \
 		-o $(dir $@)

--- a/frontend/pipeline.yml
+++ b/frontend/pipeline.yml
@@ -9,7 +9,7 @@ variables:
 
 test:frontend:lint:
   stage: test
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
+  image: ${MIRROR_REGISTRY}/library/${NODE_IMAGE}
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^(staging|saas-[a-zA-Z0-9.]+)$/
       when: never
@@ -24,7 +24,7 @@ test:frontend:lint:
 
 test:frontend:prettier:
   stage: test
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
+  image: ${MIRROR_REGISTRY}/library/${NODE_IMAGE}
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^(staging|saas-[a-zA-Z0-9.]+)$/
       when: never
@@ -38,7 +38,7 @@ test:frontend:prettier:
     - npm run format:check
 
 test:frontend:license-headers:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/denoland/deno:debian-2.0.2
+  image: ${MIRROR_REGISTRY}/denoland/deno:debian-2.0.2
   stage: test
   rules:
     - changes:
@@ -54,7 +54,7 @@ test:frontend:license-headers:
     - git diff --exit-code frontend/tests
 
 test:frontend:licenses:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/denoland/deno:debian-2.0.2
+  image: ${MIRROR_REGISTRY}/denoland/deno:debian-2.0.2
   stage: test
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^(staging|saas-[a-zA-Z0-9.]+)$/
@@ -77,7 +77,7 @@ test:frontend:licenses:
 
 test:frontend:unit:
   stage: test
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
+  image: ${MIRROR_REGISTRY}/library/${NODE_IMAGE}
   rules:
     - changes:
         paths: ['frontend/**/*']
@@ -106,7 +106,7 @@ test:frontend:unit:
 
 test:frontend:docs-links:
   stage: test
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/${NODE_IMAGE}
+  image: ${MIRROR_REGISTRY}/library/${NODE_IMAGE}
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^(staging|saas-[a-zA-Z0-9.]+)$/
       when: never
@@ -165,7 +165,7 @@ build:frontend:docker:
 
 .template:test:frontend:acceptance:
   stage: test
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/gui-e2e-testing:master
   extends: .build:base
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -181,7 +181,7 @@ build:frontend:docker:
       artifacts: false
       optional: true
   services:
-    - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
+    - name: ${MIRROR_REGISTRY}/library/docker:${DOCKER_VERSION}-dind
       alias: docker
   before_script:
     - !reference [.requires-docker]
@@ -250,7 +250,7 @@ test:frontend:acceptance:enterprise:qemu:
 
 publish:frontend:tests:
   stage: publish
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/base-alpine:master
   rules:
     - if: $CI_COMMIT_REF_PROTECTED == "true"
       when: on_success
@@ -277,7 +277,7 @@ publish:frontend:tests:
 
 publish:frontend:e2e-tests:
   stage: publish
-  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/base-alpine:master
+  image: ${ECR_REGISTRY}/gitlab/northern.tech/mender/mender-test-containers/base-alpine:master
   rules:
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
@@ -353,7 +353,7 @@ publish:frontend:licenses:
         compare_to: '${RULES_CHANGES_COMPARE_TO_REF}'
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: on_success
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/denoland/deno:debian-2.0.2
+  image: ${MIRROR_REGISTRY}/denoland/deno:debian-2.0.2
   needs:
     - job: build:frontend:docker
       artifacts: true
@@ -366,7 +366,7 @@ publish:frontend:licenses:
       - frontend/licenses.md
 
 publish:frontend:sentry:finalize:
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/getsentry/sentry-cli
+  image: ${MIRROR_REGISTRY}/getsentry/sentry-cli
   stage: .post
   rules:
     - if: $SENTRY_AUTH_TOKEN == null


### PR DESCRIPTION
Replace ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX} on every job image:/services: with the ECR pull-through cache mirror; official Docker Hub images get an explicit library/ path. Route the quay.io skopeo image and the registry.gitlab.com mender-test-containers images through the ECR quay/ and gitlab/ caches.

Ticket: QA-1669

Co-authored-with: Claude

Requires:
* [ ] https://github.com/mendersoftware/saas/pull/1918/changes