### PR TITLE
ci: remove needless resource_groups after moving to k8s

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -546,7 +546,6 @@ test:backend:unit:
   needs:
     - job: build:backend:docker
       artifacts: false
-  resource_group: test_backend_unit
   rules:
     - changes:
         paths: ["backend/**/*.go", "backend/go.mod", ".gitlab-ci.yml"]


### PR DESCRIPTION
The resource_groups makes sense with runners with congestion issues, and the k8s runner should not suffer for.