### PR TITLE
feat(deployments): add request timeout middleware to devices APIs

### DIFF
--- a/backend/pkg/middlewares/error_response.go
+++ b/backend/pkg/middlewares/error_response.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/mendersoftware/mender-server/pkg/requestid"
+	"github.com/mendersoftware/mender-server/pkg/rest.utils"
+)
+
+func renderErrorWithMessage(c *gin.Context, code int, err error, apiMessage string) {
+	ctx := c.Request.Context()
+	c.JSON(code, &rest.Error{
+		Err:       apiMessage,
+		RequestID: requestid.FromContext(ctx),
+	})
+}
+
+func renderError(c *gin.Context, code int, err error) {
+	renderErrorWithMessage(c, code, err, err.Error())
+}
+
+// ErrorHandler handles common errors if not already handled by the API handler.
+func ErrorHandler() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		ctx.Next()
+		if ctx.Writer.Written() {
+			return
+		}
+		err := ctx.Errors.Last()
+		if err == nil {
+			return // Fallback to default (200 OK)
+		}
+		var (
+			netErr        net.Error
+			validationErr validation.Errors
+			maxBytesErr   *http.MaxBytesError
+		)
+		switch {
+		case errors.As(err, &netErr) && netErr.Timeout():
+			// NOTE: context.DeadlineExceeded is also caught here
+			renderErrorWithMessage(ctx, http.StatusGatewayTimeout, err, "gateway timeout")
+		case errors.As(err, &maxBytesErr):
+			renderError(ctx, http.StatusRequestEntityTooLarge, err)
+		case err.IsType(gin.ErrorTypeBind), errors.As(err, &validationErr):
+			renderError(ctx, http.StatusBadRequest, err)
+		case errors.Is(err, context.Canceled):
+			ctx.Writer.WriteHeader(499)
+		default:
+			ctx.JSON(http.StatusInternalServerError, rest.Error{
+				Err:       "internal error",
+				RequestID: requestid.FromContext(ctx.Request.Context()),
+			})
+		}
+	}
+}

