### PR TITLE
Allow gui os from mender server with ent jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -317,6 +317,16 @@ review:deploy:
     - echo "Setting up namespace ${NAMESPACE}..."
     - ./compose/k8s/setup-review-namespace.sh
 
+    - |
+      if [ "${REVIEW_APPS_ENT_ON_OS}" == "true" ]; then
+        echo "Creating mender-enterprise-registry pull secret..."
+        kubectl create secret docker-registry mender-enterprise-registry \
+          --docker-server="registry.mender.io" \
+          --docker-username="${REGISTRY_MENDER_IO_USERNAME}" \
+          --docker-password="${REGISTRY_MENDER_IO_PASSWORD}" \
+          -n "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+      fi
+
     - echo "Adding Mender Helm repository..."
     - helm repo add mender https://charts.mender.io
     - helm repo update
@@ -324,7 +334,10 @@ review:deploy:
     - echo "Generating Helm values file..."
     - apt-get update && apt-get install -y gettext-base
     - |
-      if [ "${REVIEW_APPS_ENTERPRISE}" == "true" ]; then
+      if [ "${REVIEW_APPS_ENT_ON_OS}" == "true" ]; then
+        echo "Configuring enterprise-backend-from-OS-gui setup"
+        envsubst < compose/k8s/review-values.ent-on-os.yaml.tpl > /tmp/review-values.yaml
+      elif [ "${REVIEW_APPS_ENTERPRISE}" == "true" ]; then
         echo "Configuring enterprise setup"
         envsubst < compose/k8s/review-values.enterprise.yaml.tpl > /tmp/review-values.yaml
       else
@@ -346,7 +359,7 @@ review:deploy:
     - echo "Creating initial tenant and user..."
     - chmod +x ./compose/k8s/create-initial-user.sh
     - |
-      if [ "${REVIEW_APPS_ENTERPRISE}" == "true" ]; then
+      if [ "${REVIEW_APPS_ENT_ON_OS}" == "true" ] || [ "${REVIEW_APPS_ENTERPRISE}" == "true" ]; then
         ./compose/k8s/create-initial-user.sh --enterprise
       else
         ./compose/k8s/create-initial-user.sh

--- a/compose/k8s/review-values.ent-on-os.yaml.tpl
+++ b/compose/k8s/review-values.ent-on-os.yaml.tpl
@@ -1,0 +1,162 @@
+global:
+  url: "https://${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+
+  enterprise: true
+
+  storage: "aws"
+  s3:
+    existingSecret: "mender-s3-artifacts"
+
+  # Every backend service except gui comes from mender-server-enterprise's own
+  # published image (already published to registry.mender.io on every green
+  # main merge by that repo's own pipeline), not this pipeline's own build.
+  # Only gui below overrides this with its own image.
+  image:
+    registry: "registry.mender.io"
+    repository: "mender-server-enterprise"
+    tag: "main"
+
+# image: intentionally not set here - every backend service falls through to
+# global.image above. imagePullSecrets covers both registries in use: this
+# pipeline's own (gitlab-registry, for gui) and mender-server-enterprise's
+# (mender-enterprise-registry, manually created by review:deploy).
+default:
+  imagePullSecrets:
+    - name: gitlab-registry
+    - name: mender-enterprise-registry
+
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - preference:
+            matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+          weight: 90
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node.kubernetes.io/nodegroup
+                operator: In
+                values:
+                  - review
+  tolerations:
+    - effect: NoSchedule
+      key: review
+      operator: Equal
+      value: "true"
+
+# Use Helm chart included services (not recommended for production, fine for review apps)
+mongodb:
+  enabled: true
+
+nats:
+  enabled: true
+
+redis:
+  enabled: true
+
+# Enterprise-only services
+generate_delta_worker:
+  enabled: true
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+auditlogs:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+tenantadm:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+devicemonitor:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+# Backend services (open source + enterprise)
+deployments:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+device_auth:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+deviceconfig:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+deviceconnect:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+inventory:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+iot_manager:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+useradm:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+workflows:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+workflows_worker:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+create_artifact_worker:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+# gui is the one exception - this pipeline's own build, not mender-server-enterprise's
+gui:
+  image:
+    registry: "${CI_REGISTRY}"
+    repository: "northern.tech/mender/${CI_PROJECT_NAME}"
+    tag: "build-${CI_COMMIT_SHA}"
+  imagePullSecrets:
+    - name: gitlab-registry
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+api_gateway:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+device_gateway:
+  nodeSelector:
+    kubernetes.io/arch: amd64
+
+ingress:
+  enabled: true
+  ingressClassName: alb
+  path: /
+  annotations:
+    alb.ingress.kubernetes.io/actions.ssl-redirect:
+      '{"Type": "redirect", "RedirectConfig":
+      { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: "${REVIEW_APPS_ACM_CERTIFICATE_ARN}"
+    alb.ingress.kubernetes.io/group.name: mender
+    alb.ingress.kubernetes.io/healthcheck-path: /ui/
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http2.enabled=true,idle_timeout.timeout_seconds=600
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-2021-06
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/ip-address-type: dualstack
+  hosts:
+    - "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"
+  tls:
+    - secretName: mender-review-ingress-tls
+      hosts:
+        - "${REVIEW_APPS_PROJECT_PREFIX}-${CI_COMMIT_REF_SLUG}.${REVIEW_APPS_DOMAIN}"


### PR DESCRIPTION
Co-authored-with: Claude

Adds the ability to run Mender Server enterprise prevew apps installation from mender-server repo with gui from mender-server repo itself.

Requires:
* [x] https://github.com/mendersoftware/integration-test-runner/pull/477
* [x] https://github.com/mendersoftware/sre-tools/pull/478
* [x] https://github.com/NorthernTechHQ/mystiko/pull/570
