### PR TITLE
Request logger improvements

### DIFF
--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -61,11 +61,8 @@ func (a AccessLogger) LogFunc(
 		"path":        c.FullPath(),
 		"path_params": formatPathParams(c.Params),
 		"qs":          c.Request.URL.RawQuery,
-		"ts": startTime.
-			Truncate(time.Millisecond).
-			Format(time.RFC3339Nano),
-		"type":      c.Request.Proto,
-		"useragent": c.Request.UserAgent(),
+		"type":        c.Request.Proto,
+		"useragent":   c.Request.UserAgent(),
 	}
 	if a.ClientIPHook != nil {
 		logCtx["clientip"] = a.ClientIPHook(c.Request)
@@ -92,13 +89,6 @@ func (a AccessLogger) LogFunc(
 	} else if a.DisableLog != nil && a.DisableLog(c) {
 		return
 	}
-	latency := time.Since(startTime)
-	// We do not need more than 3 digit fraction
-	if latency > time.Second {
-		latency = latency.Round(time.Millisecond)
-	} else if latency > time.Millisecond {
-		latency = latency.Round(time.Microsecond)
-	}
 	code := c.Writer.Status()
 	select {
 	case <-ctx.Done():
@@ -107,10 +97,6 @@ func (a AccessLogger) LogFunc(
 		}
 	default:
 	}
-	logCtx["responsetime"] = latency.String()
-	logCtx["status"] = c.Writer.Status()
-	logCtx["byteswritten"] = c.Writer.Size()
-	logCtx["bytesprocessed"] = body.BytesProcessed()
 
 	var logLevel logrus.Level = logrus.InfoLevel
 	if code >= 500 {
@@ -132,6 +118,19 @@ func (a AccessLogger) LogFunc(
 		}
 		logCtx["error"] = errMsg
 	}
+
+	latency := time.Since(startTime)
+	// We do not need more than 3 digit fraction
+	if latency > time.Second {
+		latency = latency.Round(time.Millisecond)
+	} else if latency > time.Millisecond {
+		latency = latency.Round(time.Microsecond)
+	}
+	logCtx["responsetime"] = latency.String()
+	logCtx["status"] = c.Writer.Status()
+	logCtx["byteswritten"] = c.Writer.Size()
+	logCtx["bytesprocessed"] = body.BytesProcessed()
+
 	lc := fromContext(ctx)
 	if lc != nil {
 		lc.addFields(logCtx)

--- a/backend/pkg/accesslog/middleware_gin.go
+++ b/backend/pkg/accesslog/middleware_gin.go
@@ -127,7 +127,7 @@ func (a AccessLogger) LogFunc(
 		latency = latency.Round(time.Microsecond)
 	}
 	logCtx["responsetime"] = latency.String()
-	logCtx["status"] = c.Writer.Status()
+	logCtx["status"] = code
 	logCtx["byteswritten"] = c.Writer.Size()
 	logCtx["bytesprocessed"] = body.BytesProcessed()
 

--- a/backend/pkg/accesslog/middleware_gin_test.go
+++ b/backend/pkg/accesslog/middleware_gin_test.go
@@ -49,7 +49,7 @@ func TestMiddleware(t *testing.T) {
 			"method=GET",
 			"useragent=tester",
 			"responsetime=",
-			"ts=",
+			"time=",
 		},
 	}, {
 		Name: "ok, pushed error",
@@ -67,7 +67,7 @@ func TestMiddleware(t *testing.T) {
 			"method=GET",
 			"responsetime=",
 			"byteswritten=14",
-			"ts=",
+			"time=",
 			`error="internal error"`,
 		},
 	}, {
@@ -89,7 +89,7 @@ func TestMiddleware(t *testing.T) {
 			"method=GET",
 			"responsetime=",
 			"byteswritten=16",
-			"ts=",
+			"time=",
 			`error="#01: internal error 1\\n#02: internal error 2\\n"`,
 		},
 	}, {
@@ -106,7 +106,7 @@ func TestMiddleware(t *testing.T) {
 			"method=GET",
 			"responsetime=",
 			"useragent=tester",
-			"ts=",
+			"time=",
 			// First three entries in the trace should match this:
 			`trace=".+TestMiddleware\.func[0-9]*@middleware_gin_test\.go:[0-9]+\\n`,
 		},

--- a/backend/pkg/log/log.go
+++ b/backend/pkg/log/log.go
@@ -39,7 +39,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -67,6 +66,8 @@ type loggerContextKeyType int
 
 const (
 	loggerContextKey loggerContextKeyType = 0
+
+	rfc3339Milli = "2006-01-02T15:04:05.999Z07:00"
 )
 
 // ContextLogger interface for components which support
@@ -92,7 +93,7 @@ func init() {
 			opts.Level = Level(logLevel)
 		}
 	}
-	opts.TimestampFormat = time.RFC3339
+	opts.TimestampFormat = rfc3339Milli
 	opts.DisableCaller, _ = strconv.ParseBool(os.Getenv(envLogDisableCaller))
 	Configure(opts)
 

--- a/backend/pkg/log/log.go
+++ b/backend/pkg/log/log.go
@@ -148,8 +148,9 @@ func Configure(opts Options) {
 	switch opts.Format {
 	case FormatConsole:
 		formatter = &logrus.TextFormatter{
-			FullTimestamp:   true,
-			TimestampFormat: opts.TimestampFormat,
+			FullTimestamp:    true,
+			TimestampFormat:  opts.TimestampFormat,
+			QuoteEmptyFields: true,
 		}
 	case FormatJSON:
 		formatter = &logrus.JSONFormatter{


### PR DESCRIPTION
* Increase time resolution to millisecond
* Quote empty fields to ensure correct logfmt parsing
* Remove redundant `ts` field from accesslogs
* Accesslog shows 499 for clients closing connections.