### PR TITLE
MEN-10107: Handle multi-value attributes when processing identities

### DIFF
--- a/backend/services/inventory/inv/identities.go
+++ b/backend/services/inventory/inv/identities.go
@@ -17,6 +17,8 @@ package inv
 import (
 	"context"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
+
 	"github.com/mendersoftware/mender-server/services/inventory/model"
 )
 
@@ -34,10 +36,10 @@ func (i inventory) setIdentities(
 	identities := make([]any, 0, len(newAttributes))
 	for i, v := range newAttributes {
 		if v.Scope == model.AttrScopeIdentity {
-			identities = append(identities, newAttributes[i].Value)
+			identities = appendIdentity(identities, newAttributes[i].Value)
 		}
 		if v.Scope == model.AttrScopeTags && v.Name == IdentityNameAttribute {
-			identities = append(identities, newAttributes[i].Value)
+			identities = appendIdentity(identities, newAttributes[i].Value)
 		}
 	}
 	if len(identities) == 0 {
@@ -45,4 +47,27 @@ func (i inventory) setIdentities(
 	}
 
 	return i.db.SetIdentity(ctx, deviceId, identities)
+}
+
+func appendIdentity(identities []any, value interface{}) []any {
+	// We only handle strings and slices of strings (at least for now)
+	// Also, these attributes can potentially come either from the API;
+	// in which the underlying type is expected to be either string or
+	// []string, or from the database; in which case the underlying type
+	// is either string or bson.A :shrug:
+	switch v := value.(type) {
+	case string:
+		identities = append(identities, v)
+	case []string:
+		for _, s := range v {
+			identities = append(identities, s)
+		}
+	case bson.A:
+		for _, s := range v {
+			if ss, ok := s.(string); ok {
+				identities = append(identities, ss)
+			}
+		}
+	}
+	return identities
 }

--- a/backend/services/inventory/model/device.go
+++ b/backend/services/inventory/model/device.go
@@ -162,8 +162,10 @@ type Device struct {
 	//text attribute for the full-text search
 	Text string `json:"-" bson:"text,omitempty"`
 
+	// Type of 'any' introduced as workaround for MEN-10107, change back
+	// to []string once workaround is reverted.
 	//identities attribute see MEN-9974
-	Identities []string `json:"identities,omitempty" bson:"identities,omitempty"`
+	Identities []any `json:"identities,omitempty" bson:"identities,omitempty"`
 }
 
 // internalDevice is only used internally to avoid recursive type-loops for
@@ -193,6 +195,21 @@ func (d *Device) UnmarshalBSON(b []byte) error {
 			}
 		}
 	}
+
+	// MEN-10107: Some devices have array values in their their identities attribute
+	// in the database (due to the referenced bug). This is a quick workaround
+	// to allow de-serialization of these devices by ignoring identity values that are not strings.
+	// The issue should self-heal as every new update of device the identities now flatten
+	// these array values. Once all devices have been healed we can remove this workaround.
+	idx := 0
+	for _, identity := range d.Identities {
+		if _, ok := identity.(string); ok {
+			d.Identities[idx] = identity
+			idx++
+		}
+	}
+	d.Identities = d.Identities[:idx]
+
 	return nil
 }
 


### PR DESCRIPTION
**Description**
Back-porting handling of multi-value attributes when processing identities. The corresponding test coverage is not ported as the tests exist in the enterprise suite only.

Ticket: MEN-10107