### PR TITLE
MEN-7891 - fix(gui): excluded status from device identity details as it's shown below

### DIFF
--- a/frontend/src/js/components/devices/device-details/Identity.tsx
+++ b/frontend/src/js/components/devices/device-details/Identity.tsx
@@ -43,7 +43,7 @@ export const DeviceIdentity = ({ device, setSnackbar }) => {
   const { created_ts, tier, id, identity_data = {}, status = DEVICE_STATES.accepted, flags = {} } = device;
   const isTestDevice = !!flags.test_device;
   const testDeviceCount = useSelector(getTestDeviceCount);
-  const { mac, ...remainingIdentity } = identity_data;
+  const { mac, status: _status, ...remainingIdentity } = identity_data;
 
   const content = {
     ID: id || '-',


### PR DESCRIPTION
the main issue from the ticket was solved in https://github.com/mendersoftware/mender-server/pull/379 - but what's considered to be the device identity information is still misaligned between this section + the device identity text at the top + the status has a separate section all for itself 
<img width="493" height="368" alt="Screenshot 2026-06-25 at 13 13 42" src="https://github.com/user-attachments/assets/f2a54327-c3e4-4299-9022-970c4800a84e" />
vs.
<img width="617" height="388" alt="Screenshot 2026-06-25 at 13 13 53" src="https://github.com/user-attachments/assets/4e933df0-0281-4956-af19-15f61f19d49c" />