### PR TITLE
MEN-9736 - fix(gui): stop filtering out current group from move-to-group dialog

### DIFF
--- a/frontend/src/js/components/devices/group-management/CreateGroup.tsx
+++ b/frontend/src/js/components/devices/group-management/CreateGroup.tsx
@@ -17,7 +17,7 @@ import { useSelector } from 'react-redux';
 import { Button, DialogActions, DialogContent } from '@mui/material';
 
 import { BaseDialog } from '@northern.tech/common-ui/dialogs/BaseDialog';
-import { getGroups, getSelectedGroupInfo } from '@northern.tech/store/selectors';
+import { getGroups } from '@northern.tech/store/selectors';
 
 import GroupDefinition from './GroupDefinition';
 
@@ -28,7 +28,6 @@ export const CreateGroup = ({ addListOfDevices, fromFilters, isCreation, onClose
   const [newGroup, setNewGroup] = useState('');
   const [title, setTitle] = useState(isCreationDynamic ? 'Create a new group' : `Add ${selectedDevices.length ? 'selected ' : ''}devices to group`);
 
-  const { selectedGroup } = useSelector(getSelectedGroupInfo);
   // ensure that existing dynamic groups are only listed if a dynamic group should be created
   const { dynamic, static: staticGroups } = useSelector(getGroups);
   const groups = fromFilters ? [...staticGroups.map(g => g.groupId), ...dynamic.map(g => g.groupId)] : staticGroups.map(g => g.groupId);
@@ -50,7 +49,6 @@ export const CreateGroup = ({ addListOfDevices, fromFilters, isCreation, onClose
           newGroup={newGroup}
           onInputChange={(invalidName, name, isModification) => onNameChange(invalidName, name, isModification)}
           selectedDevices={selectedDevices}
-          selectedGroup={selectedGroup}
         />
       </DialogContent>
       <DialogActions>

--- a/frontend/src/js/components/devices/group-management/GroupDefinition.tsx
+++ b/frontend/src/js/components/devices/group-management/GroupDefinition.tsx
@@ -54,7 +54,7 @@ export const validateGroupName = (encodedName: string, groups = [], selectedDevi
 
 const GroupOption = (props, option) => <li {...props}>{option.title}</li>;
 
-export const GroupDefinition = ({ isCreationDynamic, groups, newGroup, onInputChange, selectedDevices, selectedGroup }) => {
+export const GroupDefinition = ({ isCreationDynamic, groups, newGroup, onInputChange, selectedDevices }) => {
   const [errorText, setErrorText] = useState('');
 
   const validateName = (encodedName: string) => {
@@ -63,12 +63,7 @@ export const GroupDefinition = ({ isCreationDynamic, groups, newGroup, onInputCh
     onInputChange(invalid, name, isModification);
   };
 
-  const filteredGroups = groups
-    .filter(group => group !== selectedGroup)
-    .map(group => ({
-      value: group,
-      title: group
-    }));
+  const mappedGroups = groups.map(group => ({ value: group, title: group }));
   return (
     <>
       <Autocomplete
@@ -102,7 +97,7 @@ export const GroupDefinition = ({ isCreationDynamic, groups, newGroup, onInputCh
         }}
         handleHomeEndKeys
         inputValue={newGroup}
-        options={filteredGroups}
+        options={mappedGroups}
         onInputChange={(e, newValue) => validateName(newValue)}
         renderInput={params => <TextField {...params} label="Select a group, or type to create new" />}
         renderOption={GroupOption}


### PR DESCRIPTION
The destination group dropdown excluded the currently-open sidebar group, preventing users from moving devices into the group they were viewing