### PR TITLE
ME-680 - fix(gui): clear stale group selection when opening devices from search

### DIFF
--- a/frontend/src/js/components/devices/DeviceGroups.tsx
+++ b/frontend/src/js/components/devices/DeviceGroups.tsx
@@ -183,6 +183,8 @@ export const DeviceGroups = () => {
     } else if (filters.length) {
       // dispatch setDeviceFilters even when filters are empty, otherwise filter will not be reset
       dispatch(setDeviceFilters(filters));
+    } else if (selectedGroup) {
+      dispatch(selectGroup({ group: '' }));
     }
     // preset selectedIssues and selectedId with empty values, in case if remain properties are missing them
     const listState = { ...remainder };


### PR DESCRIPTION
only consider a pre-existing group selection when navigating if the url is set accordingly - otherwise assume device selection is preferred

Ticket: ME-680