### PR TITLE
4.1.x integration test dockerfile backports

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
     value: "3.21"
     description: "Version of Alpine to use in jobs"
   DOCKER_VERSION:
-    value: "27.3"
+    value: "29.1"
     description: "Version of docker to use in pipelines"
   DOCKER_BUILDKITARGS:
     value: '--driver-opt "image=moby/buildkit:v0.17.3"' # QA-823

--- a/backend/tests/Dockerfile.integration
+++ b/backend/tests/Dockerfile.integration
@@ -1,21 +1,42 @@
-FROM python:3.13-bullseye
-
-ARG K8S_VERSION=1.29
-
-RUN sed -i.backup -e 's/^deb /deb [trusted=yes] /' /etc/apt/sources.list
-RUN apt-get -y -qq update && apt-get -qq -y install docker.io libzbar0 apt-transport-https gnupg2 && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION}/deb/ /" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update && \
-    apt-get install -y awscli kubectl && \
-    curl -o /usr/bin/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.9/2020-08-04/bin/linux/amd64/aws-iam-authenticator && \
-    chmod 755 /usr/bin/aws-iam-authenticator && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY requirements-integration.txt .
-
-RUN pip3 install -r requirements-integration.txt
-
+FROM python:3.14-trixie
 WORKDIR /tests
+
+# Install mender-artifact
+RUN \
+  apt-get update && \
+  apt-get install --assume-yes \
+  apt-transport-https \
+  ca-certificates \
+  gnupg && \
+  curl -fsSL https://downloads.mender.io/repos/debian/gpg | tee /etc/apt/trusted.gpg.d/mender.asc | \
+  gpg --show-keys --with-fingerprint && \
+  sed -i.bak -e "\,https://downloads.mender.io/repos/workstation-tools,d" /etc/apt/sources.list \
+  echo "deb [arch=$(dpkg --print-architecture)] https://downloads.mender.io/repos/workstation-tools debian/trixie/stable main" | \
+  tee /etc/apt/sources.list.d/mender.list && \
+  apt-get update && \
+  apt-get install --assume-yes mender-artifact
+
+# Install docker
+RUN \
+  install -m 0755 -d /etc/apt/keyrings && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+  chmod a+r /etc/apt/keyrings/docker.asc
+RUN . /etc/os-release && \
+  cat > /etc/apt/sources.list.d/docker.sources <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/debian
+Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Components: stable
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+
+RUN \
+  apt-get update -q && \
+  apt-get install --assume-yes docker-ce docker-ce-cli containerd.io docker-compose-plugin
+
+# Install python dependencies
+COPY requirements-integration.txt .
+RUN pip3 install --no-cache-dir -r requirements-integration.txt && \
+  apt-get install --assume-yes libzbar0
+
 ENTRYPOINT ["python3", "-m", "pytest"]

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     working_dir: /tests
     volumes:
         - ${MENDER_SERVER_PATH:-../../}/backend/tests/integration/docs:/docs
-        - ${MENDER_SERVER_PATH:-../../}/backend/tests/integration/downloaded-tools/mender-artifact:/usr/local/bin/mender-artifact
         - ${MENDER_SERVER_PATH:-../../}/backend/tests/integration:/tests
         - /var/run/docker.sock:/var/run/docker.sock
     command:

--- a/backend/tests/docker-compose.yml
+++ b/backend/tests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   integration-tester:
     platform: linux/amd64
     scale: 0
-    image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_INTEGRATION_IMAGE_TAG:-integration_v2}"
+    image: "${CI_REGISTRY_IMAGE:-localhost/backend-tester}:${CI_INTEGRATION_IMAGE_TAG:-integration_v3}"
     build:
       dockerfile: Dockerfile.integration
     working_dir: /tests

--- a/backend/tests/integration/run
+++ b/backend/tests/integration/run
@@ -45,7 +45,6 @@ PYTEST_REPORT=""
 PYTEST_ADDOPTS=""
 
 DOCS="$MENDER_SERVER_PATH/backend/tests/integration/docs"
-TOOLS="$MENDER_SERVER_PATH/backend/tests/integration/downloaded-tools"
 
 usage() {
     echo "runner script for backend-specific integration tests"
@@ -122,16 +121,6 @@ parse_args() {
 }
 
 get_runner_requirements() {
-    local MENDER_ARTIFACT_PATH="$TOOLS/mender-artifact"
-    local MENDER_ARTIFACT_BRANCH="master"
-
-    if [ ! -f "$MENDER_ARTIFACT_PATH" ]; then
-        echo "downloading mender-artifact/$MENDER_ARTIFACT_BRANCH"
-        curl -s --fail "https://downloads.mender.io/mender-artifact/${MENDER_ARTIFACT_BRANCH}/linux/mender-artifact" \
-            -o "$MENDER_ARTIFACT_PATH"
-        chmod +x "$MENDER_ARTIFACT_PATH"
-    fi
-
     for svc_path in $(ls -d $MENDER_SERVER_PATH/backend/services/*); do
         svc=$(basename $svc_path)
         if [ -d "${svc_path}/docs" ]; then
@@ -221,7 +210,6 @@ cleanup() {
 }
 
 parse_args "$@"
-mkdir -p "$TOOLS"
 
 if [[ -n "$DOWNLOAD_REQUIREMENTS" ]]; then
     get_runner_requirements

--- a/backend/tests/integration/tests/test_azure_iothub.py
+++ b/backend/tests/integration/tests/test_azure_iothub.py
@@ -23,7 +23,7 @@ import uuid
 from base64 import b64decode
 
 import trustme
-from azure.iot.hub import IoTHubRegistryManager
+from azure_iot_hub_api import IoTHubRegistryManager
 from pytest_httpserver import HTTPServer
 from redo import retrier, retriable
 from requests.models import Response

--- a/backend/tests/requirements-integration.txt
+++ b/backend/tests/requirements-integration.txt
@@ -3,7 +3,7 @@ azure-iot-hub-api==0.2.2
 boto3==1.43.20
 certifi==2026.5.20
 cffi==2.0.0
-cryptography==48.0.0
+cryptography==47.0.0
 docker==7.1.0
 execnet==2.1.2
 filelock==3.29.0

--- a/backend/tests/requirements-integration.txt
+++ b/backend/tests/requirements-integration.txt
@@ -3,7 +3,6 @@ azure-iot-hub-api==0.2.2
 boto3==1.43.20
 certifi==2026.5.20
 cffi==2.0.0
-chardet==7.4.3
 cryptography==48.0.0
 docker==7.1.0
 execnet==2.1.2

--- a/backend/tests/requirements-integration.txt
+++ b/backend/tests/requirements-integration.txt
@@ -1,5 +1,5 @@
 attrs==26.1.0
-azure-iot-hub==2.7.0
+azure-iot-hub-api==0.2.2
 boto3==1.43.20
 certifi==2026.5.20
 cffi==2.0.0


### PR DESCRIPTION
**Description**
Backports a bunch of commits from main updating the integration test runner Dockerfile and surrounding configuration. Most of these are coming from https://github.com/mendersoftware/mender-server/pull/1278.

The goal is to fix the recent 4.1.x integration test failures (gitlab.com/Northern.tech/Mender/mender-server/-/pipelines/2825313393) where we're failing to build the integration test runner image. With these cherry-picks it seems to be working again.