### PR TITLE
test(deviceauth): port device auth tests to integration:ng

### DIFF
--- a/backend/tests/runner/tests/opensource/devauth_management_v2_test.go
+++ b/backend/tests/runner/tests/opensource/devauth_management_v2_test.go
@@ -1,0 +1,1463 @@
+//nolint:all // This is all test code
+package opensource
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/mendersoftware/mender-server/pkg/api/client"
+	"github.com/mendersoftware/mender-server/pkg/utils/types"
+	"github.com/mendersoftware/mender-server/services/deviceauth/model"
+	"github.com/mendersoftware/mender-server/tests/runner/tests/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// DevauthManagementV2Suite ports (a subset of) the OS device auth tests
+// from mender-server/backend/tests/integration/test_devauth.py. Enterprise
+// branches (useExistingTenant()) and TestDevAuthCli (covered by acceptance
+// suites) are intentionally not ported.
+type DevauthManagementV2Suite struct {
+	suite.Suite
+
+	APIClient *client.APIClient
+	User      common.User
+	Tenant    common.Tenant
+
+	JWT string
+}
+
+func (i *BackendIntegrationSuite) TestDevauthManagementV2() {
+	suite.Run(i.T(), &DevauthManagementV2Suite{
+		APIClient: i.environment.APIClient(),
+		User:      i.user,
+		Tenant:    i.tenant,
+	})
+}
+
+func (s *DevauthManagementV2Suite) SetupSuite() {
+	require := require.New(s.T())
+
+	ctx := common.BasicAuthContext(s.T().Context(), s.User)
+	token, r, err := s.APIClient.UserAdministrationManagementAPIAPI.Login(ctx).Execute()
+
+	require.NoError(err)
+	require.NotNil(r)
+	require.Equal(http.StatusOK, r.StatusCode)
+	require.NotEmpty(token)
+	s.JWT = token
+}
+
+// ---------------------------------------------------------------------
+// TestPreauth (test_devauth.py::TestPreauth)
+// ---------------------------------------------------------------------
+
+func (s *DevauthManagementV2Suite) TestPreauth() {
+	s.Run("Ok", s.preauthOk)
+	s.Run("FailDuplicate", s.preauthFailDuplicate)
+	s.Run("FailBadRequest", s.preauthFailBadRequest)
+}
+
+func (s *DevauthManagementV2Suite) preauthOk() {
+	// ported from test_devauth.py::TestPreauth::test_ok
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	count, err := s.countDevices(ctx, model.DevStatusPreauth)
+	require.NoError(err)
+
+	type devEntry struct {
+		mac, sn string
+		idData  string
+		kp      *common.KeyPair
+		id      string
+	}
+
+	devs := make([]*devEntry, 0, len(common.KeyKinds))
+	for _, kind := range common.KeyKinds {
+		kp, err := common.NewKeyPair(kind)
+		require.NoError(err)
+		mac, sn := randMacSn()
+		devs = append(devs, &devEntry{mac: mac, sn: sn, idData: idDataJSON(mac, sn), kp: kp})
+	}
+
+	for _, d := range devs {
+		id, r, err := s.preauthorize(ctx, d.mac, d.sn, d.kp.PublicKeyPEM(), false)
+		require.NoError(err)
+		require.Equal(http.StatusCreated, r.StatusCode)
+		d.id = id
+	}
+
+	newCount, err := s.countDevices(ctx, model.DevStatusPreauth)
+	require.NoError(err)
+	assert.Equal(count+int32(len(devs)), newCount)
+
+	for _, d := range devs {
+		dev, err := s.getDevice(ctx, d.id)
+		require.NoError(err)
+		assert.Equal(model.DevStatusPreauth, dev.GetStatus())
+		require.Len(dev.AuthSets, 1)
+		aset := dev.AuthSets[0]
+		assert.Equal(d.mac, fmt.Sprint(aset.IdentityData["mac"]))
+		assert.Equal(d.sn, fmt.Sprint(aset.IdentityData["sn"]))
+		assert.Equal(model.DevStatusPreauth, aset.GetStatus())
+
+		// the actual device can obtain an auth token
+		device := common.NewDeviceFromKeyPair(d.kp, d.idData)
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.True(ok)
+
+		outdev, err := s.getDevice(ctx, d.id)
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, outdev.GetStatus())
+		require.Len(outdev.AuthSets, 1)
+		assert.Equal(model.DevStatusAccepted, outdev.AuthSets[0].GetStatus())
+	}
+
+	// send the preauth requests again with fresh keys: since the devices
+	// show up with new keys they are immediately accepted with a new
+	// authset, and the old one is rejected
+	for _, d := range devs {
+		kp, err := common.NewKeyPair(common.KeyKindRSA)
+		require.NoError(err)
+		d.kp = kp
+
+		_, r, err := s.preauthorize(ctx, d.mac, d.sn, kp.PublicKeyPEM(), true)
+		require.NoError(err)
+		assert.Equal(http.StatusCreated, r.StatusCode)
+	}
+
+	for _, d := range devs {
+		dev, err := s.getDevice(ctx, d.id)
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, dev.GetStatus())
+		require.Len(dev.AuthSets, 2)
+
+		device := common.NewDeviceFromKeyPair(d.kp, d.idData)
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.True(ok)
+
+		outdev, err := s.getDevice(ctx, d.id)
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, outdev.GetStatus())
+		require.Len(outdev.AuthSets, 2)
+
+		foundAccepted := false
+		for _, aset := range outdev.AuthSets {
+			if aset.GetStatus() == model.DevStatusAccepted {
+				foundAccepted = true
+				assert.True(comparePubkeysPEM(aset.GetPubkey(), d.kp.PublicKeyPEM()))
+				break
+			}
+		}
+		assert.True(foundAccepted)
+	}
+}
+
+func (s *DevauthManagementV2Suite) preauthFailDuplicate() {
+	// ported from test_devauth.py::TestPreauth::test_fail_duplicate
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	countBefore, err := s.countDevices(ctx, "")
+	require.NoError(err)
+
+	mac, sn := randMacSn()
+	idData := idDataJSON(mac, sn)
+	kp, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	device := common.NewDeviceFromKeyPair(kp, idData)
+	ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+	require.NoError(err)
+	assert.False(ok)
+
+	newKP, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	_, r, err := s.preauthorize(ctx, mac, sn, newKP.PublicKeyPEM(), false)
+	require.Error(err)
+	assert.Equal(http.StatusConflict, r.StatusCode)
+
+	// device list is unmodified: the failed duplicate did not add a device
+	countAfter, err := s.countDevices(ctx, "")
+	require.NoError(err)
+	assert.Equal(countBefore+1, countAfter)
+
+	// existing device has no new auth sets
+	apiDev, err := s.getDeviceByMacSn(ctx, mac, sn)
+	require.NoError(err)
+	require.Len(apiDev.AuthSets, 1)
+	assert.True(comparePubkeysPEM(apiDev.AuthSets[0].GetPubkey(), kp.PublicKeyPEM()))
+	assert.Equal(model.DevStatusPending, apiDev.AuthSets[0].GetStatus())
+}
+
+func (s *DevauthManagementV2Suite) preauthFailBadRequest() {
+	// ported from test_devauth.py::TestPreauth::test_fail_bad_request
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	kp, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	// id data not json: identity_data is a raw string instead of an
+	// object. The generated client can't build this (identity_data is
+	// typed as an object), so this one goes over a raw request.
+	body, err := json.Marshal(map[string]any{
+		"identity_data": `{"mac": "foo"}`,
+		"pubkey":        kp.PublicKeyPEM(),
+	})
+	require.NoError(err)
+	resp, err := common.RawRequest(ctx, s.APIClient, http.MethodPost, "/api/management/v2/devauth/devices", body)
+	require.NoError(err)
+	defer resp.Body.Close()
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	// not a valid key
+	mac, sn := randMacSn()
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(client.PreAuthSet{
+			IdentityData: client.IdentityData{Mac: types.Pointer(mac), Sn: types.Pointer(sn)},
+			Pubkey:       "not a public key",
+		}).
+		Execute()
+	require.Error(err)
+	assert.Equal(http.StatusBadRequest, r.StatusCode)
+}
+
+// ---------------------------------------------------------------------
+// devs_authsets fixture (test_devauth.py::make_devs_with_authsets and
+// friends). Kept local to this file, like the Python original keeps it
+// local to test_devauth.py rather than in testutils/common.py.
+// ---------------------------------------------------------------------
+
+type devFixtureAuthset struct {
+	ID     string
+	Status string
+	KP     *common.KeyPair
+}
+
+type devFixture struct {
+	ID       string
+	Mac      string
+	Sn       string
+	IDData   string
+	Status   string
+	Authsets []*devFixtureAuthset
+}
+
+func (s *DevauthManagementV2Suite) createFirstAuthset(ctx context.Context, kind string) (*devFixture, error) {
+	mac, sn := randMacSn()
+	idData := idDataJSON(mac, sn)
+	kp, err := common.NewKeyPair(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	device := common.NewDeviceFromKeyPair(kp, idData)
+	if _, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken); err != nil {
+		return nil, err
+	}
+
+	apiDev, err := s.getDeviceByMacSn(ctx, mac, sn)
+	if err != nil {
+		return nil, err
+	}
+	aset := findAuthsetByPubkey(apiDev.AuthSets, kp.PublicKeyPEM())
+	if aset == nil {
+		return nil, fmt.Errorf("authset not found after auth request for mac=%s sn=%s", mac, sn)
+	}
+
+	return &devFixture{
+		ID:     apiDev.GetId(),
+		Mac:    mac,
+		Sn:     sn,
+		IDData: idData,
+		Status: model.DevStatusPending,
+		Authsets: []*devFixtureAuthset{
+			{ID: aset.GetId(), Status: model.DevStatusPending, KP: kp},
+		},
+	}, nil
+}
+
+func (s *DevauthManagementV2Suite) addAuthset(ctx context.Context, dev *devFixture, kind string) error {
+	kp, err := common.NewKeyPair(kind)
+	if err != nil {
+		return err
+	}
+
+	device := common.NewDeviceFromKeyPair(kp, dev.IDData)
+	if _, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken); err != nil {
+		return err
+	}
+
+	apiDev, err := s.getDevice(ctx, dev.ID)
+	if err != nil {
+		return err
+	}
+	aset := findAuthsetByPubkey(apiDev.AuthSets, kp.PublicKeyPEM())
+	if aset == nil {
+		return fmt.Errorf("new authset not found for device %s", dev.ID)
+	}
+
+	dev.Authsets = append(dev.Authsets, &devFixtureAuthset{ID: aset.GetId(), Status: model.DevStatusPending, KP: kp})
+	return nil
+}
+
+func (s *DevauthManagementV2Suite) makePendingDevice(ctx context.Context, kind string, numAuthsets int) (*devFixture, error) {
+	dev, err := s.createFirstAuthset(ctx, kind)
+	if err != nil {
+		return nil, err
+	}
+	for i := 1; i < numAuthsets; i++ {
+		if err := s.addAuthset(ctx, dev, kind); err != nil {
+			return nil, err
+		}
+	}
+	return dev, nil
+}
+
+func (s *DevauthManagementV2Suite) makeAcceptedDevice(ctx context.Context, kind string, numAuthsets, numAccepted int) (*devFixture, error) {
+	dev, err := s.makePendingDevice(ctx, kind, numAuthsets)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < numAccepted; i++ {
+		if err := s.setAuthsetStatus(ctx, dev.ID, dev.Authsets[i].ID, model.DevStatusAccepted); err != nil {
+			return nil, err
+		}
+		dev.Authsets[i].Status = model.DevStatusAccepted
+	}
+	dev.Status = model.DevStatusAccepted
+	return dev, nil
+}
+
+func (s *DevauthManagementV2Suite) makeRejectedDevice(ctx context.Context, kind string, numAuthsets int) (*devFixture, error) {
+	dev, err := s.makePendingDevice(ctx, kind, numAuthsets)
+	if err != nil {
+		return nil, err
+	}
+	for _, aset := range dev.Authsets {
+		if err := s.setAuthsetStatus(ctx, dev.ID, aset.ID, model.DevStatusRejected); err != nil {
+			return nil, err
+		}
+		aset.Status = model.DevStatusRejected
+	}
+	dev.Status = model.DevStatusRejected
+	return dev, nil
+}
+
+func (s *DevauthManagementV2Suite) makePreauthdDevice(ctx context.Context, kind string) (*devFixture, error) {
+	kp, err := common.NewKeyPair(kind)
+	if err != nil {
+		return nil, err
+	}
+	mac, sn := randMacSn()
+
+	id, r, err := s.preauthorize(ctx, mac, sn, kp.PublicKeyPEM(), false)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected preauthorize status %d", r.StatusCode)
+	}
+
+	apiDev, err := s.getDevice(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(apiDev.AuthSets) != 1 {
+		return nil, fmt.Errorf("expected 1 authset for preauthd device %s, got %d", id, len(apiDev.AuthSets))
+	}
+
+	return &devFixture{
+		ID:     id,
+		Mac:    mac,
+		Sn:     sn,
+		IDData: idDataJSON(mac, sn),
+		Status: model.DevStatusPreauth,
+		Authsets: []*devFixtureAuthset{
+			{ID: apiDev.AuthSets[0].GetId(), Status: model.DevStatusPreauth, KP: kp},
+		},
+	}, nil
+}
+
+func (s *DevauthManagementV2Suite) makePreauthdDeviceWithPending(ctx context.Context, kind string, numPending int) (*devFixture, error) {
+	dev, err := s.makePreauthdDevice(ctx, kind)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < numPending; i++ {
+		if err := s.addAuthset(ctx, dev, common.KeyKindRSA); err != nil {
+			return nil, err
+		}
+	}
+	return dev, nil
+}
+
+// makeDevsWithAuthsets ports make_devs_with_authsets: a good number of
+// devices, some with >1 authsets, in every status.
+func (s *DevauthManagementV2Suite) makeDevsWithAuthsets(ctx context.Context) ([]*devFixture, error) {
+	var devs []*devFixture
+	add := func(dev *devFixture, err error) error {
+		if err != nil {
+			return err
+		}
+		devs = append(devs, dev)
+		return nil
+	}
+
+	// vanilla 'pending' devices, single authset
+	for i := 0; i < 3; i++ {
+		if err := add(s.makePendingDevice(ctx, common.KeyKindRSA, 1)); err != nil {
+			return nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.makePendingDevice(ctx, common.KeyKindECP256, 1)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makePendingDevice(ctx, common.KeyKindEd25519, 1)); err != nil {
+		return nil, err
+	}
+
+	// pending devices with >1 authsets
+	for i := 0; i < 2; i++ {
+		if err := add(s.makePendingDevice(ctx, common.KeyKindRSA, 3)); err != nil {
+			return nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.makePendingDevice(ctx, common.KeyKindECP256, 3)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makePendingDevice(ctx, common.KeyKindEd25519, 3)); err != nil {
+		return nil, err
+	}
+
+	// accepted devices, single authset
+	for i := 0; i < 3; i++ {
+		if err := add(s.makeAcceptedDevice(ctx, common.KeyKindRSA, 1, 1)); err != nil {
+			return nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.makeAcceptedDevice(ctx, common.KeyKindECP256, 1, 1)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makeAcceptedDevice(ctx, common.KeyKindEd25519, 1, 1)); err != nil {
+		return nil, err
+	}
+
+	// accepted devices with >1 authsets
+	for i := 0; i < 2; i++ {
+		if err := add(s.makeAcceptedDevice(ctx, common.KeyKindRSA, 3, 1)); err != nil {
+			return nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.makeAcceptedDevice(ctx, common.KeyKindECP256, 2, 1)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makeAcceptedDevice(ctx, common.KeyKindEd25519, 2, 1)); err != nil {
+		return nil, err
+	}
+
+	// rejected devices
+	for i := 0; i < 2; i++ {
+		if err := add(s.makeRejectedDevice(ctx, common.KeyKindRSA, 3)); err != nil {
+			return nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.makeRejectedDevice(ctx, common.KeyKindECP256, 2)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makeRejectedDevice(ctx, common.KeyKindEd25519, 2)); err != nil {
+		return nil, err
+	}
+
+	// preauthd devices
+	if err := add(s.makePreauthdDevice(ctx, common.KeyKindRSA)); err != nil {
+		return nil, err
+	}
+	if err := add(s.makePreauthdDevice(ctx, common.KeyKindECP256)); err != nil {
+		return nil, err
+	}
+	if err := add(s.makePreauthdDevice(ctx, common.KeyKindEd25519)); err != nil {
+		return nil, err
+	}
+
+	// preauthd devices with extra 'pending' sets
+	for i := 0; i < 2; i++ {
+		if err := add(s.makePreauthdDeviceWithPending(ctx, common.KeyKindRSA, 2)); err != nil {
+			return nil, err
+		}
+	}
+	if err := add(s.makePreauthdDeviceWithPending(ctx, common.KeyKindECP256, 2)); err != nil {
+		return nil, err
+	}
+	if err := add(s.makePreauthdDeviceWithPending(ctx, common.KeyKindEd25519, 2)); err != nil {
+		return nil, err
+	}
+
+	// mirrors deviceauth's own device listing order: sorted by (status,
+	// id) ascending -- see GetDevices in
+	// services/deviceauth/store/mongo/datastore_mongo.go.
+	slices.SortStableFunc(devs, func(a, b *devFixture) int {
+		if c := cmp.Compare(a.Status, b.Status); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+
+	return devs, nil
+}
+
+func filterAndPageDevs(devs []*devFixture, page, perPage int, status string) []*devFixture {
+	filtered := devs
+	if status != "" {
+		filtered = nil
+		for _, d := range devs {
+			if d.Status == status {
+				filtered = append(filtered, d)
+			}
+		}
+	}
+	if page <= 0 {
+		page = 1
+	}
+	if perPage <= 0 {
+		perPage = 20
+	}
+	lo := (page - 1) * perPage
+	hi := lo + perPage
+	if lo > len(filtered) {
+		lo = len(filtered)
+	}
+	if hi > len(filtered) {
+		hi = len(filtered)
+	}
+	return filtered[lo:hi]
+}
+
+func findAuthsetByPubkey(asets []client.AuthSet, pubkeyPEM string) *client.AuthSet {
+	for i := range asets {
+		if asets[i].Pubkey != nil && comparePubkeysPEM(*asets[i].Pubkey, pubkeyPEM) {
+			return &asets[i]
+		}
+	}
+	return nil
+}
+
+func computeDevStatus(authsets []*devFixtureAuthset) string {
+	if len(authsets) == 0 {
+		return model.DevStatusNoAuth
+	}
+	for _, a := range authsets {
+		if a.Status == model.DevStatusAccepted {
+			return model.DevStatusAccepted
+		}
+	}
+	for _, a := range authsets {
+		if a.Status == model.DevStatusPreauth {
+			return model.DevStatusPreauth
+		}
+	}
+	for _, a := range authsets {
+		if a.Status == model.DevStatusPending {
+			return model.DevStatusPending
+		}
+	}
+	return model.DevStatusRejected
+}
+
+func removeAuthset(authsets []*devFixtureAuthset, target *devFixtureAuthset) []*devFixtureAuthset {
+	out := make([]*devFixtureAuthset, 0, len(authsets))
+	for _, a := range authsets {
+		if a != target {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func (s *DevauthManagementV2Suite) compareDev(dev *devFixture, apiDev client.Device) {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+
+	assert.Equal(dev.ID, apiDev.GetId())
+	require.NotNil(apiDev.IdentityData)
+	assert.Equal(dev.Mac, apiDev.IdentityData.GetMac())
+	assert.Equal(dev.Sn, apiDev.IdentityData.GetSn())
+	assert.Equal(dev.Status, apiDev.GetStatus())
+
+	require.Len(apiDev.AuthSets, len(dev.Authsets))
+
+	// GOTCHA: don't rely on indexing, authsets can get reshuffled
+	// depending on actual contents.
+	for _, apiAset := range apiDev.AuthSets {
+		var match *devFixtureAuthset
+		for _, aset := range dev.Authsets {
+			if apiAset.Pubkey != nil && comparePubkeysPEM(*apiAset.Pubkey, aset.KP.PublicKeyPEM()) {
+				match = aset
+				break
+			}
+		}
+		require.NotNil(match, "no matching local authset for api authset %s", apiAset.GetId())
+		assert.Equal(match.ID, apiAset.GetId())
+		assert.Equal(match.Status, apiAset.GetStatus())
+	}
+}
+
+func (s *DevauthManagementV2Suite) compareDevs(devs []*devFixture, apiDevs []client.Device) {
+	require := require.New(s.T())
+	require.Len(apiDevs, len(devs))
+	for i := range apiDevs {
+		s.compareDev(devs[i], apiDevs[i])
+	}
+}
+
+func (s *DevauthManagementV2Suite) verifyDevAfterStatusUpdate(ctx context.Context, dev *devFixture) {
+	require := require.New(s.T())
+
+	apiDev, err := s.getDevice(ctx, dev.ID)
+	require.NoError(err)
+	s.compareDev(dev, *apiDev)
+
+	err = common.RetryUntil(ctx, 10*time.Second, 250*time.Millisecond, func() (bool, error) {
+		inv, _, err := s.APIClient.DeviceInventoryManagementAPIAPI.GetDeviceInventory(ctx, dev.ID).Execute()
+		if err != nil || inv == nil {
+			return false, nil
+		}
+		for _, a := range inv.Attributes {
+			if a.GetScope() == client.IDENTITY && a.GetName() == "status" {
+				return a.GetValue().String != nil && *a.GetValue().String == dev.Status, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(err, "timeout waiting for inventory status to become %q for device %s", dev.Status, dev.ID)
+}
+
+func (s *DevauthManagementV2Suite) verifyDevProvisioned(ctx context.Context, dev *devFixture) {
+	require := require.New(s.T())
+	err := common.RetryUntil(ctx, 10*time.Second, 250*time.Millisecond, func() (bool, error) {
+		_, r, err := s.APIClient.DeviceInventoryManagementAPIAPI.GetDeviceInventory(ctx, dev.ID).Execute()
+		return err == nil && r != nil && r.StatusCode == http.StatusOK, nil
+	})
+	require.NoError(err, "timeout waiting for device %s to get provisioned in inventory", dev.ID)
+}
+
+// ---------------------------------------------------------------------
+// TestDeviceMgmt (test_devauth.py::TestDeviceMgmt)
+// ---------------------------------------------------------------------
+
+func (s *DevauthManagementV2Suite) TestDeviceMgmt() {
+	s.Run("GetDevices", s.deviceMgmtGetDevices)
+	s.Run("GetDevice", s.deviceMgmtGetDevice)
+	s.Run("DeleteDeviceOk", s.deviceMgmtDeleteDeviceOk)
+	s.Run("DeleteDeviceNotFound", s.deviceMgmtDeleteDeviceNotFound)
+	s.Run("DeviceCount", s.deviceMgmtDeviceCount)
+}
+
+func (s *DevauthManagementV2Suite) deviceMgmtGetDevices() {
+	// ported from test_devauth.py::TestDeviceMgmt::test_ok_get_devices
+	require := require.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// the shared environment isn't reset between tests, so restrict the
+	// listing to the devices this test created (the Python original runs
+	// against a freshly wiped DB per test via the clean_migrated_mongo
+	// fixture and doesn't need to).
+	ids := deviceIDs(devs)
+
+	cases := []struct {
+		status        string
+		page, perPage int
+	}{
+		{"", 0, 0},
+		{model.DevStatusPending, 0, 0},
+		{model.DevStatusAccepted, 0, 0},
+		{model.DevStatusRejected, 0, 0},
+		{model.DevStatusPreauth, 0, 0},
+		{"", 1, 10},
+		{"", 3, 10},
+		{"", 2, 5},
+		{model.DevStatusAccepted, 1, 4},
+		{model.DevStatusAccepted, 2, 4},
+		{model.DevStatusAccepted, 5, 2},
+		{model.DevStatusPending, 2, 2},
+	}
+
+	for _, tc := range cases {
+		apiDevs, err := s.listDevices(ctx, tc.status, int32(tc.page), int32(tc.perPage), ids...)
+		require.NoError(err)
+
+		refDevs := filterAndPageDevs(devs, tc.page, tc.perPage, tc.status)
+		s.compareDevs(refDevs, apiDevs)
+	}
+}
+
+func (s *DevauthManagementV2Suite) deviceMgmtGetDevice() {
+	// ported from test_devauth.py::TestDeviceMgmt::test_get_device
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		apiDev, err := s.getDevice(ctx, dev.ID)
+		require.NoError(err)
+		s.compareDev(dev, *apiDev)
+	}
+
+	for _, id := range []string{"foo", "bar"} {
+		_, r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, id).Execute()
+		require.Error(err)
+		assert.Equal(http.StatusNotFound, r.StatusCode)
+	}
+}
+
+func (s *DevauthManagementV2Suite) deviceMgmtDeleteDeviceOk() {
+	// ported from test_devauth.py::TestDeviceMgmt::test_delete_device_ok
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// decommission a pending device
+	pending := filterAndPageDevs(devs, 0, len(devs), model.DevStatusPending)
+	require.NotEmpty(pending)
+	devPending := pending[0]
+
+	status, err := s.deleteDevice(ctx, devPending.ID)
+	require.NoError(err)
+	assert.Equal(http.StatusNoContent, status)
+	require.True(s.waitDeviceGone(ctx, devPending.ID), "timeout waiting for device auth to be deleted")
+
+	// log in an accepted device
+	accepted := filterAndPageDevs(devs, 0, len(devs), model.DevStatusAccepted)
+	require.NotEmpty(accepted)
+	devAcc := accepted[0]
+
+	var acceptedAset *devFixtureAuthset
+	for _, a := range devAcc.Authsets {
+		if a.Status == model.DevStatusAccepted {
+			acceptedAset = a
+			break
+		}
+	}
+	require.NotNil(acceptedAset)
+
+	device := common.NewDeviceFromKeyPair(acceptedAset.KP, devAcc.IDData)
+	ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+	require.NoError(err)
+	require.True(ok)
+	dtoken := device.Token
+
+	// decommission the accepted device
+	status, err = s.deleteDevice(ctx, devAcc.ID)
+	require.NoError(err)
+	assert.Equal(http.StatusNoContent, status)
+
+	// verify the device lost access
+	devCtx := common.JWTAuthContext(ctx, dtoken)
+	_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.CheckUpdate(devCtx).
+		DeviceType("foo").ArtifactName("bar").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusUnauthorized, r.StatusCode)
+
+	require.True(s.waitDeviceGone(ctx, devAcc.ID), "timeout waiting for device auth to be deleted")
+}
+
+func (s *DevauthManagementV2Suite) deviceMgmtDeleteDeviceNotFound() {
+	// ported from test_devauth.py::TestDeviceMgmt::test_delete_device_not_found
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	status, err := s.deleteDevice(ctx, "foo")
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, status)
+
+	// device list unmodified
+	apiDevs, err := s.listDevices(ctx, "", 0, int32(len(devs)), deviceIDs(devs)...)
+	require.NoError(err)
+	s.compareDevs(devs, apiDevs)
+}
+
+func (s *DevauthManagementV2Suite) deviceMgmtDeviceCount() {
+	// ported from test_devauth.py::TestDeviceMgmt::test_device_count
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	// G3: noauth (test_device_count_simple) - delta-based like the other statuses.
+	statuses := []string{"", model.DevStatusPending, model.DevStatusAccepted, model.DevStatusRejected, model.DevStatusPreauth, model.DevStatusNoAuth}
+
+	// CountDevices (unlike ListDevices) has no id filter, and the shared
+	// environment isn't reset between tests -- so verify counts as
+	// deltas against a baseline taken before this test's own devices
+	// exist, rather than asserting the exact count the Python original
+	// does against its freshly wiped DB.
+	baseline := make(map[string]int32, len(statuses))
+	for _, status := range statuses {
+		count, err := s.countDevices(ctx, status)
+		require.NoError(err)
+		baseline[status] = count
+	}
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, status := range statuses {
+		count, err := s.countDevices(ctx, status)
+		require.NoError(err)
+
+		refDevs := filterAndPageDevs(devs, 0, len(devs), status)
+		assert.Equal(baseline[status]+int32(len(refDevs)), count)
+	}
+
+	_, r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementCountDevices(ctx).Status("foo").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusBadRequest, r.StatusCode)
+}
+
+// ---------------------------------------------------------------------
+// TestAuthsetMgmt (test_devauth.py::TestAuthsetMgmt)
+// ---------------------------------------------------------------------
+
+func (s *DevauthManagementV2Suite) TestAuthsetMgmt() {
+	s.Run("GetStatus", s.authsetMgmtGetStatus)
+	s.Run("PutStatusAccept", s.authsetMgmtPutStatusAccept)
+	s.Run("PutStatusReject", s.authsetMgmtPutStatusReject)
+	s.Run("PutStatusFailed", s.authsetMgmtPutStatusFailed)
+	s.Run("DeleteStatus", s.authsetMgmtDeleteStatus)
+	s.Run("DeleteStatusFailed", s.authsetMgmtDeleteStatusFailed)
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtGetStatus() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_get_authset_status
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		for _, aset := range dev.Authsets {
+			status, r, err := s.getAuthsetStatus(ctx, dev.ID, aset.ID)
+			require.NoError(err)
+			require.Equal(http.StatusOK, r.StatusCode)
+			assert.Equal(aset.Status, status)
+		}
+	}
+
+	for _, tc := range []struct{ did, aid string }{
+		{devs[0].ID, "foo"},
+		{"foo", "bar"},
+	} {
+		_, r, err := s.getAuthsetStatus(ctx, tc.did, tc.aid)
+		require.Error(err)
+		assert.Equal(http.StatusNotFound, r.StatusCode)
+	}
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtPutStatusAccept() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_put_status_accept
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// select interesting devices - pending, rejected, or accepted/preauthd
+	// with extra authsets
+	var candidates []*devFixture
+	for _, status := range []string{model.DevStatusPending, model.DevStatusRejected, model.DevStatusAccepted, model.DevStatusPreauth} {
+		found := filterAndPageDevs(devs, 0, len(devs), status)
+		if status == model.DevStatusAccepted || status == model.DevStatusPreauth {
+			var multi []*devFixture
+			for _, d := range found {
+				if len(d.Authsets) > 1 {
+					multi = append(multi, d)
+				}
+			}
+			found = multi
+		}
+		candidates = append(candidates, found...)
+	}
+
+	for _, dev := range candidates {
+		// for accepted devs - first actually get a device token
+		var dtoken string
+		if dev.Status == model.DevStatusAccepted {
+			var accepted *devFixtureAuthset
+			for _, a := range dev.Authsets {
+				if a.Status == model.DevStatusAccepted {
+					accepted = a
+					break
+				}
+			}
+			require.NotNil(accepted)
+
+			device := common.NewDeviceFromKeyPair(accepted.KP, dev.IDData)
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		// find some pending or rejected authset
+		var target *devFixtureAuthset
+		for _, a := range dev.Authsets {
+			if a.Status == model.DevStatusPending || a.Status == model.DevStatusRejected {
+				target = a
+				break
+			}
+		}
+		require.NotNil(target)
+
+		// accept the authset
+		require.NoError(s.setAuthsetStatus(ctx, dev.ID, target.ID, model.DevStatusAccepted))
+
+		// in case of originally accepted devs: the original authset must
+		// be rejected now (ported verbatim: the Python original only
+		// rejects the old authset for "accepted" devices, not
+		// "preauthorized" ones)
+		if dev.Status == model.DevStatusAccepted {
+			for _, a := range dev.Authsets {
+				if a.Status == dev.Status {
+					a.Status = model.DevStatusRejected
+					break
+				}
+			}
+		}
+
+		dev.Status = model.DevStatusAccepted
+		target.Status = model.DevStatusAccepted
+
+		s.verifyDevAfterStatusUpdate(ctx, dev)
+
+		if dtoken != "" {
+			devCtx := common.JWTAuthContext(ctx, dtoken)
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.CheckUpdate(devCtx).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+
+		s.verifyDevProvisioned(ctx, dev)
+	}
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtPutStatusReject() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_put_status_reject
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	var candidates []*devFixture
+	for _, status := range []string{model.DevStatusPending, model.DevStatusAccepted} {
+		candidates = append(candidates, filterAndPageDevs(devs, 0, len(devs), status)...)
+	}
+
+	for _, dev := range candidates {
+		var aset *devFixtureAuthset
+		if dev.Status == model.DevStatusAccepted {
+			for _, a := range dev.Authsets {
+				if a.Status == dev.Status {
+					aset = a
+					break
+				}
+			}
+			require.NotNil(aset)
+		} else {
+			aset = dev.Authsets[0]
+		}
+
+		// for accepted devs, also have an active device and check it
+		// loses api access
+		var dtoken string
+		if dev.Status == model.DevStatusAccepted {
+			device := common.NewDeviceFromKeyPair(aset.KP, dev.IDData)
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		if aset.Status == model.DevStatusAccepted || aset.Status == model.DevStatusPending {
+			require.NoError(s.setAuthsetStatus(ctx, dev.ID, aset.ID, model.DevStatusRejected))
+		}
+
+		aset.Status = model.DevStatusRejected
+
+		rejCount := 0
+		for _, a := range dev.Authsets {
+			if a.ID != aset.ID && a.Status == model.DevStatusRejected {
+				rejCount++
+			}
+		}
+		if rejCount == len(dev.Authsets)-1 {
+			dev.Status = model.DevStatusRejected
+		} else {
+			dev.Status = model.DevStatusPending
+		}
+
+		s.verifyDevAfterStatusUpdate(ctx, dev)
+
+		if dtoken != "" {
+			devCtx := common.JWTAuthContext(ctx, dtoken)
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.CheckUpdate(devCtx).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+
+		// G1: post-reject re-auth (python test_device.py::test_device_accept_reject_cycle
+		// L122-123): a new auth request from the same device after reject
+		// gets rejected, and no new authset appears.
+		device := common.NewDeviceFromKeyPair(aset.KP, dev.IDData)
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.False(ok)
+
+		apiDevAfter, err := s.getDevice(ctx, dev.ID)
+		require.NoError(err)
+		s.compareDev(dev, *apiDevAfter)
+	}
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtPutStatusFailed() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_put_status_failed
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// not found: valid device, bogus authset
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, devs[0].ID, "foo").
+		Status(client.Status{Status: model.DevStatusAccepted}).
+		Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// not found: bogus device
+	r, err = s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, "foo", "bar").
+		Status(client.Status{Status: model.DevStatusAccepted}).
+		Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// not found: bogus device, status "rejected" (G2: test_device_reject_nonexistent)
+	r, err = s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, "foo", "bar").
+		Status(client.Status{Status: model.DevStatusRejected}).
+		Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// bad request - invalid status
+	r, err = s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, devs[0].ID, devs[0].Authsets[0].ID).
+		Status(client.Status{Status: "invalid"}).
+		Execute()
+	require.Error(err)
+	assert.Equal(http.StatusBadRequest, r.StatusCode)
+
+	// bad request - invalid payload: the generated client can't send an
+	// arbitrary body via the typed Status model, so this one goes over a
+	// raw request.
+	reqPath := fmt.Sprintf("/api/management/v2/devauth/devices/%s/auth/%s/status", devs[0].ID, devs[0].Authsets[0].ID)
+	resp, err := common.RawRequest(ctx, s.APIClient, http.MethodPut, reqPath, []byte(`{"foo": "bar"}`))
+	require.NoError(err)
+	defer resp.Body.Close()
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtDeleteStatus() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_delete_status
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		// for accepted or preauthd devices, target the accepted/preauthd
+		// set; otherwise just select the first one
+		var aset *devFixtureAuthset
+		if dev.Status == model.DevStatusAccepted || dev.Status == model.DevStatusPreauth {
+			for _, a := range dev.Authsets {
+				if a.Status == dev.Status {
+					aset = a
+					break
+				}
+			}
+			require.NotNil(aset)
+		} else {
+			aset = dev.Authsets[0]
+		}
+
+		var dtoken string
+		if dev.Status == model.DevStatusAccepted {
+			device := common.NewDeviceFromKeyPair(aset.KP, dev.IDData)
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		status, err := s.deleteAuthset(ctx, dev.ID, aset.ID)
+		require.NoError(err)
+		require.Equal(http.StatusNoContent, status)
+
+		dev.Authsets = removeAuthset(dev.Authsets, aset)
+
+		if dev.Status == model.DevStatusPreauth {
+			// removing the preauth authset: the device should be
+			// completely gone. Deviceauth removes it asynchronously, so
+			// poll for the 404 rather than asserting it immediately.
+			// Check specifically for 404 rather than treating any error
+			// as "gone" -- a transient request error isn't proof of
+			// removal. The budget is generous (matching decommission_test)
+			// because this async cascade runs slower against the shared,
+			// never-reset environment under CI load.
+			goneErr := common.RetryUntil(ctx, 3*time.Minute, time.Second, func() (bool, error) {
+				_, r, _ := s.APIClient.
+					DeviceAuthenticationManagementAPIAPI.
+					DeviceAuthManagementGetDevice(ctx, dev.ID).Execute()
+				return r != nil && r.StatusCode == http.StatusNotFound, nil
+			})
+			assert.NoError(goneErr, "device %s still present in device auth after preauth authset removal", dev.ID)
+			// ... including from inventory (async cascade; the removed
+			// integration-repo preauth test asserted this side too).
+			goneErr = common.RetryUntil(ctx, 3*time.Minute, time.Second, func() (bool, error) {
+				_, r, _ := s.APIClient.
+					DeviceInventoryManagementAPIAPI.
+					GetDeviceInventory(ctx, dev.ID).Execute()
+				return r != nil && r.StatusCode == http.StatusNotFound, nil
+			})
+			assert.NoError(goneErr, "device %s still present in inventory after preauth authset removal", dev.ID)
+			// ported quirk: the Python original (do_test_delete_status)
+			// also returns here, ending the whole test on the first
+			// preauthorized device -- since devs_authsets is sorted by
+			// status ascending (accepted, pending, preauthorized,
+			// rejected), rejected devices are never exercised by this
+			// test either in the original or in this port.
+			return
+		}
+
+		dev.Status = computeDevStatus(dev.Authsets)
+		s.verifyDevAfterStatusUpdate(ctx, dev)
+
+		if dtoken != "" {
+			devCtx := common.JWTAuthContext(ctx, dtoken)
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.CheckUpdate(devCtx).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+	}
+}
+
+func (s *DevauthManagementV2Suite) authsetMgmtDeleteStatusFailed() {
+	// ported from test_devauth.py::TestAuthsetMgmt::test_delete_status_failed
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// not found: valid device, bogus authset
+	status, err := s.deleteAuthset(ctx, devs[0].ID, "foo")
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, status)
+
+	// not found: bogus device
+	status, err = s.deleteAuthset(ctx, "foo", "bar")
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, status)
+}
+
+// ---------------------------------------------------------------------
+// TestAuthReq (test_devauth.py::TestAuthReq)
+// ---------------------------------------------------------------------
+
+func (s *DevauthManagementV2Suite) TestAuthReqSubmitAccept() {
+	// ported from test_devauth.py::TestAuthReq::test_submit_accept
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	type devEntry struct {
+		mac, sn string
+		idData  string
+		kp      *common.KeyPair
+	}
+
+	devs := make([]*devEntry, 0, len(common.KeyKinds))
+	for _, kind := range common.KeyKinds {
+		kp, err := common.NewKeyPair(kind)
+		require.NoError(err)
+		mac, sn := randMacSn()
+		devs = append(devs, &devEntry{mac: mac, sn: sn, idData: idDataJSON(mac, sn), kp: kp})
+	}
+
+	for _, d := range devs {
+		device := common.NewDeviceFromKeyPair(d.kp, d.idData)
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.False(ok)
+	}
+
+	for _, d := range devs {
+		apiDev, err := s.getDeviceByMacSn(ctx, d.mac, d.sn)
+		require.NoError(err)
+		require.Len(apiDev.AuthSets, 1)
+		assert.Equal(model.DevStatusPending, apiDev.AuthSets[0].GetStatus())
+
+		// accept and get/verify token
+		require.NoError(s.setAuthsetStatus(ctx, apiDev.GetId(), apiDev.AuthSets[0].GetId(), model.DevStatusAccepted))
+
+		device := common.NewDeviceFromKeyPair(d.kp, d.idData)
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		require.True(ok)
+
+		parts := strings.Split(device.Token, ".")
+		require.Len(parts, 3)
+		payloadRaw, err := base64.RawStdEncoding.DecodeString(parts[1])
+		require.NoError(err)
+
+		var payload map[string]any
+		require.NoError(json.Unmarshal(payloadRaw, &payload))
+
+		// standard claims
+		assert.Equal(apiDev.GetId(), payload["sub"])
+		assert.Equal("Mender", payload["iss"])
+		assert.NotEmpty(payload["jti"])
+		assert.NotNil(payload["exp"])
+
+		// custom claims
+		assert.Equal(true, payload["mender.device"])
+
+		// G4: JWT header typ (python test_token.py::test_token_claims)
+		headerRaw, err := base64.RawStdEncoding.DecodeString(parts[0])
+		require.NoError(err)
+		var header map[string]any
+		require.NoError(json.Unmarshal(headerRaw, &header))
+		assert.Equal("JWT", header["typ"])
+	}
+}
+
+// ---------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------
+
+func randMacSn() (string, string) {
+	return uuid.NewString(), uuid.NewString()
+}
+
+func idDataJSON(mac, sn string) string {
+	b, _ := json.Marshal(map[string]string{"mac": mac, "sn": sn})
+	return string(b)
+}
+
+func comparePubkeysPEM(a, b string) bool {
+	da, _ := pem.Decode([]byte(a))
+	db, _ := pem.Decode([]byte(b))
+	if da == nil || db == nil {
+		return false
+	}
+	return bytes.Equal(da.Bytes, db.Bytes)
+}
+
+func (s *DevauthManagementV2Suite) preauthorize(ctx context.Context, mac, sn, pubkeyPEM string, force bool) (string, *http.Response, error) {
+	preAuthSet := client.PreAuthSet{
+		IdentityData: client.IdentityData{Mac: types.Pointer(mac), Sn: types.Pointer(sn)},
+		Pubkey:       pubkeyPEM,
+	}
+	if force {
+		preAuthSet.Force = types.Pointer(true)
+	}
+
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(preAuthSet).
+		Execute()
+	if err != nil || r == nil {
+		return "", r, err
+	}
+
+	// V1: guard against an empty Location header instead of letting
+	// path.Base silently turn it into ".".
+	loc := r.Header.Get("Location")
+	if loc == "" {
+		return "", r, fmt.Errorf("preauthorize: missing Location header (status %d)", r.StatusCode)
+	}
+	return path.Base(loc), r, nil
+}
+
+func (s *DevauthManagementV2Suite) countDevices(ctx context.Context, status string) (int32, error) {
+	req := s.APIClient.DeviceAuthenticationManagementAPIAPI.DeviceAuthManagementCountDevices(ctx)
+	if status != "" {
+		req = req.Status(status)
+	}
+	count, _, err := req.Execute()
+	if err != nil {
+		return 0, err
+	}
+	return count.GetCount(), nil
+}
+
+func (s *DevauthManagementV2Suite) getDevice(ctx context.Context, id string) (*client.Device, error) {
+	dev, _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementGetDevice(ctx, id).Execute()
+	return dev, err
+}
+
+func (s *DevauthManagementV2Suite) getDeviceByMacSn(ctx context.Context, mac, sn string) (*client.Device, error) {
+	const perPage int32 = 500
+	var page int32 = 1
+	for {
+		devices, err := s.listDevices(ctx, "", page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		for i := range devices {
+			d := devices[i]
+			if d.IdentityData != nil && d.IdentityData.GetMac() == mac && d.IdentityData.GetSn() == sn {
+				return &d, nil
+			}
+		}
+		if len(devices) < int(perPage) {
+			return nil, fmt.Errorf("device not found by id data (mac=%s sn=%s)", mac, sn)
+		}
+		page++
+	}
+}
+
+// listDevices lists devices, optionally restricted to a set of device ids.
+// The shared environment isn't reset between tests (see
+// docker_compose_environment.go), so callers that need to compare the full
+// listing/paging/count against a locally tracked device set must pass ids
+// to filter out devices left behind by other tests/suites.
+func (s *DevauthManagementV2Suite) listDevices(ctx context.Context, status string, page, perPage int32, ids ...string) ([]client.Device, error) {
+	req := s.APIClient.DeviceAuthenticationManagementAPIAPI.DeviceAuthManagementListDevices(ctx)
+	if status != "" {
+		req = req.Status(status)
+	}
+	if page > 0 {
+		req = req.Page(page)
+	}
+	if perPage > 0 {
+		req = req.PerPage(perPage)
+	}
+	if len(ids) > 0 {
+		req = req.Id(ids)
+	}
+	devices, _, err := req.Execute()
+	return devices, err
+}
+
+func deviceIDs(devs []*devFixture) []string {
+	ids := make([]string, len(devs))
+	for i, d := range devs {
+		ids[i] = d.ID
+	}
+	return ids
+}
+
+func (s *DevauthManagementV2Suite) setAuthsetStatus(ctx context.Context, deviceID, authsetID, status string) error {
+	_, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, deviceID, authsetID).
+		Status(client.Status{Status: status}).
+		Execute()
+	return err
+}
+
+func (s *DevauthManagementV2Suite) getAuthsetStatus(ctx context.Context, did, aid string) (string, *http.Response, error) {
+	status, r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementGetAuthenticationStatus(ctx, did, aid).
+		Execute()
+	if status == nil {
+		return "", r, err
+	}
+	return status.GetStatus(), r, err
+}
+
+func (s *DevauthManagementV2Suite) deleteDevice(ctx context.Context, id string) (int, error) {
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementDecommissionDevice(ctx, id).Execute()
+	if r == nil {
+		return 0, err
+	}
+	return r.StatusCode, err
+}
+
+func (s *DevauthManagementV2Suite) deleteAuthset(ctx context.Context, did, aid string) (int, error) {
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementRemoveAuthentication(ctx, did, aid).Execute()
+	if r == nil {
+		return 0, err
+	}
+	return r.StatusCode, err
+}
+
+func (s *DevauthManagementV2Suite) waitDeviceGone(ctx context.Context, id string) bool {
+	err := common.RetryUntil(ctx, 10*time.Second, 200*time.Millisecond, func() (bool, error) {
+		_, r, _ := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, id).Execute()
+		return r != nil && r.StatusCode == http.StatusNotFound, nil
+	})
+	return err == nil
+}

--- a/backend/tests/runner/tests/opensource/devauth_management_v2_test.go
+++ b/backend/tests/runner/tests/opensource/devauth_management_v2_test.go
@@ -1,0 +1,1277 @@
+//nolint:all // This is all test code
+package opensource
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/mendersoftware/mender-server/pkg/api/client"
+	"github.com/mendersoftware/mender-server/services/deviceauth/model"
+	"github.com/mendersoftware/mender-server/tests/runner/tests/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type DevauthManagementV2Suite struct {
+	suite.Suite
+
+	APIClient *client.APIClient
+	User      common.User
+	Tenant    common.Tenant
+
+	JWT string
+}
+
+func (i *BackendIntegrationSuite) TestDevauthManagementV2() {
+	suite.Run(i.T(), &DevauthManagementV2Suite{
+		APIClient: i.environment.APIClient(),
+		User:      i.user,
+		Tenant:    i.tenant,
+	})
+}
+
+func (s *DevauthManagementV2Suite) SetupSuite() {
+	require := require.New(s.T())
+
+	ctx := common.BasicAuthContext(s.T().Context(), s.User)
+	token, _, err := s.APIClient.UserAdministrationManagementAPIAPI.Login(ctx).Execute()
+	require.NoError(err)
+	require.NotEmpty(token)
+	s.JWT = token
+}
+
+func (s *DevauthManagementV2Suite) TestPreauth() {
+	s.Run("Success/Preauthorize", s.testPreauthOk)
+	s.Run("Failure/Duplicate", s.testPreauthFailDuplicate)
+	s.Run("Failure/BadRequest", s.testPreauthFailBadRequest)
+}
+
+func (s *DevauthManagementV2Suite) testPreauthOk() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	before, _, err := devauthm.DeviceAuthManagementCountDevices(ctx).
+		Status(model.DevStatusPreauth).Execute()
+	require.NoError(err)
+
+	devs := make([]*common.Device, 0, len(common.KeyKinds))
+	for _, kind := range common.KeyKinds {
+		kp, err := common.NewKeyPair(kind)
+		require.NoError(err)
+		mac, err := common.RandomMAC()
+		require.NoError(err)
+		device := common.NewDeviceFromKeyPair(kp, fmt.Sprintf(`{"mac":%q}`, mac.String()))
+		device.MAC = mac.String()
+		devs = append(devs, device)
+	}
+
+	for _, device := range devs {
+		r, err := devauthm.DeviceAuthManagementPreauthorize(ctx).
+			PreAuthSet(client.PreAuthSet{
+				IdentityData: client.IdentityData{Mac: client.PtrString(device.MAC)},
+				Pubkey:       common.ExportPublicKeyPEM(device.PublicKey),
+			}).Execute()
+		require.NoError(err)
+		require.Equal(http.StatusCreated, r.StatusCode)
+		device.ID = path.Base(r.Header.Get("Location"))
+		require.NotEmpty(device.ID)
+	}
+
+	after, _, err := devauthm.DeviceAuthManagementCountDevices(ctx).
+		Status(model.DevStatusPreauth).Execute()
+	require.NoError(err)
+	assert.Equal(before.GetCount()+int32(len(devs)), after.GetCount())
+
+	for _, device := range devs {
+		dev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, device.ID).Execute()
+		require.NoError(err)
+		assert.Equal(model.DevStatusPreauth, dev.GetStatus())
+		require.Len(dev.AuthSets, 1)
+		assert.Equal(device.MAC, fmt.Sprint(dev.AuthSets[0].IdentityData["mac"]))
+		assert.Equal(model.DevStatusPreauth, dev.AuthSets[0].GetStatus())
+
+		// the actual device can obtain an auth token
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.True(ok)
+
+		outdev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, device.ID).Execute()
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, outdev.GetStatus())
+		require.Len(outdev.AuthSets, 1)
+		assert.Equal(model.DevStatusAccepted, outdev.AuthSets[0].GetStatus())
+	}
+
+	// re-preauthorize the same devices with fresh keys (force): the new auth
+	// set is accepted immediately and the old one rejected
+	for i, device := range devs {
+		kp, err := common.NewKeyPair(common.KeyKindRSA)
+		require.NoError(err)
+		fresh := common.NewDeviceFromKeyPair(kp, device.IDData)
+		fresh.MAC = device.MAC
+		fresh.ID = device.ID
+		devs[i] = fresh
+
+		r, err := devauthm.DeviceAuthManagementPreauthorize(ctx).
+			PreAuthSet(client.PreAuthSet{
+				IdentityData: client.IdentityData{Mac: client.PtrString(fresh.MAC)},
+				Pubkey:       common.ExportPublicKeyPEM(fresh.PublicKey),
+				Force:        client.PtrBool(true),
+			}).Execute()
+		require.NoError(err)
+		assert.Equal(http.StatusCreated, r.StatusCode)
+	}
+
+	for _, device := range devs {
+		dev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, device.ID).Execute()
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, dev.GetStatus())
+		require.Len(dev.AuthSets, 2)
+
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.True(ok)
+
+		outdev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, device.ID).Execute()
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, outdev.GetStatus())
+		require.Len(outdev.AuthSets, 2)
+
+		foundAccepted := false
+		for _, aset := range outdev.AuthSets {
+			if aset.GetStatus() == model.DevStatusAccepted {
+				foundAccepted = true
+				assert.True(samePubkey(aset.GetPubkey(), common.ExportPublicKeyPEM(device.PublicKey)))
+				break
+			}
+		}
+		assert.True(foundAccepted)
+	}
+}
+
+func (s *DevauthManagementV2Suite) testPreauthFailDuplicate() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	before, _, err := devauthm.DeviceAuthManagementCountDevices(ctx).Execute()
+	require.NoError(err)
+
+	mac, err := common.RandomMAC()
+	require.NoError(err)
+	idData := fmt.Sprintf(`{"mac":%q}`, mac.String())
+	kp, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	device := common.NewDeviceFromKeyPair(kp, idData)
+	ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+	require.NoError(err)
+	assert.False(ok)
+
+	newKP, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	r, err := devauthm.DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(client.PreAuthSet{
+			IdentityData: client.IdentityData{Mac: client.PtrString(mac.String())},
+			Pubkey:       newKP.PublicKeyPEM(),
+		}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusConflict, r.StatusCode)
+
+	// the failed duplicate did not add a device
+	after, _, err := devauthm.DeviceAuthManagementCountDevices(ctx).Execute()
+	require.NoError(err)
+	assert.Equal(before.GetCount()+1, after.GetCount())
+
+	// the existing device still has only its original auth set
+	id, err := s.findDeviceIDByMac(ctx, mac.String())
+	require.NoError(err)
+	apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, id).Execute()
+	require.NoError(err)
+	require.Len(apiDev.AuthSets, 1)
+	assert.True(samePubkey(apiDev.AuthSets[0].GetPubkey(), kp.PublicKeyPEM()))
+	assert.Equal(model.DevStatusPending, apiDev.AuthSets[0].GetStatus())
+}
+
+func (s *DevauthManagementV2Suite) testPreauthFailBadRequest() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	kp, err := common.NewKeyPair(common.KeyKindRSA)
+	require.NoError(err)
+
+	// identity_data as a raw string instead of an object: inject the bad
+	// value through AdditionalProperties, which the typed field can't hold
+	_, err = devauthm.DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(client.PreAuthSet{
+			AdditionalProperties: map[string]any{"identity_data": `{"mac": "foo"}`},
+			Pubkey:               kp.PublicKeyPEM(),
+		}).Execute()
+	require.Error(err)
+
+	// not a valid key
+	mac, err := common.RandomMAC()
+	require.NoError(err)
+	r, err := devauthm.DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(client.PreAuthSet{
+			IdentityData: client.IdentityData{Mac: client.PtrString(mac.String())},
+			Pubkey:       "not a public key",
+		}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusBadRequest, r.StatusCode)
+}
+
+func (s *DevauthManagementV2Suite) TestDeviceMgmt() {
+	s.Run("Success/GetDevices", s.testDeviceMgmtGetDevices)
+	s.Run("Success/GetDevice", s.testDeviceMgmtGetDevice)
+	s.Run("Success/DeleteDevice", s.testDeviceMgmtDeleteDeviceOk)
+	s.Run("Failure/DeleteDeviceNotFound", s.testDeviceMgmtDeleteDeviceNotFound)
+	s.Run("Success/DeviceCount", s.testDeviceMgmtDeviceCount)
+}
+
+func (s *DevauthManagementV2Suite) testDeviceMgmtGetDevices() {
+	require := require.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// the environment isn't reset between tests, so restrict the listing to
+	// the devices this test created
+	ids := make([]string, len(devs))
+	for i, d := range devs {
+		ids[i] = d.GetId()
+	}
+
+	cases := []struct {
+		name          string
+		status        string
+		page, perPage int
+	}{
+		{"AllStatuses", "", 0, 0},
+		{"FilterPending", model.DevStatusPending, 0, 0},
+		{"FilterAccepted", model.DevStatusAccepted, 0, 0},
+		{"FilterRejected", model.DevStatusRejected, 0, 0},
+		{"FilterPreauthorized", model.DevStatusPreauth, 0, 0},
+		{"AllPage1Size10", "", 1, 10},
+		{"AllPage3Size10", "", 3, 10},
+		{"AllPage2Size5", "", 2, 5},
+		{"AcceptedPage1Size4", model.DevStatusAccepted, 1, 4},
+		{"AcceptedPage2Size4", model.DevStatusAccepted, 2, 4},
+		{"AcceptedPage5Size2", model.DevStatusAccepted, 5, 2},
+		{"PendingPage2Size2", model.DevStatusPending, 2, 2},
+	}
+
+	for _, tc := range cases {
+		s.Run("Success/"+tc.name, func() {
+			require, assert := s.Require(), s.Assert()
+			req := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+				DeviceAuthManagementListDevices(ctx).Id(ids)
+			if tc.status != "" {
+				req = req.Status(tc.status)
+			}
+			if tc.page > 0 {
+				req = req.Page(int32(tc.page))
+			}
+			if tc.perPage > 0 {
+				req = req.PerPage(int32(tc.perPage))
+			}
+			apiDevs, _, err := req.Execute()
+			require.NoError(err)
+
+			if tc.perPage > 0 {
+				assert.LessOrEqual(len(apiDevs), tc.perPage)
+			}
+			for _, d := range apiDevs {
+				if tc.status != "" {
+					assert.Equal(tc.status, d.GetStatus())
+				}
+			}
+		})
+	}
+}
+
+func (s *DevauthManagementV2Suite) testDeviceMgmtGetDevice() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		apiDev, _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		assert.Equal(dev.GetId(), apiDev.GetId())
+		assert.Equal(dev.GetStatus(), apiDev.GetStatus())
+		require.Len(apiDev.AuthSets, len(dev.AuthSets))
+	}
+
+	for _, id := range []string{"foo", "bar"} {
+		_, r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, id).Execute()
+		require.Error(err)
+		assert.Equal(http.StatusNotFound, r.StatusCode)
+	}
+}
+
+func (s *DevauthManagementV2Suite) testDeviceMgmtDeleteDeviceOk() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, keys, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// decommission a pending device
+	var devPending *client.Device
+	for i := range devs {
+		if devs[i].GetStatus() == model.DevStatusPending {
+			devPending = &devs[i]
+			break
+		}
+	}
+	require.NotNil(devPending)
+
+	r, err := devauthm.DeviceAuthManagementDecommissionDevice(ctx, devPending.GetId()).Execute()
+	require.NoError(err)
+	assert.Equal(http.StatusNoContent, r.StatusCode)
+	require.True(s.waitDeviceGone(ctx, devPending.GetId()), "timeout waiting for device auth to be deleted")
+
+	// log an accepted device in, then decommission it and check it lost access
+	var devAcc *client.Device
+	for i := range devs {
+		if devs[i].GetStatus() == model.DevStatusAccepted {
+			devAcc = &devs[i]
+			break
+		}
+	}
+	require.NotNil(devAcc)
+
+	device := keys[devAcc.GetId()][0]
+	ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+	require.NoError(err)
+	require.True(ok)
+	dtoken := device.Token
+
+	r, err = devauthm.DeviceAuthManagementDecommissionDevice(ctx, devAcc.GetId()).Execute()
+	require.NoError(err)
+	assert.Equal(http.StatusNoContent, r.StatusCode)
+
+	_, r, err = s.APIClient.DeploymentsDeviceAPIAPI.
+		CheckUpdate(common.JWTAuthContext(ctx, dtoken)).
+		DeviceType("foo").ArtifactName("bar").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusUnauthorized, r.StatusCode)
+
+	require.True(s.waitDeviceGone(ctx, devAcc.GetId()), "timeout waiting for device auth to be deleted")
+}
+
+func (s *DevauthManagementV2Suite) testDeviceMgmtDeleteDeviceNotFound() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	_, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementDecommissionDevice(ctx, "foo").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+}
+
+func (s *DevauthManagementV2Suite) testDeviceMgmtDeviceCount() {
+	require := require.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{"Total", ""},
+		{"Pending", model.DevStatusPending},
+		{"Accepted", model.DevStatusAccepted},
+		{"Rejected", model.DevStatusRejected},
+		{"Preauth", model.DevStatusPreauth},
+		{"NoAuth", model.DevStatusNoAuth},
+	}
+
+	// CountDevices has no id filter and the environment isn't reset between
+	// tests, so verify counts as deltas against a baseline taken before this
+	// test's own devices exist
+	countBy := func(status string) int32 {
+		req := devauthm.DeviceAuthManagementCountDevices(ctx)
+		if status != "" {
+			req = req.Status(status)
+		}
+		count, _, err := req.Execute()
+		require.NoError(err)
+		return count.GetCount()
+	}
+
+	baseline := make(map[string]int32, len(cases))
+	for _, c := range cases {
+		baseline[c.status] = countBy(c.status)
+	}
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, c := range cases {
+		s.Run("Success/"+c.name, func() {
+			var created int32
+			for _, d := range devs {
+				if c.status == "" || d.GetStatus() == c.status {
+					created++
+				}
+			}
+			s.Assert().Equal(baseline[c.status]+created, countBy(c.status), "status=%q", c.status)
+		})
+	}
+
+	s.Run("Failure/InvalidStatus", func() {
+		_, r, err := devauthm.DeviceAuthManagementCountDevices(ctx).Status("foo").Execute()
+		s.Require().Error(err)
+		s.Assert().Equal(http.StatusBadRequest, r.StatusCode)
+	})
+}
+
+func (s *DevauthManagementV2Suite) TestAuthsetMgmt() {
+	s.Run("Success/GetStatus", s.testAuthsetMgmtGetStatus)
+	s.Run("Success/PutStatusAccept", s.testAuthsetMgmtPutStatusAccept)
+	s.Run("Success/PutStatusReject", s.testAuthsetMgmtPutStatusReject)
+	s.Run("Failure/PutStatus", s.testAuthsetMgmtPutStatusFailed)
+	s.Run("Success/DeleteStatus", s.testAuthsetMgmtDeleteStatus)
+	s.Run("Failure/DeleteStatus", s.testAuthsetMgmtDeleteStatusFailed)
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtGetStatus() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		for _, aset := range apiDev.AuthSets {
+			status, r, err := devauthm.
+				DeviceAuthManagementGetAuthenticationStatus(ctx, dev.GetId(), aset.GetId()).
+				Execute()
+			require.NoError(err)
+			require.Equal(http.StatusOK, r.StatusCode)
+			assert.Equal(aset.GetStatus(), status.GetStatus())
+		}
+	}
+
+	notFoundCases := []struct {
+		name     string
+		did, aid string
+	}{
+		{"UnknownAuthSet", devs[0].GetId(), "foo"},
+		{"UnknownDevice", "foo", "bar"},
+	}
+	for _, tc := range notFoundCases {
+		s.Run("Failure/"+tc.name, func() {
+			require, assert := s.Require(), s.Assert()
+			_, r, err := devauthm.
+				DeviceAuthManagementGetAuthenticationStatus(ctx, tc.did, tc.aid).Execute()
+			require.Error(err)
+			assert.Equal(http.StatusNotFound, r.StatusCode)
+		})
+	}
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtPutStatusAccept() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, keys, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// interesting devices: pending, rejected, or accepted/preauthd with an
+	// extra auth set to accept
+	var candidates []client.Device
+	for _, status := range []string{model.DevStatusPending, model.DevStatusRejected, model.DevStatusAccepted, model.DevStatusPreauth} {
+		for _, d := range devs {
+			if d.GetStatus() != status {
+				continue
+			}
+			// for accepted/preauthd devices only those with an extra auth set
+			if (status == model.DevStatusAccepted || status == model.DevStatusPreauth) && len(d.AuthSets) <= 1 {
+				continue
+			}
+			candidates = append(candidates, d)
+		}
+	}
+
+	for _, dev := range candidates {
+		apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+
+		// for an accepted device, first get a live token for the accepted set
+		var dtoken string
+		if dev.GetStatus() == model.DevStatusAccepted {
+			var accepted *client.AuthSet
+			for i := range apiDev.AuthSets {
+				if apiDev.AuthSets[i].GetStatus() == model.DevStatusAccepted {
+					accepted = &apiDev.AuthSets[i]
+					break
+				}
+			}
+			require.NotNil(accepted)
+			var device *common.Device
+			for _, k := range keys[dev.GetId()] {
+				if accepted.Pubkey != nil && samePubkey(*accepted.Pubkey, common.ExportPublicKeyPEM(k.PublicKey)) {
+					device = k
+					break
+				}
+			}
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		// accept a pending or rejected auth set
+		var target *client.AuthSet
+		for i := range apiDev.AuthSets {
+			if st := apiDev.AuthSets[i].GetStatus(); st == model.DevStatusPending || st == model.DevStatusRejected {
+				target = &apiDev.AuthSets[i]
+				break
+			}
+		}
+		require.NotNil(target)
+
+		_, err = devauthm.
+			DeviceAuthManagementSetAuthenticationStatus(ctx, dev.GetId(), target.GetId()).
+			Status(client.Status{Status: model.DevStatusAccepted}).Execute()
+		require.NoError(err)
+
+		s.waitInventoryStatus(ctx, dev.GetId(), model.DevStatusAccepted)
+
+		updated, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		assert.Equal(model.DevStatusAccepted, updated.GetStatus())
+		var targetStatus string
+		for i := range updated.AuthSets {
+			if updated.AuthSets[i].GetId() == target.GetId() {
+				targetStatus = updated.AuthSets[i].GetStatus()
+				break
+			}
+		}
+		assert.Equal(model.DevStatusAccepted, targetStatus)
+
+		if dtoken != "" {
+			// the previously active device lost access
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.
+				CheckUpdate(common.JWTAuthContext(ctx, dtoken)).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+	}
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtPutStatusReject() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, keys, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	var candidates []client.Device
+	for _, status := range []string{model.DevStatusPending, model.DevStatusAccepted} {
+		for _, d := range devs {
+			if d.GetStatus() == status {
+				candidates = append(candidates, d)
+			}
+		}
+	}
+
+	for _, dev := range candidates {
+		apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+
+		var target *client.AuthSet
+		if dev.GetStatus() == model.DevStatusAccepted {
+			for i := range apiDev.AuthSets {
+				if apiDev.AuthSets[i].GetStatus() == model.DevStatusAccepted {
+					target = &apiDev.AuthSets[i]
+					break
+				}
+			}
+		} else {
+			target = &apiDev.AuthSets[0]
+		}
+		require.NotNil(target)
+
+		// for an accepted device, also hold a live token and check it loses access
+		var dtoken string
+		if dev.GetStatus() == model.DevStatusAccepted {
+			var device *common.Device
+			for _, k := range keys[dev.GetId()] {
+				if target.Pubkey != nil && samePubkey(*target.Pubkey, common.ExportPublicKeyPEM(k.PublicKey)) {
+					device = k
+					break
+				}
+			}
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		if st := target.GetStatus(); st == model.DevStatusAccepted || st == model.DevStatusPending {
+			_, err = devauthm.
+				DeviceAuthManagementSetAuthenticationStatus(ctx, dev.GetId(), target.GetId()).
+				Status(client.Status{Status: model.DevStatusRejected}).Execute()
+			require.NoError(err)
+		}
+
+		var targetDev *common.Device
+		for _, k := range keys[dev.GetId()] {
+			if target.Pubkey != nil && samePubkey(*target.Pubkey, common.ExportPublicKeyPEM(k.PublicKey)) {
+				targetDev = k
+				break
+			}
+		}
+		updated, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		var targetStatus string
+		for i := range updated.AuthSets {
+			if updated.AuthSets[i].GetId() == target.GetId() {
+				targetStatus = updated.AuthSets[i].GetStatus()
+				break
+			}
+		}
+		assert.Equal(model.DevStatusRejected, targetStatus)
+
+		if dtoken != "" {
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.
+				CheckUpdate(common.JWTAuthContext(ctx, dtoken)).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+
+		// a fresh auth request from the rejected key stays rejected and adds
+		// no new auth set
+		ok, err := targetDev.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.False(ok)
+
+		after, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		assert.Len(after.AuthSets, len(updated.AuthSets))
+	}
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtPutStatusFailed() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, devs[0].GetId()).Execute()
+	require.NoError(err)
+	asetID := apiDev.AuthSets[0].GetId()
+
+	// not found: valid device, bogus auth set
+	r, err := devauthm.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, devs[0].GetId(), "foo").
+		Status(client.Status{Status: model.DevStatusAccepted}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// not found: bogus device
+	r, err = devauthm.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, "foo", "bar").
+		Status(client.Status{Status: model.DevStatusAccepted}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// not found: bogus device, status rejected
+	r, err = devauthm.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, "foo", "bar").
+		Status(client.Status{Status: model.DevStatusRejected}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// bad request: invalid status
+	r, err = devauthm.
+		DeviceAuthManagementSetAuthenticationStatus(ctx, devs[0].GetId(), asetID).
+		Status(client.Status{Status: "invalid"}).Execute()
+	require.Error(err)
+	assert.Equal(http.StatusBadRequest, r.StatusCode)
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtDeleteStatus() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, keys, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	for _, dev := range devs {
+		apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+
+		// for accepted/preauthd devices target that auth set; otherwise the first
+		var target *client.AuthSet
+		if dev.GetStatus() == model.DevStatusAccepted || dev.GetStatus() == model.DevStatusPreauth {
+			for i := range apiDev.AuthSets {
+				if apiDev.AuthSets[i].GetStatus() == dev.GetStatus() {
+					target = &apiDev.AuthSets[i]
+					break
+				}
+			}
+			require.NotNil(target)
+		} else {
+			target = &apiDev.AuthSets[0]
+		}
+
+		var dtoken string
+		if dev.GetStatus() == model.DevStatusAccepted {
+			var device *common.Device
+			for _, k := range keys[dev.GetId()] {
+				if target.Pubkey != nil && samePubkey(*target.Pubkey, common.ExportPublicKeyPEM(k.PublicKey)) {
+					device = k
+					break
+				}
+			}
+			ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+			require.NoError(err)
+			require.True(ok)
+			dtoken = device.Token
+		}
+
+		r, err := devauthm.
+			DeviceAuthManagementRemoveAuthentication(ctx, dev.GetId(), target.GetId()).Execute()
+		require.NoError(err)
+		require.Equal(http.StatusNoContent, r.StatusCode)
+
+		if dev.GetStatus() == model.DevStatusPreauth {
+			// removing the preauth auth set removes the device entirely.
+			// Deviceauth does this asynchronously, so poll for the 404 (a
+			// specific 404, not any error) rather than asserting it
+			// immediately. The budget is generous because the cascade runs
+			// slower against the shared environment under CI load.
+			goneErr := common.RetryUntil(ctx, 3*time.Minute, time.Second, func() (bool, error) {
+				_, r, _ := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+				return r != nil && r.StatusCode == http.StatusNotFound, nil
+			})
+			assert.NoError(goneErr, "device %s still present in device auth after preauth authset removal", dev.GetId())
+			goneErr = common.RetryUntil(ctx, 3*time.Minute, time.Second, func() (bool, error) {
+				_, r, _ := s.APIClient.DeviceInventoryManagementAPIAPI.
+					GetDeviceInventory(ctx, dev.GetId()).Execute()
+				return r != nil && r.StatusCode == http.StatusNotFound, nil
+			})
+			assert.NoError(goneErr, "device %s still present in inventory after preauth authset removal", dev.GetId())
+			// devices are listed sorted by status ascending (accepted,
+			// pending, preauthorized, rejected), so the first preauthorized
+			// device is the last one this test needs to exercise
+			return
+		}
+
+		// the device survives with its remaining auth sets
+		after, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, dev.GetId()).Execute()
+		require.NoError(err)
+		assert.Len(after.AuthSets, len(apiDev.AuthSets)-1)
+
+		if dtoken != "" {
+			_, r, err := s.APIClient.DeploymentsDeviceAPIAPI.
+				CheckUpdate(common.JWTAuthContext(ctx, dtoken)).
+				DeviceType("foo").ArtifactName("bar").Execute()
+			require.Error(err)
+			assert.Equal(http.StatusUnauthorized, r.StatusCode)
+		}
+	}
+}
+
+func (s *DevauthManagementV2Suite) testAuthsetMgmtDeleteStatusFailed() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs, _, err := s.makeDevsWithAuthsets(ctx)
+	require.NoError(err)
+
+	// not found: valid device, bogus auth set
+	r, err := devauthm.
+		DeviceAuthManagementRemoveAuthentication(ctx, devs[0].GetId(), "foo").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+
+	// not found: bogus device
+	r, err = devauthm.
+		DeviceAuthManagementRemoveAuthentication(ctx, "foo", "bar").Execute()
+	require.Error(err)
+	assert.Equal(http.StatusNotFound, r.StatusCode)
+}
+
+func (s *DevauthManagementV2Suite) TestAuthReqSubmitAccept() {
+	require := require.New(s.T())
+	assert := assert.New(s.T())
+	ctx := common.JWTAuthContext(s.T().Context(), s.JWT)
+
+	devauthm := s.APIClient.DeviceAuthenticationManagementAPIAPI
+
+	devs := make([]*common.Device, 0, len(common.KeyKinds))
+	for _, kind := range common.KeyKinds {
+		kp, err := common.NewKeyPair(kind)
+		require.NoError(err)
+		mac, err := common.RandomMAC()
+		require.NoError(err)
+		device := common.NewDeviceFromKeyPair(kp, fmt.Sprintf(`{"mac":%q}`, mac.String()))
+		device.MAC = mac.String()
+		devs = append(devs, device)
+	}
+
+	for _, device := range devs {
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		assert.False(ok)
+	}
+
+	for _, device := range devs {
+		id, err := s.findDeviceIDByMac(ctx, device.MAC)
+		require.NoError(err)
+		apiDev, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, id).Execute()
+		require.NoError(err)
+		require.Len(apiDev.AuthSets, 1)
+		assert.Equal(model.DevStatusPending, apiDev.AuthSets[0].GetStatus())
+
+		_, err = devauthm.
+			DeviceAuthManagementSetAuthenticationStatus(ctx, apiDev.GetId(), apiDev.AuthSets[0].GetId()).
+			Status(client.Status{Status: model.DevStatusAccepted}).Execute()
+		require.NoError(err)
+
+		ok, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken)
+		require.NoError(err)
+		require.True(ok)
+
+		parts := strings.Split(device.Token, ".")
+		require.Len(parts, 3)
+
+		payloadRaw, err := base64.RawStdEncoding.DecodeString(parts[1])
+		require.NoError(err)
+		var payload map[string]any
+		require.NoError(json.Unmarshal(payloadRaw, &payload))
+		assert.Equal(apiDev.GetId(), payload["sub"])
+		assert.Equal("Mender", payload["iss"])
+		assert.NotEmpty(payload["jti"])
+		assert.NotNil(payload["exp"])
+		assert.Equal(true, payload["mender.device"])
+
+		headerRaw, err := base64.RawStdEncoding.DecodeString(parts[0])
+		require.NoError(err)
+		var header map[string]any
+		require.NoError(json.Unmarshal(headerRaw, &header))
+		assert.Equal("JWT", header["typ"])
+	}
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+// samePubkey compares two public keys by their decoded DER bytes, so keys that
+// are semantically equal but re-encoded (whitespace/PEM differences) still match.
+func samePubkey(a, b string) bool {
+	da, _ := pem.Decode([]byte(a))
+	db, _ := pem.Decode([]byte(b))
+	if da == nil || db == nil {
+		return false
+	}
+	return bytes.Equal(da.Bytes, db.Bytes)
+}
+
+// findDeviceIDByMac resolves the device id for the given identity mac via an
+// indexed inventory search by mac (deviceauth's own listing has no mac filter,
+// so paging it is O(number-of-devices) against the shared, never-reset
+// environment). A pending device's id isn't set on its common.Device (only
+// Accept sets it), so this is how the fixture learns it. The device id is the
+// same in deviceauth and inventory.
+func (s *DevauthManagementV2Suite) findDeviceIDByMac(ctx context.Context, mac string) (string, error) {
+	var id string
+	err := common.RetryUntil(ctx, 15*time.Second, 500*time.Millisecond, func() (bool, error) {
+		devices, _, err := s.APIClient.DeviceInventoryFiltersAndSearchManagementAPIAPI.
+			InventoryV2SearchDeviceInventories(ctx).
+			SearchParams(client.SearchParams{
+				Filters: []client.FilterPredicate{{
+					Scope:     client.IDENTITY,
+					Attribute: "mac",
+					Type:      "$eq",
+					Value:     client.AttributeValueRequest{String: client.PtrString(mac)},
+				}},
+			}).Execute()
+		if err != nil {
+			return false, err
+		}
+		if len(devices) > 0 {
+			id = devices[0].GetId()
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("device with mac %s not found: %w", mac, err)
+	}
+	return id, nil
+}
+
+// waitDeviceGone polls until the device is removed from deviceauth; removal is
+// async, and several tests need to wait for it, so it stays a shared helper.
+func (s *DevauthManagementV2Suite) waitDeviceGone(ctx context.Context, id string) bool {
+	err := common.RetryUntil(ctx, 10*time.Second, 200*time.Millisecond, func() (bool, error) {
+		_, r, _ := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, id).Execute()
+		return r != nil && r.StatusCode == http.StatusNotFound, nil
+	})
+	return err == nil
+}
+
+// waitInventoryStatus polls until inventory reflects the given identity status;
+// the deviceauth->inventory propagation is async, so it stays a shared helper.
+func (s *DevauthManagementV2Suite) waitInventoryStatus(ctx context.Context, id, status string) {
+	err := common.RetryUntil(ctx, 10*time.Second, 250*time.Millisecond, func() (bool, error) {
+		inv, _, err := s.APIClient.DeviceInventoryManagementAPIAPI.
+			GetDeviceInventory(ctx, id).Execute()
+		if err != nil || inv == nil {
+			return false, nil
+		}
+		for _, a := range inv.Attributes {
+			if a.GetScope() == client.IDENTITY && a.GetName() == "status" {
+				return a.GetValue().String != nil && *a.GetValue().String == status, nil
+			}
+		}
+		return false, nil
+	})
+	require.NoError(s.T(), err, "timeout waiting for inventory status %q for device %s", status, id)
+}
+
+// createPending onboards a device with numAuthsets pending auth sets (each with
+// a fresh key of the given kind) sharing one identity.
+func (s *DevauthManagementV2Suite) createPending(ctx context.Context, kind string, numAuthsets int) ([]*common.Device, error) {
+	mac, err := common.RandomMAC()
+	if err != nil {
+		return nil, err
+	}
+	idData := fmt.Sprintf(`{"mac":%q}`, mac.String())
+	var authSets []*common.Device
+	for i := 0; i < numAuthsets; i++ {
+		kp, err := common.NewKeyPair(kind)
+		if err != nil {
+			return nil, err
+		}
+		device := common.NewDeviceFromKeyPair(kp, idData)
+		device.MAC = mac.String()
+		if _, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken); err != nil {
+			return nil, err
+		}
+		authSets = append(authSets, device)
+	}
+	id, err := s.findDeviceIDByMac(ctx, mac.String())
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range authSets {
+		d.ID = id
+	}
+	return authSets, nil
+}
+
+// createAccepted onboards a pending device and accepts its first numAccepted
+// auth sets.
+func (s *DevauthManagementV2Suite) createAccepted(ctx context.Context, kind string, numAuthsets, numAccepted int) ([]*common.Device, error) {
+	authSets, err := s.createPending(ctx, kind, numAuthsets)
+	if err != nil {
+		return nil, err
+	}
+	id := authSets[0].ID
+	apiDev, _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementGetDevice(ctx, id).Execute()
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < numAccepted; i++ {
+		pubkey := common.ExportPublicKeyPEM(authSets[i].PublicKey)
+		var aset *client.AuthSet
+		for j := range apiDev.AuthSets {
+			if apiDev.AuthSets[j].Pubkey != nil && samePubkey(*apiDev.AuthSets[j].Pubkey, pubkey) {
+				aset = &apiDev.AuthSets[j]
+				break
+			}
+		}
+		if aset == nil {
+			return nil, fmt.Errorf("auth set for accepted key %d not found", i)
+		}
+		if _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementSetAuthenticationStatus(ctx, id, aset.GetId()).
+			Status(client.Status{Status: model.DevStatusAccepted}).Execute(); err != nil {
+			return nil, err
+		}
+	}
+	return authSets, nil
+}
+
+// createRejected onboards a pending device and rejects all its auth sets.
+func (s *DevauthManagementV2Suite) createRejected(ctx context.Context, kind string, numAuthsets int) ([]*common.Device, error) {
+	authSets, err := s.createPending(ctx, kind, numAuthsets)
+	if err != nil {
+		return nil, err
+	}
+	id := authSets[0].ID
+	apiDev, _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementGetDevice(ctx, id).Execute()
+	if err != nil {
+		return nil, err
+	}
+	for _, aset := range apiDev.AuthSets {
+		if _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementSetAuthenticationStatus(ctx, id, aset.GetId()).
+			Status(client.Status{Status: model.DevStatusRejected}).Execute(); err != nil {
+			return nil, err
+		}
+	}
+	return authSets, nil
+}
+
+// createPreauthd preauthorizes a device (single preauthorized auth set).
+func (s *DevauthManagementV2Suite) createPreauthd(ctx context.Context, kind string) ([]*common.Device, error) {
+	kp, err := common.NewKeyPair(kind)
+	if err != nil {
+		return nil, err
+	}
+	mac, err := common.RandomMAC()
+	if err != nil {
+		return nil, err
+	}
+	idData := fmt.Sprintf(`{"mac":%q}`, mac.String())
+	r, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+		DeviceAuthManagementPreauthorize(ctx).
+		PreAuthSet(client.PreAuthSet{
+			IdentityData: client.IdentityData{Mac: client.PtrString(mac.String())},
+			Pubkey:       kp.PublicKeyPEM(),
+		}).Execute()
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected preauthorize status %d", r.StatusCode)
+	}
+	id := path.Base(r.Header.Get("Location"))
+	if id == "" {
+		return nil, fmt.Errorf("preauthorize: missing Location header")
+	}
+	device := common.NewDeviceFromKeyPair(kp, idData)
+	device.MAC = mac.String()
+	device.ID = id
+	return []*common.Device{device}, nil
+}
+
+// createPreauthdWithPending preauthorizes a device and adds numPending extra
+// pending auth sets; the device stays preauthorized.
+func (s *DevauthManagementV2Suite) createPreauthdWithPending(ctx context.Context, kind string, numPending int) ([]*common.Device, error) {
+	authSets, err := s.createPreauthd(ctx, kind)
+	if err != nil {
+		return nil, err
+	}
+	idData := authSets[0].IDData
+	id, mac := authSets[0].ID, authSets[0].MAC
+	for i := 0; i < numPending; i++ {
+		kp, err := common.NewKeyPair(common.KeyKindRSA)
+		if err != nil {
+			return nil, err
+		}
+		device := common.NewDeviceFromKeyPair(kp, idData)
+		device.MAC = mac
+		device.ID = id
+		if _, err := device.SubmitAuthRequest(ctx, s.APIClient, s.Tenant.TenantToken); err != nil {
+			return nil, err
+		}
+		authSets = append(authSets, device)
+	}
+	return authSets, nil
+}
+
+// makeDevsWithAuthsets returns the created devices as their live client.Device
+// state (sorted the way the management listing returns them, by status then id)
+// plus a map from device id to the per-auth-set keys (common.Device) used to
+// create it, which the API never returns.
+func (s *DevauthManagementV2Suite) makeDevsWithAuthsets(ctx context.Context) ([]client.Device, map[string][]*common.Device, error) {
+	var groups [][]*common.Device
+	add := func(g []*common.Device, err error) error {
+		if err != nil {
+			return err
+		}
+		groups = append(groups, g)
+		return nil
+	}
+
+	// pending devices, single auth set
+	for i := 0; i < 3; i++ {
+		if err := add(s.createPending(ctx, common.KeyKindRSA, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.createPending(ctx, common.KeyKindECP256, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createPending(ctx, common.KeyKindEd25519, 1)); err != nil {
+		return nil, nil, err
+	}
+
+	// pending devices with more than one auth set
+	for i := 0; i < 2; i++ {
+		if err := add(s.createPending(ctx, common.KeyKindRSA, 3)); err != nil {
+			return nil, nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.createPending(ctx, common.KeyKindECP256, 3)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createPending(ctx, common.KeyKindEd25519, 3)); err != nil {
+		return nil, nil, err
+	}
+
+	// accepted devices, single auth set
+	for i := 0; i < 3; i++ {
+		if err := add(s.createAccepted(ctx, common.KeyKindRSA, 1, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.createAccepted(ctx, common.KeyKindECP256, 1, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createAccepted(ctx, common.KeyKindEd25519, 1, 1)); err != nil {
+		return nil, nil, err
+	}
+
+	// accepted devices with more than one auth set
+	for i := 0; i < 2; i++ {
+		if err := add(s.createAccepted(ctx, common.KeyKindRSA, 3, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.createAccepted(ctx, common.KeyKindECP256, 2, 1)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createAccepted(ctx, common.KeyKindEd25519, 2, 1)); err != nil {
+		return nil, nil, err
+	}
+
+	// rejected devices
+	for i := 0; i < 2; i++ {
+		if err := add(s.createRejected(ctx, common.KeyKindRSA, 3)); err != nil {
+			return nil, nil, err
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := add(s.createRejected(ctx, common.KeyKindECP256, 2)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createRejected(ctx, common.KeyKindEd25519, 2)); err != nil {
+		return nil, nil, err
+	}
+
+	// preauthorized devices
+	if err := add(s.createPreauthd(ctx, common.KeyKindRSA)); err != nil {
+		return nil, nil, err
+	}
+	if err := add(s.createPreauthd(ctx, common.KeyKindECP256)); err != nil {
+		return nil, nil, err
+	}
+	if err := add(s.createPreauthd(ctx, common.KeyKindEd25519)); err != nil {
+		return nil, nil, err
+	}
+
+	// preauthorized devices with extra pending auth sets
+	for i := 0; i < 2; i++ {
+		if err := add(s.createPreauthdWithPending(ctx, common.KeyKindRSA, 2)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := add(s.createPreauthdWithPending(ctx, common.KeyKindECP256, 2)); err != nil {
+		return nil, nil, err
+	}
+	if err := add(s.createPreauthdWithPending(ctx, common.KeyKindEd25519, 2)); err != nil {
+		return nil, nil, err
+	}
+
+	keys := make(map[string][]*common.Device, len(groups))
+	devs := make([]client.Device, 0, len(groups))
+	for _, g := range groups {
+		id := g[0].ID
+		apiDev, _, err := s.APIClient.DeviceAuthenticationManagementAPIAPI.
+			DeviceAuthManagementGetDevice(ctx, id).Execute()
+		if err != nil {
+			return nil, nil, err
+		}
+		devs = append(devs, *apiDev)
+		keys[id] = g
+	}
+	slices.SortStableFunc(devs, func(a, b client.Device) int {
+		if c := cmp.Compare(a.GetStatus(), b.GetStatus()); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.GetId(), b.GetId())
+	})
+
+	return devs, keys, nil
+}


### PR DESCRIPTION
Part of the suite-by-suite python-to-Go port (see #2079). Ports
test_devauth.py: preauthorization, device and authset management, auth
requests across RSA, four ECDSA curves and Ed25519. The python tests
keep running in parallel. Builds on #2079.