### PR TITLE
few fixes to prevent deviceauth from sending Internal Server Errors on token verification

### DIFF
--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -723,12 +723,6 @@ func (d *DevAuth) DeleteDevice(ctx context.Context, devID string) error {
 
 // Deletes device authentication set, and optionally the device.
 func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string) error {
-	l := log.FromContext(ctx)
-
-	l.Warnf("Delete authentication set with id: "+
-		"%s for the device with id: %s",
-		authId, devID)
-
 	// retrieve device authentication set to check its status
 	authSet, err := d.db.GetAuthSetById(ctx, authId)
 	if err != nil {
@@ -738,26 +732,11 @@ func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string
 		return errors.Wrap(err, "db get auth set error")
 	}
 
-	// delete device authorization set
-	if err := d.db.DeleteAuthSetForDevice(ctx, devID, authId); err != nil {
+	if err := d.deleteAuthSet(ctx, authSet); err != nil {
 		return err
 	}
 
-	// if the device authentication set is accepted delete device tokens
-	if authSet.Status == model.DevStatusAccepted {
-		// If string is not a valid UUID there's no token.
-		devOID := oid.FromString(devID)
-		if err := d.db.DeleteTokenByDevId(
-			ctx, devOID,
-		); err != nil && err != store.ErrTokenNotFound {
-			return errors.Wrap(err,
-				"db delete device tokens error")
-		}
-		err := d.cacheDeleteToken(ctx, devID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete token for %s from cache", devID)
-		}
-	} else if authSet.Status == model.DevStatusPreauth {
+	if authSet.Status == model.DevStatusPreauth {
 		// if the auth set status is 'preauthorized', the device is deleted from
 		// deviceauth. We cannot start the decommission_device workflow because
 		// we don't provision devices until they are accepted. Still, we need to
@@ -766,33 +745,68 @@ func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string
 		// from the inventory service, we start the status update workflow with the
 		// special value "decommissioned", which will cause the deletion of the
 		// device from the inventory service's database
-		tenantID := ""
-		idData := identity.FromContext(ctx)
-		if idData != nil {
-			tenantID = idData.Tenant
-		}
-
-		//nolint:bodyclose
-		_, _, err := d.cOrch.StartWorkflow(ctx, "update_device_status").
-			RequestBody(map[string]interface{}{
-				"request_id":    requestid.FromContext(ctx),
-				"devices":       []model.DeviceInventoryUpdate{{Id: devID}},
-				"tenant_id":     tenantID,
-				"device_status": "decommissioned",
-			}).Execute()
-		if err != nil {
-			return errors.Wrap(err, "update device status job error")
-		}
-
-		// delete device
-		if err := d.db.DeleteDevice(ctx, devID); err != nil {
+		if err := d.deletePreauthDevice(ctx, authSet.DeviceId); err != nil {
 			return err
 		}
-
 		return nil
 	}
 
 	return d.updateDeviceStatus(ctx, devID, "", authSet.Status)
+}
+
+func (d *DevAuth) deletePreauthDevice(ctx context.Context, devId string) error {
+	tenantId := ""
+	idData := identity.FromContext(ctx)
+	if idData != nil {
+		tenantId = idData.Tenant
+	}
+
+	//nolint:bodyclose
+	_, _, err := d.cOrch.StartWorkflow(ctx, "update_device_status").
+		RequestBody(map[string]interface{}{
+			"request_id":    requestid.FromContext(ctx),
+			"devices":       []model.DeviceInventoryUpdate{{Id: devId}},
+			"tenant_id":     tenantId,
+			"device_status": "decommissioned",
+		}).Execute()
+	if err != nil {
+		return errors.Wrap(err, "failed to start update device status job")
+	}
+
+	// delete device
+	err = d.db.DeleteDevice(ctx, devId)
+
+	return err
+}
+
+func (d *DevAuth) deleteAuthSet(ctx context.Context, authSet *model.AuthSet) error {
+	l := log.FromContext(ctx)
+
+	l.Warnf("Delete authentication set with id: "+
+		"%s for the device with id: %s",
+		authSet.Id, authSet.DeviceId)
+
+	// delete device authorization set
+	if err := d.db.DeleteAuthSetForDevice(ctx, authSet.DeviceId, authSet.Id); err != nil {
+		return err
+	}
+
+	// if the device authentication set is accepted delete device tokens
+	if authSet.Status == model.DevStatusAccepted {
+		// If string is not a valid UUID there's no token.
+		devOID := oid.FromString(authSet.DeviceId)
+		if err := d.db.DeleteTokenByDevId(
+			ctx, devOID,
+		); err != nil && err != store.ErrTokenNotFound {
+			return errors.Wrap(err,
+				"db delete device tokens error")
+		}
+		err := d.cacheDeleteToken(ctx, authSet.DeviceId)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete token for %s from cache", authSet.DeviceId)
+		}
+	}
+	return nil
 }
 
 func (d *DevAuth) AcceptDeviceAuth(ctx context.Context, device_id string, auth_id string) error {

--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -736,19 +736,27 @@ func (d *DevAuth) DeleteAuthSet(ctx context.Context, devID string, authId string
 		return err
 	}
 
+	// If the auth set status is 'preauthorized' and this is the only auth set
+	// for this device, the device is deleted from deviceauth.
+	// We cannot start the decommission_device workflow because
+	// we don't provision devices until they are accepted. Still, we need to
+	// remove the device from the inventory service because we index pre-authorized
+	// devices for consumption via filtering APIs. To trigger the deletion
+	// from the inventory service, we start the status update workflow with the
+	// special value "decommissioned", which will cause the deletion of the
+	// device from the inventory service's database.
 	if authSet.Status == model.DevStatusPreauth {
-		// if the auth set status is 'preauthorized', the device is deleted from
-		// deviceauth. We cannot start the decommission_device workflow because
-		// we don't provision devices until they are accepted. Still, we need to
-		// remove the device from the inventory service because we index pre-authorized
-		// devices for consumption via filtering APIs. To trigger the deletion
-		// from the inventory service, we start the status update workflow with the
-		// special value "decommissioned", which will cause the deletion of the
-		// device from the inventory service's database
-		if err := d.deletePreauthDevice(ctx, authSet.DeviceId); err != nil {
-			return err
+		authSets, err := d.db.GetAuthSetsForDevice(ctx, authSet.DeviceId)
+		if err != nil {
+			return errors.Wrap(err, "db get auth sets error")
 		}
-		return nil
+		if len(authSets) == 0 {
+			err = d.deletePreauthDevice(ctx, authSet.DeviceId)
+			if err != nil {
+				return errors.Wrap(err, "failed to delete preauthorized device")
+			}
+			return nil
+		}
 	}
 
 	return d.updateDeviceStatus(ctx, devID, "", authSet.Status)

--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -461,7 +461,7 @@ func (d *DevAuth) updateDeviceStatus(
 	currentStatus string,
 ) error {
 	newStatus, err := d.db.GetDeviceStatus(ctx, devId)
-	if currentStatus == newStatus {
+	if err == nil && currentStatus == newStatus {
 		return nil
 	}
 	if status == "" {

--- a/backend/services/deviceauth/devauth/devauth.go
+++ b/backend/services/deviceauth/devauth/devauth.go
@@ -1230,6 +1230,15 @@ func (d *DevAuth) VerifyToken(ctx context.Context, raw string) error {
 	// decommissioning
 	dev, err := d.db.GetDeviceById(ctx, auth.DeviceId)
 	if err != nil {
+		if err == store.ErrDevNotFound {
+			// apparently the auth set is an orphan and should be deleted
+			l.Warnf("Delete orphan authentication set with id: %s for device with id: %s",
+				auth.Id, auth.DeviceId)
+			if err := d.deleteAuthSet(ctx, auth); err != nil {
+				return err
+			}
+			return jwt.ErrTokenInvalid
+		}
 		return err
 	}
 	if dev.Decommissioning {

--- a/backend/services/deviceauth/devauth/devauth_test.go
+++ b/backend/services/deviceauth/devauth/devauth_test.go
@@ -2880,11 +2880,12 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 		dbGetAuthSetByIdErr         error
 		dbDeleteTokenByDevIdErr     error
 		dbDeleteAuthSetForDeviceErr error
-		dbGetAuthSetsForDeviceErr   error
 		dbDeleteDeviceErr           error
 		dbGetDeviceStatus           string
 		dbGetDeviceStatusErr        error
 		dbUpdateDeviceErr           error
+		dbGetAuthSetsForDevice      []model.AuthSet
+		dbGetAuthSetsForDeviceErr   error
 
 		submitJob       bool
 		orchestratorErr error
@@ -2906,102 +2907,192 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 			outErr:              store.ErrAuthSetNotFound.Error(),
 		},
 		{
-			devId:                   oid.NewUUIDv5("devId3").String(),
-			authId:                  oid.NewUUIDv5("authId3").String(),
-			authSet:                 &model.AuthSet{Status: model.DevStatusAccepted},
+			devId:  oid.NewUUIDv5("devId3").String(),
+			authId: oid.NewUUIDv5("authId3").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId3").String(),
+				DeviceId: oid.NewUUIDv5("devId3").String(),
+				Status:   model.DevStatusAccepted,
+			},
 			dbDeleteTokenByDevIdErr: errors.New("DeleteTokenByDevId Error"),
 			outErr:                  "db delete device tokens error: DeleteTokenByDevId Error",
 		},
 		{
-			devId:                   oid.NewUUIDv5("devId4").String(),
-			authId:                  oid.NewUUIDv5("authId4").String(),
-			authSet:                 &model.AuthSet{Status: model.DevStatusPending},
+			devId:  oid.NewUUIDv5("devId4").String(),
+			authId: oid.NewUUIDv5("authId4").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId4").String(),
+				DeviceId: oid.NewUUIDv5("devId4").String(),
+				Status:   model.DevStatusPending,
+			},
 			submitJob:               true,
 			dbDeleteTokenByDevIdErr: errors.New("DeleteTokenByDevId Error"),
 		},
 		{
-			devId:                   oid.NewUUIDv5("devId5").String(),
-			authId:                  oid.NewUUIDv5("authId5").String(),
+			devId:  oid.NewUUIDv5("devId5").String(),
+			authId: oid.NewUUIDv5("authId5").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId5").String(),
+				DeviceId: oid.NewUUIDv5("devId5").String(),
+				Status:   model.DevStatusAccepted,
+			},
 			submitJob:               true,
 			dbDeleteTokenByDevIdErr: store.ErrTokenNotFound,
 		},
 		{
-			devId:                       oid.NewUUIDv5("devId6").String(),
-			authId:                      oid.NewUUIDv5("authId6").String(),
+			devId:  oid.NewUUIDv5("devId6").String(),
+			authId: oid.NewUUIDv5("authId6").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId6").String(),
+				DeviceId: oid.NewUUIDv5("devId6").String(),
+			},
 			dbDeleteAuthSetForDeviceErr: errors.New("DeleteAuthSetsForDevice Error"),
 			outErr:                      "DeleteAuthSetsForDevice Error",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId8").String(),
-			authId:            oid.NewUUIDv5("authId8").String(),
-			authSet:           &model.AuthSet{Status: model.DevStatusPreauth},
+			devId:  oid.NewUUIDv5("devId8").String(),
+			authId: oid.NewUUIDv5("authId8").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId8").String(),
+				DeviceId: oid.NewUUIDv5("devId8").String(),
+				Status:   model.DevStatusPreauth,
+			},
 			submitJob:         true,
 			dbGetDeviceStatus: "decommissioned",
 			dbDeleteDeviceErr: errors.New("DeleteDevice Error"),
-			outErr:            "DeleteDevice Error",
+			outErr:            "failed to delete preauthorized device: DeleteDevice Error",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId8").String(),
-			authId:            oid.NewUUIDv5("authId8").String(),
-			authSet:           &model.AuthSet{Status: model.DevStatusPreauth},
+			devId:  oid.NewUUIDv5("devId8").String(),
+			authId: oid.NewUUIDv5("authId8").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId8").String(),
+				DeviceId: oid.NewUUIDv5("devId8").String(),
+				Status:   model.DevStatusPreauth,
+			},
 			submitJob:         true,
 			dbGetDeviceStatus: "decommissioned",
 			orchestratorErr:   errors.New("orchestrator error"),
-			outErr:            "update device status job error: orchestrator error",
+			outErr:            "failed to delete preauthorized device: failed to start update device status job: orchestrator error",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId9").String(),
-			authId:            oid.NewUUIDv5("authId9").String(),
+			devId:  oid.NewUUIDv5("devId9").String(),
+			authId: oid.NewUUIDv5("authId9").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId9").String(),
+				DeviceId: oid.NewUUIDv5("devId9").String(),
+				Status:   model.DevStatusPreauth,
+			},
 			submitJob:         true,
+			dbGetDeviceStatus: "decommissioned",
 			dbDeleteDeviceErr: errors.New("DeleteDevice Error"),
+			outErr:            "failed to delete preauthorized device: DeleteDevice Error",
 		},
 		{
-			devId:                oid.NewUUIDv5("devId10").String(),
-			authId:               oid.NewUUIDv5("authId10").String(),
+			devId:  oid.NewUUIDv5("devId10").String(),
+			authId: oid.NewUUIDv5("authId10").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId10").String(),
+				DeviceId: oid.NewUUIDv5("devId10").String(),
+			},
 			dbGetDeviceStatusErr: errors.New("Get Device Status Error"),
 			outErr:               "Cannot determine device status: Get Device Status Error",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId11").String(),
-			authId:            oid.NewUUIDv5("authId11").String(),
+			devId:  oid.NewUUIDv5("devId11").String(),
+			authId: oid.NewUUIDv5("authId11").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId11").String(),
+				DeviceId: oid.NewUUIDv5("devId11").String(),
+				Status:   model.DevStatusPending,
+			},
 			submitJob:         true,
 			dbUpdateDeviceErr: errors.New("Update Device Error"),
 			outErr:            "failed to update device status: Update Device Error",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId12").String(),