--- a/backend/pkg/middlewares/error_response_test.go
+++ b/backend/pkg/middlewares/error_response_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// netError is a minimal net.Error implementation for exercising the
+// timeout branch of ErrorHandler.
+type netError struct {
+	msg     string
+	timeout bool
+}
+
+func (e *netError) Error() string   { return e.msg }
+func (e *netError) Timeout() bool   { return e.timeout }
+func (e *netError) Temporary() bool { return false }
+
+func TestErrorHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	testCases := []struct {
+		name         string
+		handler      gin.HandlerFunc
+		expectedCode int
+		expectedBody string
+		checkBody    bool
+		rawBody      bool
+	}{
+		{
+			name:         "no error",
+			handler:      func(c *gin.Context) {},
+			expectedCode: http.StatusOK,
+			expectedBody: "",
+			checkBody:    true,
+		},
+		{
+			name: "response already written is left untouched",
+			handler: func(c *gin.Context) {
+				c.String(http.StatusTeapot, "already written")
+				_ = c.Error(errors.New("this error must be ignored"))
+			},
+			expectedCode: http.StatusTeapot,
+			expectedBody: "already written",
+			checkBody:    true,
+			rawBody:      true,
+		},
+		{
+			name: "net.Error timeout maps to gateway timeout",
+			handler: func(c *gin.Context) {
+				_ = c.Error(&netError{msg: "i/o timeout", timeout: true})
+			},
+			expectedCode: http.StatusGatewayTimeout,
+			expectedBody: `{"error":"gateway timeout"}`,
+			checkBody:    true,
+		},
+		{
+			name: "context.DeadlineExceeded maps to gateway timeout",
+			handler: func(c *gin.Context) {
+				_ = c.Error(context.DeadlineExceeded)
+			},
+			expectedCode: http.StatusGatewayTimeout,
+			expectedBody: `{"error":"gateway timeout"}`,
+			checkBody:    true,
+		},
+		{
+			name: "non-timeout net.Error falls through to internal error",
+			handler: func(c *gin.Context) {
+				_ = c.Error(&netError{msg: "connection reset", timeout: false})
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: `{"error":"internal error"}`,
+			checkBody:    true,
+		},
+		{
+			name: "max bytes error maps to request entity too large",
+			handler: func(c *gin.Context) {
+				_ = c.Error(&http.MaxBytesError{Limit: 1024})
+			},
+			expectedCode: http.StatusRequestEntityTooLarge,
+			checkBody:    false,
+		},
+		{
+			name: "gin bind error maps to bad request",
+			handler: func(c *gin.Context) {
+				_ = c.Error(errors.New("invalid request body")).SetType(gin.ErrorTypeBind)
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: `{"error":"invalid request body"}`,
+			checkBody:    true,
+		},
+		{
+			name: "validation error maps to bad request",
+			handler: func(c *gin.Context) {
+				_ = c.Error(validation.Errors{
+					"name": errors.New("cannot be blank"),
+				})
+			},
+			expectedCode: http.StatusBadRequest,
+			checkBody:    false,
+		},
+		{
+			name: "context canceled maps to 499",
+			handler: func(c *gin.Context) {
+				_ = c.Error(context.Canceled)
+			},
+			expectedCode: 499,
+			expectedBody: "",
+			checkBody:    true,
+		},
+		{
+			name: "unhandled error maps to internal error",
+			handler: func(c *gin.Context) {
+				_ = c.Error(errors.New("boom"))
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: `{"error":"internal error"}`,
+			checkBody:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := gin.New()
+			engine.Use(ErrorHandler())
+			engine.GET("/test", tc.handler)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+			engine.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.expectedCode, w.Code)
+			if tc.checkBody {
+				switch {
+				case tc.expectedBody == "":
+					assert.Empty(t, w.Body.String())
+				case tc.rawBody:
+					assert.Equal(t, tc.expectedBody, w.Body.String())
+				default:
+					assert.JSONEq(t, tc.expectedBody, w.Body.String())
+				}
+			}
+		})
+	}
+}

--- a/backend/pkg/middlewares/timeout.go
+++ b/backend/pkg/middlewares/timeout.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/mendersoftware/mender-server/pkg/rest.utils"
+)
+
+// Timeout wraps the http.Request.Context with a fixed timeout.
+func Timeout(duration time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), duration)
+		defer cancel()
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) &&
+			!c.Writer.Written() {
+			rest.RenderError(c,
+				http.StatusGatewayTimeout,
+				errors.New("request deadline exceeded"),
+			)
+			return
+		}
+	}
+}

