### PR TITLE
MEN-10073 - fix(gui): ensured data w/ multiple attribute values gets shown in a readable manner

### DIFF
--- a/frontend/src/js/common-ui/TwoColumnData.test.tsx
+++ b/frontend/src/js/common-ui/TwoColumnData.test.tsx
@@ -21,10 +21,11 @@ import { ColumnWidthProvider, SynchronizedTwoColumnData, TwoColumnData } from '.
 
 describe('TwoColumnData Component', () => {
   it('renders correctly', async () => {
-    const { baseElement } = render(<TwoColumnData data={{ uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2' }} />);
+    const { baseElement } = render(<TwoColumnData data={{ uiPasswordRequired: true, foo: 'bar', timezone: 'GMT+2', multi: ['something', 'else'] }} />);
     const view = baseElement.firstChild.firstChild;
     expect(view).toMatchSnapshot();
     expect(view).toEqual(expect.not.stringMatching(undefineds));
+    expect(screen.getByText('something, else')).toBeInTheDocument();
   });
   it('renders with chipLikeKey prop', async () => {
     const { baseElement } = render(<TwoColumnData chipLikeKey data={{ attribute: 'value', another: 'item' }} />);

--- a/frontend/src/js/common-ui/TwoColumnData.tsx
+++ b/frontend/src/js/common-ui/TwoColumnData.tsx
@@ -40,9 +40,10 @@ const useStyles = makeStyles()(theme => ({
 
 const ValueColumn = ({ setSnackbar, value = '' }: { setSnackbar?: (message: string) => void; value?: DataValue }) => {
   const copyableValue = React.isValidElement(value) ? value.props.value : value;
+  const renderedValue = React.isValidElement(value) ? value : Array.isArray(value) ? value.join(', ') : value;
 
   if (!setSnackbar) {
-    return <CopyableText title={copyableValue}>{value}</CopyableText>;
+    return <CopyableText title={copyableValue}>{renderedValue}</CopyableText>;
   }
 
   const onCopy = () => {
@@ -52,7 +53,7 @@ const ValueColumn = ({ setSnackbar, value = '' }: { setSnackbar?: (message: stri
 
   return (
     <CopyableText onCopy={onCopy} textClasses="clickable" title={copyableValue}>
-      {value}
+      {renderedValue}
     </CopyableText>
   );
 };

--- a/frontend/src/js/common-ui/__snapshots__/TwoColumnData.test.tsx.snap
+++ b/frontend/src/js/common-ui/__snapshots__/TwoColumnData.test.tsx.snap
@@ -76,6 +76,23 @@ exports[`TwoColumnData Component > renders correctly 1`] = `
       GMT+2
     </p>
   </div>
+  <h6
+    class="MuiTypography-root MuiTypography-subtitle2 key emotion-1"
+    style="white-space: nowrap;"
+  >
+    multi
+  </h6>
+  <div
+    class="flexbox align-items-center "
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body2 emotion-2"
+      style="display: -webkit-box; -webkit-line-clamp: 5; -webkit-box-orient: vertical; overflow: hidden; word-break: break-word; text-overflow: ellipsis;"
+      title="something,else"
+    >
+      something, else
+    </p>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
### this:

<img width="653" height="177" alt="Screenshot 2026-08-24 at 10 39 21" src="https://github.com/user-attachments/assets/14a39803-ff85-4cbc-a62a-2a4f081e64ba" />

### before:

<img width="655" height="173" alt="Screenshot 2026-08-24 at 10 39 49" src="https://github.com/user-attachments/assets/d652f81f-a853-4223-8361-388e6f94a209" />