-			authId:            oid.NewUUIDv5("authId12").String(),
+			devId:  oid.NewUUIDv5("devId12").String(),
+			authId: oid.NewUUIDv5("authId12").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId12").String(),
+				DeviceId: oid.NewUUIDv5("devId12").String(),
+			},
 			submitJob:         true,
 			dbGetDeviceStatus: "accepted",
 		},
 		{
-			devId:             oid.NewUUIDv5("devId12").String(),
-			authId:            oid.NewUUIDv5("authId12").String(),
+			devId:  oid.NewUUIDv5("devId12").String(),
+			authId: oid.NewUUIDv5("authId12").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId12").String(),
+				DeviceId: oid.NewUUIDv5("devId12").String(),
+			},
 			submitJob:         true,
 			tenant:            "acme",
 			dbGetDeviceStatus: "accepted",
 		},
 		{
-			devId:                oid.NewUUIDv5("devId12").String(),
-			authId:               oid.NewUUIDv5("authId12").String(),
+			devId:  oid.NewUUIDv5("devId12").String(),
+			authId: oid.NewUUIDv5("authId12").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId12").String(),
+				DeviceId: oid.NewUUIDv5("devId12").String(),
+				Status:   model.DevStatusPending,
+			},
 			submitJob:            true,
 			dbGetDeviceStatusErr: store.ErrAuthSetNotFound,
 		},
 		{
-			devId:          oid.NewUUIDv5("devId12").String(),
-			authId:         oid.NewUUIDv5("authId12").String(),
-			authSet:        &model.AuthSet{Status: model.DevStatusAccepted},
+			devId:  oid.NewUUIDv5("devId12").String(),
+			authId: oid.NewUUIDv5("authId12").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId12").String(),
+				DeviceId: oid.NewUUIDv5("devId12").String(),
+				Status:   model.DevStatusAccepted,
+			},
 			withCache:      true,
 			tenant:         "acme",
 			cacheDeleteErr: errors.New("redis error"),
 			outErr:         "failed to delete token for c410d383-c9cd-5c98-9aeb-87166c5920f2 from cache: redis error",
 		},
 		{
-			devId:     oid.NewUUIDv5("devId12").String(),
-			authId:    oid.NewUUIDv5("authId12").String(),
-			authSet:   &model.AuthSet{Status: model.DevStatusAccepted},
+			devId:  oid.NewUUIDv5("devId12").String(),
+			authId: oid.NewUUIDv5("authId12").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId12").String(),
+				DeviceId: oid.NewUUIDv5("devId12").String(),
+				Status:   model.DevStatusAccepted,
+			},
 			withCache: true,
 			outErr:    "failed to delete token for c410d383-c9cd-5c98-9aeb-87166c5920f2 from cache: can't unpack tenant identity data from context",
