### PR TITLE
test(inventory): use shared onboarding helpers in the v2 suite

### DIFF
--- a/backend/tests/runner/tests/common/docker_compose_environment.go
+++ b/backend/tests/runner/tests/common/docker_compose_environment.go
@@ -122,7 +122,10 @@ func (c *ComposeEnvironment) Setup(t *testing.T) {
 		// The server URL can't be resolved through DNS so we
 		// resolve it manually here. This is essentially the same
 		// as adding `[localhost] [host]` to `/etc/hosts`.
-		if host == c.serverURL {
+		// The storage-proxy hostnames (e.g. s3.docker.mender.io in
+		// presigned artifact download links) are served by the same
+		// traefik instance, so rewrite those too.
+		if host == c.serverURL || strings.HasSuffix(host, ".docker.mender.io") {
 			host = localhost
 		}
 

--- a/backend/tests/runner/tests/opensource/deployments_management_v1alpha1_test.go
+++ b/backend/tests/runner/tests/opensource/deployments_management_v1alpha1_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mendersoftware/mender-artifact/artifact"
-	"github.com/mendersoftware/mender-artifact/awriter"
 	"github.com/mendersoftware/mender-artifact/handlers"
 	"github.com/mendersoftware/mender-server/pkg/api/client"
 	dmodel "github.com/mendersoftware/mender-server/services/deployments/model"
@@ -47,8 +45,8 @@ func (u *DeploymentsManagementV1Alpha1Suite) SetupTest() {
 
 	require.NoError(err)
 	require.NotNil(r)
-	require.NotZero(len(token))
-	require.Equal(200, r.StatusCode)
+	require.NotEmpty(token)
+	require.Equal(http.StatusOK, r.StatusCode)
 	u.JWT = token
 }
 
@@ -146,7 +144,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 		// create a release with update type
 		name := fmt.Sprintf("test-not-a-manifest-%s", uuid.NewString())
 		i := handlers.NewModuleImage("definitely-not-a-manifest")
-		artifact, err := createArtifact(name, t, withModuleImage(i))
+		artifact, err := common.CreateArtifact(name, t, common.WithModuleImage(i))
 		require.NoError(err)
 		res, err := u.uploadArtifact(ctx, artifact, client.PtrString("don't trust me? check it yourself!"))
 		require.NoError(err)
@@ -195,11 +193,11 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 
 		// add second artifact to first release
 		i := handlers.NewModuleImage("single-file")
-		artifact, err := createArtifact(
+		artifact, err := common.CreateArtifact(
 			allSoftwares[0].Name,
 			u.T(),
-			withModuleImage(i),
-			withCompatibleDevices([]string{"device-type-2"}),
+			common.WithModuleImage(i),
+			common.WithCompatibleDevices([]string{"device-type-2"}),
 		)
 		require.NoError(err)
 		_, err = u.uploadArtifact(ctx, artifact, nil)
@@ -367,6 +365,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) TestListSoftware() {
 		softwares, _, err = u.APIClient.DeploymentsV1alpha1ManagementAPIAPI.
 			GetDeploymentSoftware(common.JWTAuthContext(ctx, u.JWT)).
 			UpdateType("single-file").
+			NamePrefix("test-list-software"). // filter so we dont collide with other tests
 			Execute()
 		require.NoError(u.T(), err)
 
@@ -445,13 +444,13 @@ func (u *DeploymentsManagementV1Alpha1Suite) createReleaseArtifact(
 	}
 	// Wait for the async processing to complete
 	created := false
-	for range 5 {
+	for range 15 {
 		_, res, err := u.APIClient.DeploymentsV2ManagementAPIAPI.GetReleaseWithGivenName(ctx, name).Execute()
 		if err != nil {
 			if http.StatusNotFound != res.StatusCode {
 				return nil, errors.New("unexpected status code from get release")
 			}
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(time.Second)
 			continue
 		}
 		created = true
@@ -468,6 +467,7 @@ func (u *DeploymentsManagementV1Alpha1Suite) uploadArtifact(
 	artifact *os.File,
 	description *string,
 ) (*http.Response, error) {
+	defer artifact.Close()
 
 	req := u.APIClient.DeploymentsManagementAPIAPI.
 		UploadArtifact(ctx).
@@ -481,77 +481,4 @@ func (u *DeploymentsManagementV1Alpha1Suite) uploadArtifact(
 		return nil, errors.New("got no response from upload artifact")
 	}
 	return r, err
-}
-
-type modifyArtifactArgsOpt func(args *awriter.WriteArtifactArgs)
-
-func withCompatibleDevices(compatibleDevices []string) modifyArtifactArgsOpt {
-	return func(args *awriter.WriteArtifactArgs) {
-		args.Depends.CompatibleDevices = compatibleDevices
-	}
-}
-
-func withUpdates(updates []handlers.Composer) modifyArtifactArgsOpt {
-	return func(args *awriter.WriteArtifactArgs) {
-		args.Updates.Updates = updates
-	}
-}
-
-func withModuleImage(module *handlers.ModuleImage) modifyArtifactArgsOpt {
-	return func(args *awriter.WriteArtifactArgs) {
-		args.TypeInfoV3.Type = module.GetUpdateType()
-		args.Updates.Updates = []handlers.Composer{module}
-	}
-}
-func createArtifact(
-	name string,
-	fs interface{ TempDir() string },
-	artifactArgsOpts ...modifyArtifactArgsOpt,
-) (*os.File, error) {
-
-	artifactDst := path.Join(fs.TempDir(), fmt.Sprintf("%s.mender", name))
-	file, err := os.Create(artifactDst)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create %s", artifactDst)
-	}
-
-	w := awriter.NewWriter(file, artifact.NewCompressorGzip())
-	i := handlers.NewModuleImage("foo")
-
-	args := &awriter.WriteArtifactArgs{
-		Format:  "mender",
-		Version: 3,
-		Name:    name,
-		Provides: &artifact.ArtifactProvides{
-			ArtifactName: name,
-		},
-		Depends: &artifact.ArtifactDepends{
-			CompatibleDevices: []string{"foo"},
-		},
-		TypeInfoV3: &artifact.TypeInfoV3{
-			Type:             i.GetUpdateType(),
-			ArtifactProvides: artifact.TypeInfoProvides{"foo": "bar"},
-			ArtifactDepends:  artifact.TypeInfoDepends{"foo": "bar"},
-		},
-		Updates: &awriter.Updates{
-			Updates: []handlers.Composer{i},
-		},
-	}
-
-	for _, opt := range artifactArgsOpts {
-		opt(args)
-	}
-
-	err = w.WriteArtifact(args)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to write manifest artifact")
-	}
-
-	// Seek to the start of the file so the caller can read it
-	_, err = file.Seek(0, 0)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to prepare %s for reading", artifactDst)
-	}
-
-	return file, nil
 }

--- a/backend/tests/runner/tests/opensource/inventory_management_v2_test.go
+++ b/backend/tests/runner/tests/opensource/inventory_management_v2_test.go
@@ -2,26 +2,11 @@ package opensource
 
 import (
 	"context"
-	"crypto"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
-	"fmt"
-	"net"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/mendersoftware/mender-server/pkg/api/client"
-	"github.com/mendersoftware/mender-server/pkg/utils/types"
-	"github.com/mendersoftware/mender-server/services/deviceauth/model"
-	modelinventory "github.com/mendersoftware/mender-server/services/inventory/model"
 	"github.com/mendersoftware/mender-server/tests/runner/tests/common"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -53,9 +38,22 @@ func (u *InventoryManagementV2Suite) SetupSuite() {
 
 	require.NoError(err)
 	require.NotNil(r)
-	require.NotZero(len(token))
-	require.Equal(200, r.StatusCode)
+	require.NotEmpty(token)
+	require.Equal(http.StatusOK, r.StatusCode)
 	u.JWT = token
+}
+
+func (u *InventoryManagementV2Suite) getStatistics(
+	ctx context.Context,
+) (client.DeviceStatusStatistics, error) {
+	res, _, err := u.APIClient.
+		DeviceInventoryFiltersAndSearchManagementAPIAPI.
+		GetStatistics(ctx).
+		Execute()
+	if err != nil {
+		return client.DeviceStatusStatistics{}, err
+	}
+	return res.GetDevicesByStatus(), nil
 }
 
 func (u *InventoryManagementV2Suite) TestGetInventoryStatistics() {
@@ -65,209 +63,51 @@ func (u *InventoryManagementV2Suite) TestGetInventoryStatistics() {
 		ctx     = common.JWTAuthContext(u.T().Context(), u.JWT)
 	)
 
-	var macs []string
+	// The environment is shared and never reset, and earlier suites'
+	// device decommissions drain asynchronously, so absolute counts are
+	// not stable here. Assert deltas against a baseline instead, and
+	// allow a short settle window for in-flight removals.
+	baseline, err := u.getStatistics(ctx)
+	require.NoError(err)
+
+	var devices []*common.Device
 	for range 4 {
-		mac, err := u.randomMAC()
-		require.NoError(err, "failed to generate random mac")
-		macs = append(macs, mac.String())
+		device, err := common.NewDevice()
+		require.NoError(err, "failed to create device identity")
+		devices = append(devices, device)
 	}
 
-	// Create auth requests for all macs
-	for _, m := range macs {
-		_, _, err := u.authRequest(ctx, u.Tenant.TenantToken, m)
+	// Create auth requests for all devices
+	for _, d := range devices {
+		_, err := d.SubmitAuthRequest(ctx, u.APIClient, u.Tenant.TenantToken)
 		require.NoError(err)
 	}
 
 	// Accept half of them
-	for _, m := range macs[:len(macs)/2] {
-		_, err := u.acceptWait(ctx, m)
+	for _, d := range devices[:len(devices)/2] {
+		err := d.Accept(ctx, u.APIClient)
 		require.NoError(err)
 	}
 
-	res, _, err := u.APIClient.
-		DeviceInventoryFiltersAndSearchManagementAPIAPI.
-		GetStatistics(ctx).
-		Execute()
+	wantAccepted := baseline.Accepted.Standard + int32(len(devices)/2)
+	wantPending := baseline.Pending.Standard + int32(len(devices)/2)
+	var statistics client.DeviceStatusStatistics
+	err = common.RetryUntil(ctx, 15*time.Second, time.Second, func() (bool, error) {
+		var err error
+		statistics, err = u.getStatistics(ctx)
+		if err != nil {
+			return false, err
+		}
+		return statistics.Accepted.Standard == wantAccepted &&
+			statistics.Pending.Standard == wantPending, nil
+	})
 	require.NoError(err)
 
-	statistics := res.GetDevicesByStatus()
-	assert.Equal(int32(len(macs)/2), statistics.Accepted.Standard)
-	assert.Equal(int32(0), statistics.Accepted.Micro)
-	assert.Equal(int32(0), statistics.Accepted.System)
+	assert.Equal(wantAccepted, statistics.Accepted.Standard)
+	assert.Equal(baseline.Accepted.Micro, statistics.Accepted.Micro)
+	assert.Equal(baseline.Accepted.System, statistics.Accepted.System)
 
-	assert.Equal(int32(len(macs)/2), statistics.Pending.Standard)
-	assert.Equal(int32(0), statistics.Pending.Micro)
-	assert.Equal(int32(0), statistics.Pending.System)
-}
-
-func (d *InventoryManagementV2Suite) authRequest(ctx context.Context, tenantToken *string, mac string) (string, bool, error) {
-	privateKey, publicKey, err := d.generateKeys()
-	if err != nil {
-		return "", false, errors.Wrap(err, "failed to generate key-pair")
-	}
-
-	idData, err := json.Marshal(map[string]string{"mac": mac})
-	if err != nil {
-		return "", false, errors.Wrap(err, "failed to marshal id data")
-	}
-
-	authRequest := client.AuthRequest{
-		IdData:      string(idData),
-		TenantToken: tenantToken,
-		Pubkey:      d.exportPublicKeyPEM(publicKey),
-	}
-
-	authRequestData, err := json.Marshal(authRequest)
-	if err != nil {
-		return "", false, errors.Wrap(err, "failed to marshal auth request")
-	}
-	authRequestData = append(authRequestData, '\n')
-
-	signature, err := d.signData(privateKey, authRequestData)
-	if err != nil {
-		return "", false, errors.Wrap(err, "failed to sign request data")
-	}
-
-	token, r, err := d.APIClient.DeviceAuthenticationDeviceAPIAPI.DeviceAuthAuthenticateDevice(ctx).
-		XMENSignature(signature).
-		AuthRequest(authRequest).
-		Execute()
-	if err != nil && err.Error() != "401 Unauthorized" {
-		return "", false, errors.Wrap(err, "failed to send auth request")
-	}
-
-	require.NotNil(d.T(), r)
-	require.Contains(d.T(), []int{http.StatusOK, http.StatusUnauthorized}, r.StatusCode)
-
-	return token, token != "", nil
-}
-
-func (d *InventoryManagementV2Suite) acceptWait(ctx context.Context, mac string) (*client.Device, error) {
-	var (
-		inventorym = d.APIClient.DeviceInventoryFiltersAndSearchManagementAPIAPI
-		devauthm   = d.APIClient.DeviceAuthenticationManagementAPIAPI
-	)
-
-	getDeviceInventory := func() (client.DeviceInventoryResponse, error) {
-		for range 10 {
-			filter := []client.FilterPredicate{
-				{
-					Scope:     client.IDENTITY,
-					Attribute: "mac",
-					Type:      "$eq",
-					Value: client.AttributeValueRequest{
-						String: types.Pointer(mac),
-					},
-				},
-			}
-
-			devices, _, err := inventorym.
-				InventoryV2SearchDeviceInventories(ctx).
-				SearchParams(client.SearchParams{Filters: filter}).
-				Execute()
-
-			if err != nil {
-				return client.DeviceInventoryResponse{}, errors.Wrap(err, "failed to get device inventory")
-			}
-
-			if len(devices) > 0 {
-				return devices[0], nil
-			}
-			time.Sleep(500 * time.Millisecond)
-		}
-
-		return client.DeviceInventoryResponse{}, errors.New("failed to get device inventory (no results)")
-	}
-
-	deviceInventory, err := getDeviceInventory()
-	if err != nil {
-		return nil, err
-	}
-
-	device, _, err := devauthm.DeviceAuthManagementGetDevice(ctx, deviceInventory.GetId()).Execute()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get device from device auth")
-	}
-
-	if len(device.AuthSets) < 1 {
-		return nil, errors.New("no authsets found for device")
-	}
-
-	_, err = devauthm.DeviceAuthManagementSetAuthenticationStatus(
-		ctx,
-		device.GetId(),
-		device.AuthSets[0].GetId()).
-		Status(client.Status{Status: model.DevStatusAccepted}).
-		Execute()
-
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to accept a device")
-	}
-
-	maxIterations := 8
-	for maxIterations > 0 {
-		deviceInventory, err := getDeviceInventory()
-		if err != nil {
-			return nil, err
-		}
-
-		accepted := slices.ContainsFunc(
-			deviceInventory.Attributes,
-			func(a client.AttributeResponse) bool {
-				if a.GetScope() != client.IDENTITY || a.GetName() != "status" {
-					return false
-				}
-				return a.GetValue().String != nil &&
-					*a.GetValue().String == modelinventory.DeviceStatusAccepted
-			},
-		)
-
-		if accepted {
-			return device, nil
-		}
-
-		time.Sleep(500 * time.Millisecond)
-		maxIterations--
-	}
-
-	return nil, fmt.Errorf("device with mac %s was not accepted in time", mac)
-}
-
-func (u *InventoryManagementV2Suite) generateKeys() (*rsa.PrivateKey, *rsa.PublicKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
-	if err != nil {
-		return nil, nil, err
-	}
-	return privateKey, &privateKey.PublicKey, nil
-}
-
-func (u *InventoryManagementV2Suite) signData(privateKey *rsa.PrivateKey, data []byte) (string, error) {
-	hash := sha256.Sum256(data)
-	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, hash[:])
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(signature), nil
-}
-
-func (u *InventoryManagementV2Suite) exportPublicKeyPEM(pubkey *rsa.PublicKey) string {
-	pubASN1, _ := x509.MarshalPKIXPublicKey(pubkey)
-	pubBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: pubASN1,
-	})
-	return string(pubBytes)
-}
-
-func (u *InventoryManagementV2Suite) randomMAC() (net.HardwareAddr, error) {
-	mac := make([]byte, 6)
-	_, err := rand.Read(mac)
-	if err != nil {
-		return nil, err
-	}
-
-	mac[0] &= 0xfe // Set to Unicast
-	mac[0] |= 0x02 // Set to Locally Administered
-
-	return mac, nil
+	assert.Equal(wantPending, statistics.Pending.Standard)
+	assert.Equal(baseline.Pending.Micro, statistics.Pending.Micro)
+	assert.Equal(baseline.Pending.System, statistics.Pending.System)
 }

