### PR TITLE
ci: force chore type for all renovate updates to avoid unintended server version bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,15 +6,15 @@
   "extends": [
     "config:recommended",
     ":gitSignOff",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":semanticCommitTypeAll(chore)"
   ],
 
   // CODEOWNERS drives reviewer assignment. Keep CODEOWNERS complete.
   "reviewersFromCodeOwners": true,
 
-  // chore(deps): <desc>, matching the old Dependabot prefix. CI files get ci: below.
+  // chore(deps): <desc>, matching the old Dependabot prefix.
   "semanticCommits": "enabled",
-  "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
 
   // Fallback window for weeks with no merges; the .pre CI job is the primary trigger.
@@ -89,10 +89,9 @@
   ],
 
   "packageRules": [
-    // GitLab CI image bumps -> ci: (keeps them out of the deps changelog section).
+    // GitLab CI image bumps
     {
       "matchManagers": ["gitlabci", "gitlabci-include"],
-      "semanticCommitType": "ci",
       "semanticCommitScope": ""
     },
 


### PR DESCRIPTION
to prevent bumps like: https://github.com/mendersoftware/mender-server/pull/1985 - based on  https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-type - unfortunately there doesn't seem to be a "per dependency group"/ regular config setting (at least based on [the config schema](https://docs.renovatebot.com/renovate-schema.json))