### PR TITLE
MEN-9924: stream transmission control ack messages before buffering

### DIFF
--- a/backend/pkg/stream/nats.go
+++ b/backend/pkg/stream/nats.go
@@ -173,17 +173,17 @@ func (stream *natsStream) handleMessage(ctx context.Context, msg *nats.Msg) erro
 		return stream.term()
 
 	case strings.HasPrefix(msgType, "data"):
-		err := msg.Respond(nil)
-		if err != nil {
-			return fmt.Errorf("failed to ack message: %w", err)
-		}
 		_, seqNumStr, _ := cutLast(msg.Subject, ":")
 		seqNum, _ := strconv.ParseUint(seqNumStr, 10, 32)
 		diff := stream.remoteSeq - uint32(seqNum)
 		if diff == 0 {
-			stream.remoteSeq++
 			select {
 			case stream.recvChan <- msg.Data:
+				stream.remoteSeq++
+				err := msg.Respond(nil)
+				if err != nil {
+					return fmt.Errorf("failed to ack message: %w", err)
+				}
 			default:
 			}
 			return nil


### PR DESCRIPTION
Messages received on a stream are acked before they are buffered, even if the message is eventually dropped. This leads to a protocol error whenever there is a slow consumer at the other end. This commit moves the message acknowledgement and the advancement of the sequence number until after the message is buffered in the application.