### PR TITLE
ci: bump redis to 8.8

### DIFF
--- a/compose/docker-compose.enterprise.yml
+++ b/compose/docker-compose.enterprise.yml
@@ -175,7 +175,7 @@ services:
     image: ${MENDER_IMAGE_REGISTRY:-registry.mender.io}/${MENDER_IMAGE_REPOSITORY:-mender-server-enterprise}/workflows:${MENDER_IMAGE_TAG:-latest}
 
   redis:
-    image: ${MIRROR_REGISTRY:-docker.io}/library/redis:8.6
+    image: ${MIRROR_REGISTRY:-docker.io}/library/redis:8.8
     networks:
       default:
         aliases: [mender-redis]


### PR DESCRIPTION
Switch from redis 8.6 to latest 8.8 in pipeline