### PR TITLE
MEN-8279 - fix(gui): align delete icons across ui

### DIFF
--- a/frontend/src/js/components/dashboard/__snapshots__/SoftwareDistribution.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/__snapshots__/SoftwareDistribution.test.tsx.snap
@@ -436,12 +436,12 @@ exports[`Devices Component > renders correctly 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
-                data-testid="ClearIcon"
+                data-testid="DeleteIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
                 />
               </svg>
             </button>
@@ -1701,12 +1701,12 @@ exports[`Devices Component > renders correctly without data retrieval 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
-                data-testid="ClearIcon"
+                data-testid="DeleteIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
                 />
               </svg>
             </button>

--- a/frontend/src/js/components/dashboard/widgets/Distribution.tsx
+++ b/frontend/src/js/components/dashboard/widgets/Distribution.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router';
 
-import { Clear as ClearIcon, Settings, Square } from '@mui/icons-material';
+import { Delete as DeleteIcon, Settings, Square } from '@mui/icons-material';
 import { IconButton, LinearProgress, linearProgressClasses } from '@mui/material';
 import { makeStyles } from 'tss-react/mui';
 
@@ -306,7 +306,7 @@ export const DistributionReport = ({ onClick, onSave, selection = {}, software: 
               <Settings fontSize="small" />
             </IconButton>
             <IconButton onClick={toggleRemoving} size="small">
-              <ClearIcon fontSize="small" />
+              <DeleteIcon fontSize="small" />
             </IconButton>
           </div>
         </div>

--- a/frontend/src/js/components/dashboard/widgets/__snapshots__/Distribution.test.tsx.snap
+++ b/frontend/src/js/components/dashboard/widgets/__snapshots__/Distribution.test.tsx.snap
@@ -263,12 +263,12 @@ exports[`Distribution Component > renders correctly 1`] = `
               <svg
                 aria-hidden="true"
                 class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-3"
-                data-testid="ClearIcon"
+                data-testid="DeleteIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
                 />
               </svg>
             </button>

--- a/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
+++ b/frontend/src/js/components/devices/__snapshots__/ExpandedDevice.test.tsx.snap
@@ -2719,11 +2719,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-34:focus::-ms-input-
                 <svg
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-108"
+                  data-testid="DeleteIcon"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z"
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
                   />
                 </svg>
               </button>

--- a/frontend/src/js/components/devices/widgets/DeviceQuickActions.tsx
+++ b/frontend/src/js/components/devices/widgets/DeviceQuickActions.tsx
@@ -17,6 +17,7 @@ import { useSelector } from 'react-redux';
 import {
   AddCircle as AddCircleIcon,
   CheckCircle as CheckCircleIcon,
+  Delete as DeleteIcon,
   HeightOutlined as HeightOutlinedIcon,
   HighlightOffOutlined as HighlightOffOutlinedIcon,
   RemoveCircleOutlined as RemoveCircleOutlineIcon,
@@ -25,7 +26,6 @@ import {
 
 import { mdiFlaskOutline as TestIcon } from '@mdi/js';
 import { mdiFlaskOffOutline as TestOffIcon } from '@mdi/js';
-import { mdiTrashCanOutline as TrashCan } from '@mdi/js';
 import MaterialDesignIcon from '@northern.tech/common-ui/MaterialDesignIcon';
 import { BaseQuickActions, type QuickAction } from '@northern.tech/common-ui/QuickActions';
 import { DEVICE_STATES, TIMEOUTS, UNGROUPED_GROUP, onboardingSteps } from '@northern.tech/store/constants';
@@ -108,7 +108,7 @@ const defaultActions = {
     checkRelevance: ({ selectedGroup, userCapabilities: { canWriteDevices } }) => canWriteDevices && !!selectedGroup
   },
   removeFromGroup: {
-    icon: <MaterialDesignIcon path={TrashCan} fontSize="small" />,
+    icon: <DeleteIcon fontSize="small" />,
     key: 'group-remove',
     title: pluralized => `Remove selected ${pluralized} from this group`,
     action: ({ onRemoveDevicesFromGroup, selection }) => onRemoveDevicesFromGroup(selection),


### PR DESCRIPTION
before:
<img width="438" height="269" alt="Screenshot 2026-06-25 at 14 05 02" src="https://github.com/user-attachments/assets/5f71bff4-079a-4442-b864-2e8876a0655d" />
vs
<img width="410" height="263" alt="Screenshot 2026-06-25 at 14 04 45" src="https://github.com/user-attachments/assets/3edc2d37-a25b-4c0f-a7cb-8ffdbdf7e0b1" />

in similar situations in the custom column dialog + key value editor I've stuck to the existing `Clear` icon as this seemed to more align with a "clear" in other forms (e.g. search input) - although it might cause removal, the intent is likely more to update & set new input values