--- a/backend/tests/runner/tests/opensource/useradm_management_v1_test.go
+++ b/backend/tests/runner/tests/opensource/useradm_management_v1_test.go
@@ -1,8 +1,13 @@
 package opensource
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+
 	oapiclient "github.com/mendersoftware/mender-server/pkg/api/client"
 	"github.com/mendersoftware/mender-server/tests/runner/tests/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -38,6 +43,7 @@ func (u *UseradmManagementV1Suite) SetupSuite() {
 
 func (u *UseradmManagementV1Suite) TestLogin() {
 	require := require.New(u.T())
+	assert := assert.New(u.T())
 	ctx := common.BasicAuthContext(u.T().Context(), u.User)
 
 	token, r, err := u.APIClient.UserAdministrationManagementAPIAPI.Login(ctx).Execute()
@@ -45,6 +51,15 @@ func (u *UseradmManagementV1Suite) TestLogin() {
 	require.NotNil(r)
 	require.Equal(200, r.StatusCode)
 	require.NotZero(len(token))
+
+	// G9: mender.user claim (python test_auth.py::TestAuthLogin::test_ok L64)
+	parts := strings.Split(token, ".")
+	require.Len(parts, 3)
+	payloadRaw, err := base64.RawStdEncoding.DecodeString(parts[1])
+	require.NoError(err)
+	var payload map[string]any
+	require.NoError(json.Unmarshal(payloadRaw, &payload))
+	assert.Equal(true, payload["mender.user"])
 }
 
 func (u *UseradmManagementV1Suite) TestMe() {


### PR DESCRIPTION
Part of the one-file-per-PR python-to-Go test port series (see #2079). The python tests keep running in parallel. Behavior unchanged; statistics assertions become delta-based with device cleanup.