### PR TITLE
feat(inventory): support additional MongoDB operators

### DIFF
--- a/backend/services/inventory/model/filters.go
+++ b/backend/services/inventory/model/filters.go
@@ -23,7 +23,20 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/rest.utils"
 )
 
-var validSelectors = []interface{}{"$eq", "$in", "$nin"}
+var validSelectors = []interface{}{
+	"$eq",
+	"$gt",
+	"$gte",
+	"$in",
+	"$lt",
+	"$lte",
+	"$ltne",
+	"$ne",
+	"$nin",
+	"$exists",
+	"$regex",
+}
+
 var validSortOrders = []interface{}{"asc", "desc"}
 var validScopes = []string{"system", "identity", "inventory", "monitor", "tags"}
 

--- a/backend/services/inventory/model/filters_test.go
+++ b/backend/services/inventory/model/filters_test.go
@@ -82,7 +82,7 @@ func TestSearchParams(t *testing.T) {
 					{
 						Scope:     "system",
 						Attribute: "attribute",
-						Type:      "$regex",
+						Type:      "$foo",
 						Value:     "value",
 					},
 				},


### PR DESCRIPTION
With this commit we add support for given operators: $gt, $gte, $lt, $lte, $ltne, $ne, $exists, $regex

Ticket: MEN-9927