### PR TITLE
fix(deviceconnect): enforce tenant access scope for device connections

### DIFF
--- a/backend/services/deviceconnect/api/http/device.go
+++ b/backend/services/deviceconnect/api/http/device.go
@@ -136,7 +136,7 @@ func (h DeviceController) Connect(c *gin.Context) {
 		return
 	}
 
-	listener, err := h.nats.Listen(idata.Subject)
+	listener, err := h.nats.Listen(idata.Tenant + ":" + idata.Subject)
 	if err != nil {
 		_ = c.Error(err)
 		c.JSON(http.StatusInternalServerError, gin.H{

--- a/backend/services/deviceconnect/api/http/device_test.go
+++ b/backend/services/deviceconnect/api/http/device_test.go
@@ -129,7 +129,7 @@ func TestDeviceConnect(t *testing.T) {
 	connCh := make(chan stream.Conn, 1)
 	listener := setupMockListener(t, connCh)
 	natsClient := nats_mocks.NewClient(t)
-	natsClient.On("Listen", Identity.Subject).
+	natsClient.On("Listen", Identity.Tenant+":"+Identity.Subject).
 		Return(listener, nil)
 
 	router, _ := NewRouter(app, natsClient, nil)

--- a/backend/services/deviceconnect/api/http/internal.go
+++ b/backend/services/deviceconnect/api/http/internal.go
@@ -74,7 +74,7 @@ func (h InternalController) sendMenderCommand(c *gin.Context, msgType string) {
 
 func sendMenderCommand(ctx context.Context, nc nats.Client, tenantID, deviceID, cmd string) error {
 	recvAddr := fmt.Sprintf("%s:cmd%s", tenantID, uuid.NewString())
-	s, err := nc.Connect(ctx, recvAddr, deviceID)
+	s, err := nc.Connect(ctx, recvAddr, tenantID+":"+deviceID)
 	if err != nil {
 		return err
 	}

--- a/backend/services/deviceconnect/api/http/internal_test.go
+++ b/backend/services/deviceconnect/api/http/internal_test.go
@@ -300,7 +300,7 @@ func TestInternalSendInventory(t *testing.T) {
 				natsClient.On("Connect",
 					contextMatcher,
 					mock.MatchedBy(func(s string) bool { return strings.HasPrefix(s, tc.TenantID+":cmd") }),
-					tc.DeviceID,
+					tc.TenantID+":"+tc.DeviceID,
 				).
 					Return(func(
 						ctx context.Context, localAddr, remoteAddr string,

--- a/backend/services/deviceconnect/api/http/management.go
+++ b/backend/services/deviceconnect/api/http/management.go
@@ -164,7 +164,11 @@ func (h ManagementController) Connect(c *gin.Context) {
 		Types:              []string{},
 	}
 
-	s, err := h.nats.Connect(ctx, session.TenantID+":"+session.ID, session.DeviceID)
+	s, err := h.nats.Connect(
+		ctx,
+		session.TenantID+":"+session.ID,
+		session.TenantID+":"+session.DeviceID,
+	)
 	if err != nil {
 		if errors.Is(err, stream.ErrConnectionRefused) {
 			rest.RenderErrorWithMessage(c, http.StatusNotFound, err,

--- a/backend/services/deviceconnect/api/http/management_filetransfer.go
+++ b/backend/services/deviceconnect/api/http/management_filetransfer.go
@@ -492,7 +492,7 @@ func (h ManagementController) DownloadFile(c *gin.Context) {
 
 	srcAddr := fmt.Sprintf("%s:%s", sess.TenantID, sess.ID)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, fileTransferTimeout)
-	conn, err := h.nats.Connect(ctxWithTimeout, srcAddr, sess.DeviceID)
+	conn, err := h.nats.Connect(ctxWithTimeout, srcAddr, sess.TenantID+":"+sess.DeviceID)
 	cancel()
 	if err != nil {
 		switch {
@@ -880,7 +880,7 @@ func (h ManagementController) UploadFile(c *gin.Context) {
 
 	srcAddr := fmt.Sprintf("%s:%s", sess.TenantID, sess.ID)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, fileTransferTimeout)
-	conn, err := h.nats.Connect(ctxWithTimeout, srcAddr, sess.DeviceID)
+	conn, err := h.nats.Connect(ctxWithTimeout, srcAddr, sess.TenantID+":"+sess.DeviceID)
 	cancel()
 	if err != nil {
 		switch {

--- a/backend/services/deviceconnect/api/http/management_filetransfer_test.go
+++ b/backend/services/deviceconnect/api/http/management_filetransfer_test.go
@@ -99,7 +99,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -258,7 +258,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -433,7 +433,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -534,7 +534,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -638,7 +638,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -799,7 +799,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -853,7 +853,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -979,7 +979,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -1110,7 +1110,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 				conn.On("Close", contextMatcher).
@@ -1220,7 +1220,7 @@ func TestManagementDownloadFile(t *testing.T) {
 					tenantID, _, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(nil, stream.ErrConnectionRefused).
 					Once()
 			},
@@ -1328,7 +1328,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -1446,7 +1446,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -1562,7 +1562,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -1643,7 +1643,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -1749,7 +1749,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -1880,7 +1880,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, _, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(func(ctx context.Context, _, _ string) (stream.Conn, error) {
 						select {
 						case <-ctx.Done():
@@ -1923,7 +1923,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, sessionID, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(conn, nil).
 					Once()
 
@@ -2076,7 +2076,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, _, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(nil, stream.ErrConnectionRefused).
 					Once()
 			},
@@ -2107,7 +2107,7 @@ func TestManagementUploadFile(t *testing.T) {
 					tenantID, _, ok = strings.Cut(srcAddr, ":")
 					return assert.Truef(t, ok, "unexpected srcAddr format: %s", srcAddr) &&
 						assert.Equal(t, "000000000000000000000000", tenantID)
-				}), "1234567890").
+				}), "000000000000000000000000:1234567890").
 					Return(nil, fmt.Errorf("generic error")).
 					Once()
 			},

--- a/backend/services/deviceconnect/api/http/management_test.go
+++ b/backend/services/deviceconnect/api/http/management_test.go
@@ -249,7 +249,7 @@ func TestManagementConnect(t *testing.T) {
 	if !t.Run("dial and connect", func(t *testing.T) {
 		natsClient.On("Connect", contextMatcher, mock.MatchedBy(func(s string) bool {
 			return strings.HasPrefix(s, Identity.Tenant)
-		}), "1234567890").
+		}), Identity.Tenant+":1234567890").
 			Return(streamConn, nil)
 
 		url := "ws" + strings.TrimPrefix(s.URL, "http")
@@ -659,7 +659,7 @@ func TestManagementConnectFailures(t *testing.T) {
 					mock.MatchedBy(func(s string) bool {
 						return strings.HasPrefix(s, tc.Identity.Tenant)
 					}),
-					tc.DeviceID).
+					tc.Identity.Tenant+":"+tc.DeviceID).
 					Return(conn, err).
 					Once()
 			}


### PR DESCRIPTION
The tenant ID was missing from the NATS topic effectively removing the multi-tenancy scope restrictions from the NATS interface. With this commit, any connections made to a device can only reach devices within the same tenant (without external checks/workarounds).