+		},
+		{
+			devId:  oid.NewUUIDv5("devId16").String(),
+			authId: oid.NewUUIDv5("authId16").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId16").String(),
+				DeviceId: oid.NewUUIDv5("devId16").String(),
+				Status:   model.DevStatusPreauth,
+			},
+			dbGetDeviceStatus:         "decommissioned",
+			dbGetAuthSetsForDeviceErr: errors.New("GetAuthSetsForDevice Error"),
+			outErr:                    "db get auth sets error: GetAuthSetsForDevice Error",
+		},
+		{
+			devId:  oid.NewUUIDv5("devId16").String(),
+			authId: oid.NewUUIDv5("authId16").String(),
+			authSet: &model.AuthSet{
+				Id:       oid.NewUUIDv5("authId16").String(),
+				DeviceId: oid.NewUUIDv5("devId16").String(),
+				Status:   model.DevStatusPreauth,
+			},
+			dbGetDeviceStatus: "pending",
+			dbGetAuthSetsForDevice: []model.AuthSet{
+				{
+					Id: "foo",
+				},
+			},
+			submitJob: true,
 		},
 	}
 
@@ -3047,6 +3138,12 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 				mock.AnythingOfType("model.DeviceUpdate")).Return(tc.dbUpdateDeviceErr)
 			db.On("GetDeviceById", ctx,
 				mock.AnythingOfType("string")).Return(&model.Device{Id: tc.devId}, nil)
