### PR TITLE
MEN-8386 - fix(gui): hide pat creation and revocation for read-only users

### DIFF
--- a/frontend/src/js/components/settings/user-management/SelfUserManagement.tsx
+++ b/frontend/src/js/components/settings/user-management/SelfUserManagement.tsx
@@ -26,7 +26,15 @@ import PasswordInput from '@northern.tech/common-ui/forms/PasswordInput';
 import TextInput from '@northern.tech/common-ui/forms/TextInput';
 import storeActions from '@northern.tech/store/actions';
 import { DARK_MODE, LIGHT_MODE, OWN_USER_ID } from '@northern.tech/store/constants';
-import { getCurrentSession, getCurrentUser, getFeatures, getIsDarkMode, getIsEnterprise, getUserSettings } from '@northern.tech/store/selectors';
+import {
+  getCurrentSession,
+  getCurrentUser,
+  getFeatures,
+  getIsDarkMode,
+  getIsEnterprise,
+  getUserCapabilities,
+  getUserSettings
+} from '@northern.tech/store/selectors';
 import { useAppDispatch } from '@northern.tech/store/store';
 import { editUser, passwordResetStart, saveUserSettings, verifyEmailStart } from '@northern.tech/store/thunks';
 import { toggle } from '@northern.tech/utils/helpers';
@@ -77,6 +85,7 @@ export const SelfUserManagement = () => {
   const isDarkMode = useSelector(getIsDarkMode);
   const { token } = useSelector(getCurrentSession);
   const [showNotice, setShowNotice] = useState<string>('');
+  const { canManageUsers } = useSelector(getUserCapabilities);
 
   const editSubmit = userData => {
     if (userData.password != userData.password_confirmation) {
@@ -266,7 +275,7 @@ export const SelfUserManagement = () => {
         }
         sideBarContent={<CopyTextToClipboard token={token} />}
       />
-      <AccessTokenManagement />
+      {canManageUsers && <AccessTokenManagement />}
       {isEnterprise && hasTracking && (
         <ToggleSettingsItem
           description="Enable usage data and errors to be sent to help us improve our service."


### PR DESCRIPTION
note the lack of a PAT section in the settings there:

<img width="1124" height="731" alt="Screenshot 2026-06-25 at 14 39 47" src="https://github.com/user-attachments/assets/417a51a1-91fa-408f-a3fa-ea7ea157393c" />
