### PR TITLE
fix(create-artifact-worker): pin single-file-artifact-gen to a release tag

### DIFF
--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -48,6 +48,7 @@ FROM ${REGISTRY}/library/alpine:3.24.1
 ARG TARGETARCH
 ARG TARGETOS
 ARG USER=65534:65534
+ARG MENDER_CLIENT_VERSION=5.1.0
 RUN apk add libc6-compat xz bash
 USER $USER
 
@@ -58,7 +59,7 @@ COPY --from=builder --chown=$USER \
   /var/cache/create-artifact-worker
 
 # Install mender-artifact
-ADD --chmod=0755 https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/single-file-artifact-gen \
+ADD --chmod=0755 https://raw.githubusercontent.com/mendersoftware/mender/${MENDER_CLIENT_VERSION}/support/modules-artifact-gen/single-file-artifact-gen \
   /usr/bin/single-file-artifact-gen
 COPY --from=builder --chown=$USER \
   /build/mender-artifact \

--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,20 @@
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
     },
+    // MENDER_CLIENT_VERSION as a Dockerfile ARG (create-artifact-worker). Pins the
+    // single-file-artifact-gen script fetched from the mender client repo, which used
+    // to float on master. semver skips non-semver tags like qnx-preview-v1.
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/Dockerfile/"],
+      "matchStrings": [
+        "ARG MENDER_CLIENT_VERSION=\\s*[\"']?(?<currentValue>[\\d\\.]+)[\"']?"
+      ],
+      "depNameTemplate": "mendersoftware/mender",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
+    },
     // DOCKER_VERSION as a .gitlab-ci.yml variable (currently tracked by nothing).
     {
       "customType": "regex",


### PR DESCRIPTION
Closes [QA-345](https://northerntech.atlassian.net/browse/QA-345).

`create-artifact-worker` fetched `single-file-artifact-gen` from the mender client repo at `master`, so any image rebuild silently picked up whatever was on the branch head. This is the last piece of QA-345 in this repo: the original `FROM mendersoftware/workflows:master` base image is already gone, and `MENDER_ARTIFACT_VERSION` is already tracked.

## Change

- `ARG MENDER_CLIENT_VERSION=5.1.0`, with the URL using `${MENDER_CLIENT_VERSION}` instead of `master`.
- A renovate customManager for that ARG (`github-releases` on `mendersoftware/mender`, `semver`), reusing the existing `MENDER_ARTIFACT_VERSION` pattern.

The ARG is declared in the **final** stage — a builder-stage ARG is not visible to `ADD`. `semver` versioning also skips the non-semver `qnx-preview-v1` pre-release tag.

`backend/services/Makefile.common` passes only `BUILDFLAGS`, `LDFLAGS` and `REGISTRY` as build args, so nothing overrides this ARG and the Dockerfile default is authoritative.

## Verification

- `renovate-config-validator` passes (renovate 44.11.1).
- Image builds (exit 0).
- The fetched script in the built image is byte-identical to git tag 5.1.0 (sha256 `d7d948d9…4fbdb`).
- End-to-end: `single-file-artifact-gen -n … -t … -o out.mender` inside the built image exits 0 and produces a valid artifact.

## Reviewer note: this gives up three master-only script changes

`single-file-artifact-gen` at 5.1.0 differs from `master` by 8 insertions / 5 deletions:

1. `device_types+=("$1" "$2")` becomes `device_types+=("--compatible-types" "$2")`
2. A `trap ... EXIT` handler that cleans up the temporary directory
3. An explicit error when `mender-artifact` writes no output

Item 1 matters most. The 5.1.0 script forwards `-t`/`--device-type` through, and mender-artifact 4.4.1 reports that flag as `DEPRECATED. Use --compatible-types instead.` It works today (verified end-to-end above), but this pin means we break when mender-artifact drops the deprecated flag, where floating on `master` would have absorbed the fix silently.

If you want those changes now, bump `MENDER_CLIENT_VERSION` to a release containing them rather than reverting to `master`. Otherwise the next renovate bump picks them up.


[QA-345]: https://northerntech.atlassian.net/browse/QA-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