### PR TITLE
ci: fix nats images in ent-on-os review app values

### DIFF
--- a/compose/k8s/review-values.ent-on-os.yaml.tpl
+++ b/compose/k8s/review-values.ent-on-os.yaml.tpl
@@ -7,20 +7,15 @@ global:
   s3:
     existingSecret: "mender-s3-artifacts"
 
-  # Every backend service except gui comes from mender-server-enterprise's own
-  # published image (already published to registry.mender.io on every green
-  # main merge by that repo's own pipeline), not this pipeline's own build.
-  # Only gui below overrides this with its own image.
+# Every backend service except gui comes from mender-server-enterprise's own
+# published image. Must be default.image, not global.image: global propagates
+# to the nats subchart, which reads global.image.registry for its own images.
+default:
   image:
     registry: "registry.mender.io"
     repository: "mender-server-enterprise"
     tag: "main"
 
-# image: intentionally not set here - every backend service falls through to
-# global.image above. imagePullSecrets covers both registries in use: this
-# pipeline's own (gitlab-registry, for gui) and mender-server-enterprise's
-# (mender-enterprise-registry, manually created by review:deploy).
-default:
   imagePullSecrets:
     - name: gitlab-registry
     - name: mender-enterprise-registry


### PR DESCRIPTION
global.image is propagated to subcharts, and the nats subchart reads global.image.registry for its own images, rewriting nats:2.14.0-alpine and natsio/nats-server-config-reloader to registry.mender.io/* and leaving nats-0..2 and nats-box in ImagePullBackOff.

Move the mender-server-enterprise image override to default.image, which is mender-chart-only. The chart's mender.image.* helpers already fall through to it for every service, so backend images are unchanged and the per-service gui override still wins.

Ticket: QA-1525