### PR TITLE
chore: backport pagination test improvements to 4.1.x

### DIFF
--- a/frontend/tests/e2e_tests/integration/03-advanced/04-deployments.spec.ts
+++ b/frontend/tests/e2e_tests/integration/03-advanced/04-deployments.spec.ts
@@ -149,11 +149,12 @@ test.describe('Deployments', () => {
     await page.getByText(/rows/i).scrollIntoViewIfNeeded();
     // 10 clicks as anything leading outside of the 50 + something releases present (considering the 10 item page size)
     for (let clickAttempt = 0; clickAttempt < 10; clickAttempt++) {
-      const paginationButton = page.getByRole('button', { name: 'next' });
-      if (await paginationButton.isDisabled()) {
+      try {
+        await page.getByRole('button', { name: 'next' }).click({ noWaitAfter: true, force: true });
+      } catch {
+        // the pagination component may re-render between clicks, momentarily hiding the button - just retry
         continue;
       }
-      await paginationButton.click({ noWaitAfter: true, force: true });
     }
     await expect(page.getByText(/-([5|6]\d) of \1/)).toBeVisible(); // depending on the deployment speed of other tests there might be slightly more than 50
     await expect(page.getByText(/queued to start/i).first()).toBeVisible();


### PR DESCRIPTION
**Description**
Backport https://github.com/mendersoftware/mender-server/pull/1389 to 4.1.x to hopefully avoid failures like these in the future: https://gitlab.com/Northern.tech/Mender/mender-server/-/jobs/15328592773

(cherry picked from commit 4cbf9ce798cef8b263dfb9697e0ea9d714d5c953)