+			db.On("GetAuthSetsForDevice",
+				ctx,
+				tc.devId,
+			).Return(
+				tc.dbGetAuthSetsForDevice,
+				tc.dbGetAuthSetsForDeviceErr)
 
 			co := oas_mocks.NewMockWorkflowsOtherAPI(t)
 			status := tc.dbGetDeviceStatus
@@ -3108,7 +3205,7 @@ func TestDevAuthDeleteAuthSet(t *testing.T) {
 				assert.EqualError(t, err, tc.outErr)
 			} else {
 				assert.NoError(t, err)
-				if authSet.Status == model.DevStatusPreauth {
+				if authSet.Status == model.DevStatusPreauth && len(tc.dbGetAuthSetsForDevice) == 0 {
 					db.AssertCalled(t, "DeleteDevice", tc.devId)
 				} else {
 					db.AssertNotCalled(t, "DeleteDevice", tc.devId)


### PR DESCRIPTION
There are few issues in the deviceauth:
- it's possible to accept device without provisioning;
- it's possible to provision same device multiple times;
- when the device has more than one auth set and one of them is a preauth, when removing preauth, we remove the device leaving orphan auth sets behind.
This PR addresses only the last issue.
For the first two issues I'll create separate PR with workaround and I also created bug report, so we'll have opportunity to fix it properly - https://northerntech.atlassian.net/browse/MEN-9993 

I divided fix into smaller commits.
First one moves code responsible for deleting auth sets and removing preauth device into separate methods. First method is also used when verifying token to remove orphan authset.
Second prevents device that has more auth sets than single preauth from being deleted.
Last one adds a bit of cleanup when, during token verification, we see auth set without corresponding device - in this case we remove the auth set.

After spending more time with deviceauth code and tests I also created this one - https://northerntech.atlassian.net/browse/MEN-9997
The fix included in this PR (https://github.com/mendersoftware/mender-server/pull/2088/changes/13f55baf2c2e2ff297dff751fbc9477e3a9dc3bb) is more of a workaround.