### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,10 +127,6 @@ include:
   - project: "Northern.tech/Mender/mendertesting"
     file: "qa-common/send-results-to-mantra.yml"
     ref: "master"
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
-    inputs:
-      stage: ".pre"
-      runner: "k8s"
 
 stages:
   - lint


### PR DESCRIPTION
Renovate now runs centrally from NorthernTechHQ/renovate-ring, which reads this repo's renovate.json5 straight from GitHub. Nothing about grouping or managers changes.

The job only ever triggered on a pipeline schedule and that schedule is already deleted, so this removes config that can no longer run.