### PR TITLE
fix(create-artifact-worker): pin single-file-artifact-gen to a release tag

### DIFF
--- a/backend/services/create-artifact-worker/Dockerfile
+++ b/backend/services/create-artifact-worker/Dockerfile
@@ -48,6 +48,7 @@ FROM ${REGISTRY}/library/alpine:3.24.1
 ARG TARGETARCH
 ARG TARGETOS
 ARG USER=65534:65534
+ARG MENDER_CLIENT_VERSION=5.1.0
 RUN apk add libc6-compat xz bash
 USER $USER
 
@@ -58,7 +59,7 @@ COPY --from=builder --chown=$USER \
   /var/cache/create-artifact-worker
 
 # Install mender-artifact
-ADD --chmod=0755 https://raw.githubusercontent.com/mendersoftware/mender/master/support/modules-artifact-gen/single-file-artifact-gen \
+ADD --chmod=0755 https://raw.githubusercontent.com/mendersoftware/mender/${MENDER_CLIENT_VERSION}/support/modules-artifact-gen/single-file-artifact-gen \
   /usr/bin/single-file-artifact-gen
 COPY --from=builder --chown=$USER \
   /build/mender-artifact \

--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,20 @@
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
     },
+    // MENDER_CLIENT_VERSION as a Dockerfile ARG (create-artifact-worker). Pins the
+    // single-file-artifact-gen script fetched from the mender client repo, which used
+    // to float on master. semver skips non-semver tags like qnx-preview-v1.
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/Dockerfile/"],
+      "matchStrings": [
+        "ARG MENDER_CLIENT_VERSION=\\s*[\"']?(?<currentValue>[\\d\\.]+)[\"']?"
+      ],
+      "depNameTemplate": "mendersoftware/mender",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
+    },
     // DOCKER_VERSION as a .gitlab-ci.yml variable (currently tracked by nothing).
     {
       "customType": "regex",


### PR DESCRIPTION
Closes QA-345

single-file-artifact-gen was fetched from the mender client repo at master so any rebuild picked up whatever was on the branch head

Now it is pinned to MENDER_CLIENT_VERSION=5.1.0 and renovate tracks that ARG

I checked that the renovate config validates the image builds and artifact generation works inside it

One thing for the reviewer - 5.1.0 does not have master's change from -t to --compatible-types and mender-artifact 4.4.1 already marks --device-type as deprecated so this will need a version bump before that flag goes away
