### PR TITLE
Fix websocket accesslogs

### DIFF
--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -70,10 +70,6 @@ func (a AccessLogger) LogFunc(
 	if a.ClientIPHook != nil {
 		logCtx["clientip"] = a.ClientIPHook(c.Request)
 	}
-	lc := fromContext(ctx)
-	if lc != nil {
-		lc.addFields(logCtx)
-	}
 	if r := recover(); r != nil {
 		// Skip 4
 		// = accesslog.LogFunc
@@ -135,6 +131,10 @@ func (a AccessLogger) LogFunc(
 			}
 		}
 		logCtx["error"] = errMsg
+	}
+	lc := fromContext(ctx)
+	if lc != nil {
+		lc.addFields(logCtx)
 	}
 	log.FromContext(c.Request.Context()).
 		WithFields(logCtx).

--- a/backend/services/deviceconnect/api/http/device.go
+++ b/backend/services/deviceconnect/api/http/device.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack/v5"
 
+	"github.com/mendersoftware/mender-server/pkg/accesslog"
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
 	"github.com/mendersoftware/mender-server/pkg/rest.utils"
@@ -171,6 +172,8 @@ func (h DeviceController) Connect(c *gin.Context) {
 		l.Error(err)
 		return
 	}
+	logCtx := accesslog.GetContext(ctx)
+	logCtx.SetField("status", 101)
 	conn.SetReadLimit(int64(app.MessageSizeLimit))
 
 	// register the websocket for graceful shutdown
@@ -199,7 +202,13 @@ func (h DeviceController) Connect(c *gin.Context) {
 	// websocketWriter is responsible for closing the websocket
 	//nolint:errcheck
 	err = h.connectWSWriter(ctxWithCancel, conn, listener)
-	if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+	var wsErr *websocket.CloseError
+	if errors.As(err, &wsErr) {
+		logCtx.SetField("wsstatus", wsErr.Code)
+	}
+	if err != nil && !websocket.IsCloseError(
+		err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
+	) {
 		_ = c.Error(err)
 	}
 }

--- a/backend/services/deviceconnect/api/http/management.go
+++ b/backend/services/deviceconnect/api/http/management.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack/v5"
 
+	"github.com/mendersoftware/mender-server/pkg/accesslog"
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
 	"github.com/mendersoftware/mender-server/pkg/requestid"
@@ -213,6 +214,9 @@ func (h ManagementController) Connect(c *gin.Context) {
 		// upgrader.Upgrade has already responded
 		return
 	}
+	logCtx := accesslog.GetContext(ctx)
+	logCtx.SetField("status", http.StatusSwitchingProtocols)
+
 	conn.SetReadLimit(int64(app.MessageSizeLimit))
 	defer conn.Close()
 
@@ -228,8 +232,16 @@ func (h ManagementController) Connect(c *gin.Context) {
 		)
 	})
 
-	//nolint:errcheck
-	h.ConnectServeWS(c, ctx, conn, session, s)
+	err = h.ConnectServeWS(c, ctx, conn, session, s)
+	var wsErr *websocket.CloseError
+	if errors.As(err, &wsErr) {
+		logCtx.SetField("wsstatus", wsErr.Code)
+	}
+	if err != nil && !websocket.IsCloseError(
+		err, websocket.CloseNormalClosure, websocket.CloseGoingAway,
+	) {
+		_ = c.Error(err)
+	}
 }
 
 func (h ManagementController) Playback(c *gin.Context) {
@@ -349,7 +361,9 @@ func writerFinalizer(conn WSConn, e *error, l *log.Logger) {
 				)
 			}
 		}
-		l.Errorf("websocket closed with error: %s", err.Error())
+		if closeErr == nil {
+			l.Errorf("websocket closed with error: %s", err.Error())
+		}
 	} else {
 		err = conn.WriteControl(websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
@@ -656,9 +670,6 @@ func (h ManagementController) ConnectServeWS(
 	case err = <-errWrite:
 	case <-ctx.Done():
 		err = ctx.Err()
-	}
-	if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-		_ = c.Error(err)
 	}
 	return err
 }


### PR DESCRIPTION
Puts correct `status` and adds `wsstatus` to reflect the status sent or received from the websocket peer.