### PR TITLE
fix(gui): let auditlog filters stay in line even if there's something telling them to stretch vertically

### DIFF
--- a/frontend/src/js/components/auditlogs/AuditLogsFilter.tsx
+++ b/frontend/src/js/components/auditlogs/AuditLogsFilter.tsx
@@ -95,6 +95,7 @@ export const AuditLogsFilter = ({
             title: 'Performed by',
             Component: ControlledSelect,
             componentProps: {
+              classes: { root: 'align-self-start' },
               labelAttribute: 'email',
               options: Object.values(users),
               placeholder: 'Select a user',

--- a/frontend/src/js/components/auditlogs/__snapshots__/Auditlogs.test.tsx.snap
+++ b/frontend/src/js/components/auditlogs/__snapshots__/Auditlogs.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`Auditlogs Component > renders correctly 1`] = `
               Performed by
             </h6>
             <div
-              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiSelect-root css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiSelect-root align-self-start css-sc8y68-MuiInputBase-root-MuiOutlinedInput-root-MuiSelect-root"
               style="width: 240px;"
             >
               <div


### PR DESCRIPTION
to fix:
<img width="960" height="413" alt="Screenshot 2026-07-30 at 16 41 50" src="https://github.com/user-attachments/assets/baf8a367-5ede-45e6-b9a4-50c7585740c7" />