--- a/backend/pkg/middlewares/timeout_test.go
+++ b/backend/pkg/middlewares/timeout_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package middlewares
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("handler completes and writes a response", func(t *testing.T) {
+		engine := gin.New()
+		engine.Use(Timeout(time.Second))
+		engine.GET("/test", func(c *gin.Context) {
+			c.String(http.StatusOK, "ok")
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+		engine.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "ok", w.Body.String())
+	})
+
+	t.Run("handler exceeds the deadline and observes context cancellation", func(t *testing.T) {
+		engine := gin.New()
+		engine.Use(Timeout(10 * time.Millisecond))
+		handlerReturned := make(chan struct{})
+		engine.GET("/test", func(c *gin.Context) {
+			defer close(handlerReturned)
+			select {
+			case <-c.Request.Context().Done():
+				return
+			case <-time.After(time.Second):
+				c.String(http.StatusOK, "too slow")
+			}
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+		engine.ServeHTTP(w, req)
+
+		select {
+		case <-handlerReturned:
+		case <-time.After(time.Second):
+			t.Fatal("handler did not observe context cancellation in time")
+		}
+
+		assert.Equal(t, http.StatusGatewayTimeout, w.Code)
+		var body map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, "request deadline exceeded", body["error"])
+	})
+
+	t.Run("request context is given a deadline", func(t *testing.T) {
+		const duration = 50 * time.Millisecond
+		engine := gin.New()
+		engine.Use(Timeout(duration))
+
+		var (
+			deadline time.Time
+			ok       bool
+		)
+		start := time.Now()
+		engine.GET("/test", func(c *gin.Context) {
+			deadline, ok = c.Request.Context().Deadline()
+			c.Status(http.StatusOK)
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+		engine.ServeHTTP(w, req)
+
+		require.True(t, ok, "expected request context to carry a deadline")
+		assert.WithinDuration(t, start.Add(duration), deadline, 20*time.Millisecond)
+	})
+}

--- a/backend/services/deployments/api/http/api_deployments.go
+++ b/backend/services/deployments/api/http/api_deployments.go
@@ -150,6 +150,8 @@ type Config struct {
 	// related to releases; helpful in performing long-running maintenance and data
 	// migrations on the artifacts and releases collections.
 	DisableNewReleasesFeature bool
+
+	RequestTimeoutDevicesAPI time.Duration
 }
 
 func NewConfig() *Config {
@@ -209,6 +211,11 @@ func (conf *Config) SetDisableNewReleasesFeature(disable bool) *Config {
 
 func (conf *Config) SetMaxRequestSize(size int64) *Config {
 	conf.MaxRequestSize = size
+	return conf
+}
+
+func (conf *Config) SetRequestTimeoutDevicesAPI(timeout time.Duration) *Config {
+	conf.RequestTimeoutDevicesAPI = timeout
 	return conf
 }
 
@@ -1455,7 +1462,8 @@ func (d *DeploymentsApiHandlers) getDeploymentForDevice(
 		if err == app.ErrConflictingRequestData {
 			d.view.RenderError(c, err, http.StatusConflict)
 		} else {
-			d.view.RenderInternalError(c, err)
+			// fallback on middlewares.ErrorHandler
+			_ = c.Error(err)
 		}
 		return
 	}
@@ -1522,20 +1530,18 @@ func (d *DeploymentsApiHandlers) PutDeploymentStatusForDevice(
 		d.view.RenderError(c, err, http.StatusBadRequest)
 		return
 	}
-	l := log.FromContext(ctx)
-	l.Infof("status: %+v", report)
 	if err := d.app.UpdateDeviceDeploymentStatus(ctx, did,
 		idata.Subject, model.DeviceDeploymentState{
 			Status:   report.Status,
 			SubState: report.SubState,
 		}); err != nil {
-
 		if err == app.ErrDeploymentAborted || err == app.ErrDeviceDecommissioned {
 			d.view.RenderError(c, err, http.StatusConflict)
 		} else if err == app.ErrStorageNotFound {
 			d.view.RenderErrorNotFound(c)
 		} else {
-			d.view.RenderInternalError(c, err)
+			// fallback on middlewares.ErrorHandler
+			_ = c.Error(err)
 		}
 		return
 	}
@@ -1899,7 +1905,7 @@ func (d *DeploymentsApiHandlers) PutDeploymentLogForDevice(c *gin.Context) {
 		if err == app.ErrModelDeploymentNotFound {
 			d.view.RenderError(c, err, http.StatusNotFound)
 		} else {
-			d.view.RenderInternalError(c, err)
+			_ = c.Error(err)
 		}
 		return
 	}

--- a/backend/services/deployments/api/http/api_deployments_test.go
+++ b/backend/services/deployments/api/http/api_deployments_test.go
@@ -1150,7 +1150,7 @@ func TestDownloadConfiguration(t *testing.T) {
 			reqClone := tc.Request.Clone(context.Background())
 			handlers := NewDeploymentsApiHandlers(nil, &view.RESTView{}, tc.App, tc.Config)
 			router := setUpTestRouter()
-			NewDeploymentsResourceRoutes(router.Group("."), handlers)
+			NewDeploymentsResourceRoutes(router.Group("."), handlers, NewConfig())
 
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, tc.Request)

--- a/backend/services/deployments/api/http/common_test.go
+++ b/backend/services/deployments/api/http/common_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mendersoftware/mender-server/pkg/accesslog"
 	"github.com/mendersoftware/mender-server/pkg/config"
+	"github.com/mendersoftware/mender-server/pkg/middlewares"
 	"github.com/mendersoftware/mender-server/pkg/requestid"
 
 	dconfig "github.com/mendersoftware/mender-server/services/deployments/config"
@@ -28,6 +29,7 @@ func setUpTestRouter() *gin.Engine {
 	router := gin.New()
 	router.Use(accesslog.Middleware())
 	router.Use(requestid.Middleware())
+	router.Use(middlewares.ErrorHandler())
 
 	return router
 }

--- a/backend/services/deployments/api/http/routing.go
+++ b/backend/services/deployments/api/http/routing.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mendersoftware/mender-server/pkg/contenttype"
 	"github.com/mendersoftware/mender-server/pkg/identity"
 	"github.com/mendersoftware/mender-server/pkg/log"
+	"github.com/mendersoftware/mender-server/pkg/middlewares"
 	"github.com/mendersoftware/mender-server/pkg/requestid"
 	"github.com/mendersoftware/mender-server/pkg/requestsize"
 	"github.com/mendersoftware/mender-server/pkg/routing"
@@ -141,7 +142,7 @@ func NewRouter(
 	publicAPIs.Use(requestsize.Middleware(cfg.MaxRequestSize))
 	withAuth.Use(requestsize.Middleware(cfg.MaxRequestSize))
 
-	NewDeploymentsResourceRoutes(publicAPIs, deploymentsHandlers)
+	NewDeploymentsResourceRoutes(publicAPIs, deploymentsHandlers, cfg)
 	NewLimitsResourceRoutes(withAuth, deploymentsHandlers)
 	InternalRoutes(internalAPIs, deploymentsHandlers)
 	ReleasesRoutes(withAuth, deploymentsHandlers)
@@ -218,7 +219,11 @@ func NewImagesResourceRoutes(router *gin.RouterGroup,
 	}
 }
 
-func NewDeploymentsResourceRoutes(router *gin.RouterGroup, controller *DeploymentsApiHandlers) {
+func NewDeploymentsResourceRoutes(
+	router *gin.RouterGroup,
+	controller *DeploymentsApiHandlers,
+	cfg *Config,
+) {
 
 	if controller == nil {
 		return
@@ -261,7 +266,10 @@ func NewDeploymentsResourceRoutes(router *gin.RouterGroup, controller *Deploymen
 	devices.GET(ApiUrlDevicesDownloadConfig,
 		controller.DownloadConfiguration)
 
-	devices.Use(identity.Middleware())
+	devices.Use(identity.Middleware(), middlewares.ErrorHandler())
+	if cfg.RequestTimeoutDevicesAPI > 0 {
+		devices.Use(middlewares.Timeout(cfg.RequestTimeoutDevicesAPI))
+	}
 
 	devices.GET(ApiUrlDevicesDeploymentsNext, controller.GetDeploymentForDevice)
 	devices.Group(".").Use(contenttype.CheckJSON()).

--- a/backend/services/deployments/config.yaml
+++ b/backend/services/deployments/config.yaml
@@ -71,13 +71,11 @@
 
 # mender-workflows: "http://mender-workflows-server:8080"
 
-
 # This is a flag that turns off the new API end-points related to releases
 # Defaults to: false
 # Overwrite with environment variable: DEPLOYMENTS_DISABLE_NEW_RELEASES_FEATURE
 
 # disable_new_releases_feature: false
-
 
 # storage:
 #     # storage.default: Default storage service
@@ -143,7 +141,6 @@
 #     # scenario. This feature is disabled by default.
 #     # Overwrite with environment variable: DEPLOYMENTS_STORAGE_DIRECT_UPLOAD_SKIP_VERIFY
 #     # direct_upload_skip_verify: false
-
 
 # # AWS configuration section
 # aws:
@@ -320,7 +317,6 @@
 #       #
 #       # uri: "https://myStorageAccount.not.windows.net"
 
-
 # presign:
 #   # Presign algorithm
 #   # Signature algorithm used for generating URL signature for signed URLs.
@@ -365,3 +361,11 @@
 # Overwrite with environment variable: DEPLOYMENTS_REQUEST_SIZE_LIMIT
 
 # request_size_limit: 1048576
+
+# request_timeout:
+#   # Read header timout specifies the maximum amount of time the server
+#   # reads HTTP headers before timing out.
+#   read_headers: 15s
+#   # Devices API timeout specifies the timeout for the Devices API request
+#   # handlers to process the requests from devices.
+#   devices_api: 60s

--- a/backend/services/deployments/config/config.go
+++ b/backend/services/deployments/config/config.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -155,6 +156,10 @@ const (
 	// Max Request body size
 	SettingMaxRequestSize        = "request_size_limit"
 	SettingMaxRequestSizeDefault = 1024 * 1024 // 1 MiB
+
+	SettingRequestTimeout            = "request_timeout"
+	SettingRequestTimeoutReadHeaders = SettingRequestTimeout + ".read_headers"
+	SettingRequestTimeoutDevicesAPI  = SettingRequestTimeout + ".devices_api"
 )
 
 const (
@@ -317,5 +322,7 @@ var (
 		{Key: SettingPresignScheme, Value: SettingPresignSchemeDefault},
 		{Key: SettingDisableNewReleasesFeature, Value: SettingDisableNewReleasesFeatureDefault},
 		{Key: SettingMaxRequestSize, Value: SettingMaxRequestSizeDefault},
+		{Key: SettingRequestTimeoutReadHeaders, Value: time.Second * 15},
+		{Key: SettingRequestTimeoutDevicesAPI, Value: time.Minute},
 	}
 )

--- a/backend/services/deployments/server.go
+++ b/backend/services/deployments/server.go
@@ -233,7 +233,8 @@ func RunServer(ctx context.Context) error {
 		SetEnableDirectUpload(c.GetBool(dconfig.SettingStorageEnableDirectUpload)).
 		SetEnableDirectUploadSkipVerify(c.GetBool(dconfig.SettingStorageDirectUploadSkipVerify)).
 		SetDisableNewReleasesFeature(c.GetBool(dconfig.SettingDisableNewReleasesFeature)).
-		SetMaxRequestSize(c.GetInt64(dconfig.SettingMaxRequestSize))
+		SetMaxRequestSize(c.GetInt64(dconfig.SettingMaxRequestSize)).
+		SetRequestTimeoutDevicesAPI(c.GetDuration(dconfig.SettingRequestTimeoutDevicesAPI))
 	if key, err := base64.RawStdEncoding.DecodeString(
 		base64Repl.Replace(
 			c.GetString(dconfig.SettingPresignSecret),
@@ -246,8 +247,9 @@ func RunServer(ctx context.Context) error {
 	listen := c.GetString(dconfig.SettingListen)
 
 	srv := &http.Server{
-		Addr:    listen,
-		Handler: handler,
+		Addr:              listen,
+		Handler:           handler,
+		ReadHeaderTimeout: c.GetDuration(dconfig.SettingRequestTimeoutReadHeaders),
 	}
 
 	if c.IsSet(dconfig.SettingHttps) {


### PR DESCRIPTION
Adds configuration `request_timeout` (duration) for setting the timeout for reading request headers as well as request handler context.

Ticket: MEN-10042