### PR TITLE
feat(deviceconnect): add thundering herd rate limit to ws APIs

### DIFF
--- a/backend/services/deviceconnect/api/http/rate_test.go
+++ b/backend/services/deviceconnect/api/http/rate_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestWebsocketRatelimitMiddleware(t *testing.T) {
+	router := gin.New()
+	router.Use(websocketRatelimitMiddleware(rate.NewLimiter(rate.Every(rate.InfDuration), 1))).
+		Any("/", func(*gin.Context) {})
+
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	t.Run("stop requests exceeding burst", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusTooManyRequests, w.Result().StatusCode)
+	})
+
+}

--- a/backend/services/deviceconnect/api/http/router.go
+++ b/backend/services/deviceconnect/api/http/router.go
@@ -15,12 +15,16 @@
 package http
 
 import (
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/requestsize"
+	"github.com/mendersoftware/mender-server/pkg/rest.utils"
 	"github.com/mendersoftware/mender-server/pkg/routing"
 
 	"github.com/mendersoftware/mender-server/services/deviceconnect/app"
@@ -62,6 +66,18 @@ type RouterConfig struct {
 	GracefulShutdownTimeout time.Duration
 	MaxRequestSize          int64
 	MaxFileSize             int64
+
+	WebsocketBurstLimit int
+}
+
+func websocketRatelimitMiddleware(rl *rate.Limiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !rl.Allow() {
+			rest.RenderError(c, http.StatusTooManyRequests, fmt.Errorf("too many requests"))
+			c.Abort()
+			return
+		}
+	}
 }
 
 // NewRouter returns the gin router
@@ -79,9 +95,17 @@ func NewRouter(
 
 	publicAPI := router.Group(".")
 	fileLimit := publicAPI.Group(".")
+	wsAPIs := publicAPI.Group(".")
 	if config != nil {
 		publicAPI.Use(requestsize.Middleware(config.MaxRequestSize))
+		wsAPIs.Use(requestsize.Middleware(config.MaxRequestSize))
 		fileLimit.Use(requestsize.Middleware(config.MaxFileSize))
+		if config.WebsocketBurstLimit > 0 {
+			wsAPIs.Use(websocketRatelimitMiddleware(
+				rate.NewLimiter(rate.Limit(config.WebsocketBurstLimit),
+					config.WebsocketBurstLimit),
+			))
+		}
 	}
 
 	gracefulShutdownTimeout := time.Duration(0)
@@ -99,13 +123,13 @@ func NewRouter(
 	router.POST(APIURLInternalDevicesIDSendInventory, internal.SendInventory)
 
 	device := NewDeviceController(app, natsClient)
-	publicAPI.GET(APIURLDevicesConnect, device.Connect)
+	wsAPIs.GET(APIURLDevicesConnect, device.Connect)
 	publicAPI.POST(APIURLInternalDevices, device.Provision)
 	publicAPI.DELETE(APIURLInternalDevicesID, device.Delete)
 
 	management := NewManagementController(app, natsClient)
 	publicAPI.GET(APIURLManagementDevice, management.GetDevice)
-	publicAPI.GET(APIURLManagementDeviceConnect, management.Connect)
+	wsAPIs.GET(APIURLManagementDeviceConnect, management.Connect)
 	publicAPI.GET(APIURLManagementDeviceDownload, management.DownloadFile)
 	publicAPI.HEAD(APIURLManagementDeviceDownload, management.DownloadFile)
 	publicAPI.POST(APIURLManagementDeviceCheckUpdate, management.CheckUpdate)

--- a/backend/services/deviceconnect/config.yaml
+++ b/backend/services/deviceconnect/config.yaml
@@ -77,3 +77,8 @@
 # Overwrite with environment variable: DEVICECONNECT_REQUEST_SIZE_LIMIT
 
 # request_size_limit: 1048576
+
+# Number of websocket that can be accepted per second for "thundering herd" protection.
+# A value <= 0 means no limit (default).
+# Overwrite with environment variable: DEVICECONNECT_WEBSOCKET_BURST_LIMIT
+# websocket_burst_limit: 0

--- a/backend/services/deviceconnect/config/config.go
+++ b/backend/services/deviceconnect/config/config.go
@@ -82,6 +82,8 @@ const (
 	// Max Upload size
 	SettingMaxFileUploadSize        = "file_upload_limit"
 	SettingMaxFileUploadSizeDefault = 1024 * 1024 * 1024 // 1 GiB
+
+	SettingWebsocketBurstLimit = "websocket_burst_limit" // Defaults to unlimited
 )
 
 var (


### PR DESCRIPTION
A new configuration `websocket_burst_limit` sets the number of burst requests to accept per second to prevent trembling herd resource exhaustion.

Ticket: MEN-10052